### PR TITLE
Add support for the full S3 client.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
         "state": {
           "branch": null,
-          "revision": "5041f2673aa75d6e973d9b6bd3956bc5068387c8",
-          "version": "1.7.3"
+          "revision": "d0ccb4158b83f8692531892a9c894bb757593c6f",
+          "version": "1.8.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "4b79ecb01d74a6223811100d1907e63b68c0df75",
-          "version": "0.5.0"
+          "revision": "d46977166ceecdda654ec2859e074dfbd012d6a4",
+          "version": "0.6.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "176dd6e8564d60e936b76f3a896d667ae3acba31",
-          "version": "1.10.0"
+          "revision": "a20e129c22ad00a51c902dca54a5456f90664780",
+          "version": "1.12.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:4.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -31,6 +31,12 @@ let package = Package(
             name: "ElasticContainerModel",
             targets: ["ElasticContainerModel"]),
         .library(
+            name: "S3Client",
+            targets: ["S3Client"]),
+        .library(
+            name: "S3Model",
+            targets: ["S3Model"]),
+        .library(
             name: "SecurityTokenClient",
             targets: ["SecurityTokenClient"]),
         .library(
@@ -61,9 +67,6 @@ let package = Package(
             name: "StepFunctionsModel",
             targets: ["StepFunctionsModel"]),
         .library(
-            name: "S3Client",
-            targets: ["S3Client"]),
-        .library(
             name: "SmokeAWSCore",
             targets: ["SmokeAWSCore"]),
         .library(
@@ -75,7 +78,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", .upToNextMajor(from: "0.4.0")),
-        .package(url: "https://github.com/amzn/smoke-http.git", .upToNextMajor(from: "0.5.0")),
+        .package(url: "https://github.com/amzn/smoke-http.git", .upToNextMajor(from: "0.6.0")),
     ],
     targets: [
         .target(
@@ -101,6 +104,12 @@ let package = Package(
             dependencies: ["ElasticContainerModel", "SmokeAWSHttp"]),
         .target(
             name: "ElasticContainerModel",
+            dependencies: ["LoggerAPI"]),
+        .target(
+            name: "S3Client",
+            dependencies: ["S3Model", "SmokeAWSHttp"]),
+        .target(
+            name: "S3Model",
             dependencies: ["LoggerAPI"]),
         .target(
             name: "SecurityTokenClient",
@@ -137,10 +146,9 @@ let package = Package(
             dependencies: ["LoggerAPI", "XMLCoding"]),
         .target(
             name: "SmokeAWSHttp",
-            dependencies: ["LoggerAPI", "NIO", "NIOHTTP1", "NIOOpenSSL", "SmokeAWSCore", "SmokeHTTPClient", "QueryCoder"]),
-        .target(
-            name: "S3Client",
-            dependencies: ["SmokeAWSHttp"]),
+            dependencies: ["LoggerAPI", "NIO", "NIOHTTP1", "NIOOpenSSL",
+                           "SmokeAWSCore", "SmokeHTTPClient", "QueryCoding",
+                           "HTTPPathCoding", "HTTPHeadersCoding"]),
         .testTarget(
             name: "S3ClientTests",
             dependencies: ["S3Client"]),

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://travis-ci.org/amzn/smoke-aws">
+<a href="https://travis-ci.com/amzn/smoke-aws">
 <img src="https://travis-ci.com/amzn/smoke-aws.svg?branch=master" alt="Build - Master Branch">
 </a>
 <img src="https://img.shields.io/badge/os-linux-green.svg?style=flat" alt="Linux">

--- a/Sources/CloudWatchClient/AWSCloudWatchClient.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClient.swift
@@ -66,6 +66,22 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
     }
 
     /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times.
+     */
+    public func close() {
+        httpClient.close()
+    }
+
+    /**
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
+     */
+    public func wait() {
+        httpClient.wait()
+    }
+
+    /**
      Invokes the DeleteAlarms operation returning immediately and passing the response to a callback.
 
      - Parameters:
@@ -74,14 +90,14 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: resourceNotFound.
      */
-    public func deleteAlarmsAsync(input: CloudWatchModel.DeleteAlarmsInput, completion: @escaping (Error?) -> ()) throws {
+    public func deleteAlarmsAsync(input: CloudWatchModel.DeleteAlarmsInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteAlarmsOperationHTTPRequestInput<CloudWatchModel.DeleteAlarmsInput>(encodable: input)
+        let wrappedInput = DeleteAlarmsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -110,7 +126,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteAlarmsOperationHTTPRequestInput<CloudWatchModel.DeleteAlarmsInput>(encodable: input)
+        let wrappedInput = DeleteAlarmsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -141,7 +157,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteDashboardsOperationHTTPRequestInput<CloudWatchModel.DeleteDashboardsInput>(encodable: input)
+        let wrappedInput = DeleteDashboardsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -172,7 +188,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteDashboardsOperationHTTPRequestInput<CloudWatchModel.DeleteDashboardsInput>(encodable: input)
+        let wrappedInput = DeleteDashboardsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -203,7 +219,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAlarmHistoryOperationHTTPRequestInput<CloudWatchModel.DescribeAlarmHistoryInput>(encodable: input)
+        let wrappedInput = DescribeAlarmHistoryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -234,7 +250,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAlarmHistoryOperationHTTPRequestInput<CloudWatchModel.DescribeAlarmHistoryInput>(encodable: input)
+        let wrappedInput = DescribeAlarmHistoryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -265,7 +281,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAlarmsOperationHTTPRequestInput<CloudWatchModel.DescribeAlarmsInput>(encodable: input)
+        let wrappedInput = DescribeAlarmsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -296,7 +312,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAlarmsOperationHTTPRequestInput<CloudWatchModel.DescribeAlarmsInput>(encodable: input)
+        let wrappedInput = DescribeAlarmsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -326,7 +342,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAlarmsForMetricOperationHTTPRequestInput<CloudWatchModel.DescribeAlarmsForMetricInput>(encodable: input)
+        let wrappedInput = DescribeAlarmsForMetricOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -356,7 +372,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAlarmsForMetricOperationHTTPRequestInput<CloudWatchModel.DescribeAlarmsForMetricInput>(encodable: input)
+        let wrappedInput = DescribeAlarmsForMetricOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -378,14 +394,14 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disableAlarmActionsAsync(input: CloudWatchModel.DisableAlarmActionsInput, completion: @escaping (Error?) -> ()) throws {
+    public func disableAlarmActionsAsync(input: CloudWatchModel.DisableAlarmActionsInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DisableAlarmActionsOperationHTTPRequestInput<CloudWatchModel.DisableAlarmActionsInput>(encodable: input)
+        let wrappedInput = DisableAlarmActionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -413,7 +429,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisableAlarmActionsOperationHTTPRequestInput<CloudWatchModel.DisableAlarmActionsInput>(encodable: input)
+        let wrappedInput = DisableAlarmActionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -435,14 +451,14 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func enableAlarmActionsAsync(input: CloudWatchModel.EnableAlarmActionsInput, completion: @escaping (Error?) -> ()) throws {
+    public func enableAlarmActionsAsync(input: CloudWatchModel.EnableAlarmActionsInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = EnableAlarmActionsOperationHTTPRequestInput<CloudWatchModel.EnableAlarmActionsInput>(encodable: input)
+        let wrappedInput = EnableAlarmActionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -470,7 +486,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = EnableAlarmActionsOperationHTTPRequestInput<CloudWatchModel.EnableAlarmActionsInput>(encodable: input)
+        let wrappedInput = EnableAlarmActionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -501,7 +517,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetDashboardOperationHTTPRequestInput<CloudWatchModel.GetDashboardInput>(encodable: input)
+        let wrappedInput = GetDashboardOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -532,7 +548,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetDashboardOperationHTTPRequestInput<CloudWatchModel.GetDashboardInput>(encodable: input)
+        let wrappedInput = GetDashboardOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -563,7 +579,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetMetricDataOperationHTTPRequestInput<CloudWatchModel.GetMetricDataInput>(encodable: input)
+        let wrappedInput = GetMetricDataOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -594,7 +610,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetMetricDataOperationHTTPRequestInput<CloudWatchModel.GetMetricDataInput>(encodable: input)
+        let wrappedInput = GetMetricDataOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -625,7 +641,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetMetricStatisticsOperationHTTPRequestInput<CloudWatchModel.GetMetricStatisticsInput>(encodable: input)
+        let wrappedInput = GetMetricStatisticsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -656,7 +672,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetMetricStatisticsOperationHTTPRequestInput<CloudWatchModel.GetMetricStatisticsInput>(encodable: input)
+        let wrappedInput = GetMetricStatisticsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -686,7 +702,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetMetricWidgetImageOperationHTTPRequestInput<CloudWatchModel.GetMetricWidgetImageInput>(encodable: input)
+        let wrappedInput = GetMetricWidgetImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -716,7 +732,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetMetricWidgetImageOperationHTTPRequestInput<CloudWatchModel.GetMetricWidgetImageInput>(encodable: input)
+        let wrappedInput = GetMetricWidgetImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -747,7 +763,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListDashboardsOperationHTTPRequestInput<CloudWatchModel.ListDashboardsInput>(encodable: input)
+        let wrappedInput = ListDashboardsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -778,7 +794,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListDashboardsOperationHTTPRequestInput<CloudWatchModel.ListDashboardsInput>(encodable: input)
+        let wrappedInput = ListDashboardsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -809,7 +825,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListMetricsOperationHTTPRequestInput<CloudWatchModel.ListMetricsInput>(encodable: input)
+        let wrappedInput = ListMetricsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -840,7 +856,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListMetricsOperationHTTPRequestInput<CloudWatchModel.ListMetricsInput>(encodable: input)
+        let wrappedInput = ListMetricsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -871,7 +887,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PutDashboardOperationHTTPRequestInput<CloudWatchModel.PutDashboardInput>(encodable: input)
+        let wrappedInput = PutDashboardOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -902,7 +918,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PutDashboardOperationHTTPRequestInput<CloudWatchModel.PutDashboardInput>(encodable: input)
+        let wrappedInput = PutDashboardOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -925,14 +941,14 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: limitExceeded.
      */
-    public func putMetricAlarmAsync(input: CloudWatchModel.PutMetricAlarmInput, completion: @escaping (Error?) -> ()) throws {
+    public func putMetricAlarmAsync(input: CloudWatchModel.PutMetricAlarmInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = PutMetricAlarmOperationHTTPRequestInput<CloudWatchModel.PutMetricAlarmInput>(encodable: input)
+        let wrappedInput = PutMetricAlarmOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -961,7 +977,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PutMetricAlarmOperationHTTPRequestInput<CloudWatchModel.PutMetricAlarmInput>(encodable: input)
+        let wrappedInput = PutMetricAlarmOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -984,14 +1000,14 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: internalService, invalidParameterCombination, invalidParameterValue, missingRequiredParameter.
      */
-    public func putMetricDataAsync(input: CloudWatchModel.PutMetricDataInput, completion: @escaping (Error?) -> ()) throws {
+    public func putMetricDataAsync(input: CloudWatchModel.PutMetricDataInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = PutMetricDataOperationHTTPRequestInput<CloudWatchModel.PutMetricDataInput>(encodable: input)
+        let wrappedInput = PutMetricDataOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1020,7 +1036,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PutMetricDataOperationHTTPRequestInput<CloudWatchModel.PutMetricDataInput>(encodable: input)
+        let wrappedInput = PutMetricDataOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1043,14 +1059,14 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: invalidFormat, resourceNotFound.
      */
-    public func setAlarmStateAsync(input: CloudWatchModel.SetAlarmStateInput, completion: @escaping (Error?) -> ()) throws {
+    public func setAlarmStateAsync(input: CloudWatchModel.SetAlarmStateInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = SetAlarmStateOperationHTTPRequestInput<CloudWatchModel.SetAlarmStateInput>(encodable: input)
+        let wrappedInput = SetAlarmStateOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1079,7 +1095,7 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SetAlarmStateOperationHTTPRequestInput<CloudWatchModel.SetAlarmStateInput>(encodable: input)
+        let wrappedInput = SetAlarmStateOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,

--- a/Sources/CloudWatchClient/CloudWatchClientProtocol.swift
+++ b/Sources/CloudWatchClient/CloudWatchClientProtocol.swift
@@ -28,7 +28,7 @@ import SmokeHTTPClient
  */
 public protocol CloudWatchClientProtocol {
     typealias DeleteAlarmsSyncType = (_ input: CloudWatchModel.DeleteAlarmsInput) throws -> ()
-    typealias DeleteAlarmsAsyncType = (_ input: CloudWatchModel.DeleteAlarmsInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteAlarmsAsyncType = (_ input: CloudWatchModel.DeleteAlarmsInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteDashboardsSyncType = (_ input: CloudWatchModel.DeleteDashboardsInput) throws -> CloudWatchModel.DeleteDashboardsOutputForDeleteDashboards
     typealias DeleteDashboardsAsyncType = (_ input: CloudWatchModel.DeleteDashboardsInput, _ completion: @escaping (HTTPResult<CloudWatchModel.DeleteDashboardsOutputForDeleteDashboards>) -> ()) throws -> ()
     typealias DescribeAlarmHistorySyncType = (_ input: CloudWatchModel.DescribeAlarmHistoryInput) throws -> CloudWatchModel.DescribeAlarmHistoryOutputForDescribeAlarmHistory
@@ -38,9 +38,9 @@ public protocol CloudWatchClientProtocol {
     typealias DescribeAlarmsForMetricSyncType = (_ input: CloudWatchModel.DescribeAlarmsForMetricInput) throws -> CloudWatchModel.DescribeAlarmsForMetricOutputForDescribeAlarmsForMetric
     typealias DescribeAlarmsForMetricAsyncType = (_ input: CloudWatchModel.DescribeAlarmsForMetricInput, _ completion: @escaping (HTTPResult<CloudWatchModel.DescribeAlarmsForMetricOutputForDescribeAlarmsForMetric>) -> ()) throws -> ()
     typealias DisableAlarmActionsSyncType = (_ input: CloudWatchModel.DisableAlarmActionsInput) throws -> ()
-    typealias DisableAlarmActionsAsyncType = (_ input: CloudWatchModel.DisableAlarmActionsInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DisableAlarmActionsAsyncType = (_ input: CloudWatchModel.DisableAlarmActionsInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias EnableAlarmActionsSyncType = (_ input: CloudWatchModel.EnableAlarmActionsInput) throws -> ()
-    typealias EnableAlarmActionsAsyncType = (_ input: CloudWatchModel.EnableAlarmActionsInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias EnableAlarmActionsAsyncType = (_ input: CloudWatchModel.EnableAlarmActionsInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias GetDashboardSyncType = (_ input: CloudWatchModel.GetDashboardInput) throws -> CloudWatchModel.GetDashboardOutputForGetDashboard
     typealias GetDashboardAsyncType = (_ input: CloudWatchModel.GetDashboardInput, _ completion: @escaping (HTTPResult<CloudWatchModel.GetDashboardOutputForGetDashboard>) -> ()) throws -> ()
     typealias GetMetricDataSyncType = (_ input: CloudWatchModel.GetMetricDataInput) throws -> CloudWatchModel.GetMetricDataOutputForGetMetricData
@@ -56,11 +56,11 @@ public protocol CloudWatchClientProtocol {
     typealias PutDashboardSyncType = (_ input: CloudWatchModel.PutDashboardInput) throws -> CloudWatchModel.PutDashboardOutputForPutDashboard
     typealias PutDashboardAsyncType = (_ input: CloudWatchModel.PutDashboardInput, _ completion: @escaping (HTTPResult<CloudWatchModel.PutDashboardOutputForPutDashboard>) -> ()) throws -> ()
     typealias PutMetricAlarmSyncType = (_ input: CloudWatchModel.PutMetricAlarmInput) throws -> ()
-    typealias PutMetricAlarmAsyncType = (_ input: CloudWatchModel.PutMetricAlarmInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias PutMetricAlarmAsyncType = (_ input: CloudWatchModel.PutMetricAlarmInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias PutMetricDataSyncType = (_ input: CloudWatchModel.PutMetricDataInput) throws -> ()
-    typealias PutMetricDataAsyncType = (_ input: CloudWatchModel.PutMetricDataInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias PutMetricDataAsyncType = (_ input: CloudWatchModel.PutMetricDataInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias SetAlarmStateSyncType = (_ input: CloudWatchModel.SetAlarmStateInput) throws -> ()
-    typealias SetAlarmStateAsyncType = (_ input: CloudWatchModel.SetAlarmStateInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias SetAlarmStateAsyncType = (_ input: CloudWatchModel.SetAlarmStateInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
 
     /**
      Invokes the DeleteAlarms operation returning immediately and passing the response to a callback.
@@ -71,7 +71,7 @@ public protocol CloudWatchClientProtocol {
            is complete.
            The possible errors are: resourceNotFound.
      */
-    func deleteAlarmsAsync(input: CloudWatchModel.DeleteAlarmsInput, completion: @escaping (Error?) -> ()) throws
+    func deleteAlarmsAsync(input: CloudWatchModel.DeleteAlarmsInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteAlarms operation waiting for the response before returning.
@@ -180,7 +180,7 @@ public protocol CloudWatchClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func disableAlarmActionsAsync(input: CloudWatchModel.DisableAlarmActionsInput, completion: @escaping (Error?) -> ()) throws
+    func disableAlarmActionsAsync(input: CloudWatchModel.DisableAlarmActionsInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DisableAlarmActions operation waiting for the response before returning.
@@ -198,7 +198,7 @@ public protocol CloudWatchClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func enableAlarmActionsAsync(input: CloudWatchModel.EnableAlarmActionsInput, completion: @escaping (Error?) -> ()) throws
+    func enableAlarmActionsAsync(input: CloudWatchModel.EnableAlarmActionsInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the EnableAlarmActions operation waiting for the response before returning.
@@ -376,7 +376,7 @@ public protocol CloudWatchClientProtocol {
            is complete.
            The possible errors are: limitExceeded.
      */
-    func putMetricAlarmAsync(input: CloudWatchModel.PutMetricAlarmInput, completion: @escaping (Error?) -> ()) throws
+    func putMetricAlarmAsync(input: CloudWatchModel.PutMetricAlarmInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the PutMetricAlarm operation waiting for the response before returning.
@@ -396,7 +396,7 @@ public protocol CloudWatchClientProtocol {
            is complete.
            The possible errors are: internalService, invalidParameterCombination, invalidParameterValue, missingRequiredParameter.
      */
-    func putMetricDataAsync(input: CloudWatchModel.PutMetricDataInput, completion: @escaping (Error?) -> ()) throws
+    func putMetricDataAsync(input: CloudWatchModel.PutMetricDataInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the PutMetricData operation waiting for the response before returning.
@@ -416,7 +416,7 @@ public protocol CloudWatchClientProtocol {
            is complete.
            The possible errors are: invalidFormat, resourceNotFound.
      */
-    func setAlarmStateAsync(input: CloudWatchModel.SetAlarmStateInput, completion: @escaping (Error?) -> ()) throws
+    func setAlarmStateAsync(input: CloudWatchModel.SetAlarmStateInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the SetAlarmState operation waiting for the response before returning.

--- a/Sources/CloudWatchClient/CloudWatchOperationsClientOutput.swift
+++ b/Sources/CloudWatchClient/CloudWatchOperationsClientOutput.swift
@@ -1,0 +1,168 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// CloudWatchOperationsClientOutput.swift
+// CloudWatchClient
+//
+
+import Foundation
+import SmokeHTTPClient
+import CloudWatchModel
+
+/**
+ Type to handle the output from the DeleteDashboards operation in a HTTP client.
+ */
+extension DeleteDashboardsOutputForDeleteDashboards: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteDashboardsOutputForDeleteDashboards
+    public typealias HeadersType = DeleteDashboardsOutputForDeleteDashboards
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteDashboardsOutputForDeleteDashboards {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeAlarmHistory operation in a HTTP client.
+ */
+extension DescribeAlarmHistoryOutputForDescribeAlarmHistory: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeAlarmHistoryOutputForDescribeAlarmHistory
+    public typealias HeadersType = DescribeAlarmHistoryOutputForDescribeAlarmHistory
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeAlarmHistoryOutputForDescribeAlarmHistory {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeAlarms operation in a HTTP client.
+ */
+extension DescribeAlarmsOutputForDescribeAlarms: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeAlarmsOutputForDescribeAlarms
+    public typealias HeadersType = DescribeAlarmsOutputForDescribeAlarms
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeAlarmsOutputForDescribeAlarms {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeAlarmsForMetric operation in a HTTP client.
+ */
+extension DescribeAlarmsForMetricOutputForDescribeAlarmsForMetric: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeAlarmsForMetricOutputForDescribeAlarmsForMetric
+    public typealias HeadersType = DescribeAlarmsForMetricOutputForDescribeAlarmsForMetric
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeAlarmsForMetricOutputForDescribeAlarmsForMetric {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetDashboard operation in a HTTP client.
+ */
+extension GetDashboardOutputForGetDashboard: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetDashboardOutputForGetDashboard
+    public typealias HeadersType = GetDashboardOutputForGetDashboard
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetDashboardOutputForGetDashboard {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetMetricData operation in a HTTP client.
+ */
+extension GetMetricDataOutputForGetMetricData: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetMetricDataOutputForGetMetricData
+    public typealias HeadersType = GetMetricDataOutputForGetMetricData
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetMetricDataOutputForGetMetricData {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetMetricStatistics operation in a HTTP client.
+ */
+extension GetMetricStatisticsOutputForGetMetricStatistics: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetMetricStatisticsOutputForGetMetricStatistics
+    public typealias HeadersType = GetMetricStatisticsOutputForGetMetricStatistics
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetMetricStatisticsOutputForGetMetricStatistics {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetMetricWidgetImage operation in a HTTP client.
+ */
+extension GetMetricWidgetImageOutputForGetMetricWidgetImage: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetMetricWidgetImageOutputForGetMetricWidgetImage
+    public typealias HeadersType = GetMetricWidgetImageOutputForGetMetricWidgetImage
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetMetricWidgetImageOutputForGetMetricWidgetImage {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListDashboards operation in a HTTP client.
+ */
+extension ListDashboardsOutputForListDashboards: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListDashboardsOutputForListDashboards
+    public typealias HeadersType = ListDashboardsOutputForListDashboards
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListDashboardsOutputForListDashboards {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListMetrics operation in a HTTP client.
+ */
+extension ListMetricsOutputForListMetrics: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListMetricsOutputForListMetrics
+    public typealias HeadersType = ListMetricsOutputForListMetrics
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListMetricsOutputForListMetrics {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PutDashboard operation in a HTTP client.
+ */
+extension PutDashboardOutputForPutDashboard: HTTPResponseOutputProtocol {
+    public typealias BodyType = PutDashboardOutputForPutDashboard
+    public typealias HeadersType = PutDashboardOutputForPutDashboard
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PutDashboardOutputForPutDashboard {
+        return try bodyDecodableProvider()
+    }
+}
+

--- a/Sources/CloudWatchClient/MockCloudWatchClient.swift
+++ b/Sources/CloudWatchClient/MockCloudWatchClient.swift
@@ -146,7 +146,7 @@ public struct MockCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: resourceNotFound.
      */
-    public func deleteAlarmsAsync(input: CloudWatchModel.DeleteAlarmsInput, completion: @escaping (Error?) -> ()) throws {
+    public func deleteAlarmsAsync(input: CloudWatchModel.DeleteAlarmsInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteAlarmsAsyncOverride = deleteAlarmsAsyncOverride {
             return try deleteAlarmsAsyncOverride(input, completion)
         }
@@ -322,7 +322,7 @@ public struct MockCloudWatchClient: CloudWatchClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disableAlarmActionsAsync(input: CloudWatchModel.DisableAlarmActionsInput, completion: @escaping (Error?) -> ()) throws {
+    public func disableAlarmActionsAsync(input: CloudWatchModel.DisableAlarmActionsInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let disableAlarmActionsAsyncOverride = disableAlarmActionsAsyncOverride {
             return try disableAlarmActionsAsyncOverride(input, completion)
         }
@@ -351,7 +351,7 @@ public struct MockCloudWatchClient: CloudWatchClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func enableAlarmActionsAsync(input: CloudWatchModel.EnableAlarmActionsInput, completion: @escaping (Error?) -> ()) throws {
+    public func enableAlarmActionsAsync(input: CloudWatchModel.EnableAlarmActionsInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let enableAlarmActionsAsyncOverride = enableAlarmActionsAsyncOverride {
             return try enableAlarmActionsAsyncOverride(input, completion)
         }
@@ -638,7 +638,7 @@ public struct MockCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: limitExceeded.
      */
-    public func putMetricAlarmAsync(input: CloudWatchModel.PutMetricAlarmInput, completion: @escaping (Error?) -> ()) throws {
+    public func putMetricAlarmAsync(input: CloudWatchModel.PutMetricAlarmInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let putMetricAlarmAsyncOverride = putMetricAlarmAsyncOverride {
             return try putMetricAlarmAsyncOverride(input, completion)
         }
@@ -669,7 +669,7 @@ public struct MockCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: internalService, invalidParameterCombination, invalidParameterValue, missingRequiredParameter.
      */
-    public func putMetricDataAsync(input: CloudWatchModel.PutMetricDataInput, completion: @escaping (Error?) -> ()) throws {
+    public func putMetricDataAsync(input: CloudWatchModel.PutMetricDataInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let putMetricDataAsyncOverride = putMetricDataAsyncOverride {
             return try putMetricDataAsyncOverride(input, completion)
         }
@@ -700,7 +700,7 @@ public struct MockCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: invalidFormat, resourceNotFound.
      */
-    public func setAlarmStateAsync(input: CloudWatchModel.SetAlarmStateInput, completion: @escaping (Error?) -> ()) throws {
+    public func setAlarmStateAsync(input: CloudWatchModel.SetAlarmStateInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setAlarmStateAsyncOverride = setAlarmStateAsyncOverride {
             return try setAlarmStateAsyncOverride(input, completion)
         }

--- a/Sources/CloudWatchClient/ThrowingCloudWatchClient.swift
+++ b/Sources/CloudWatchClient/ThrowingCloudWatchClient.swift
@@ -148,7 +148,7 @@ public struct ThrowingCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: resourceNotFound.
      */
-    public func deleteAlarmsAsync(input: CloudWatchModel.DeleteAlarmsInput, completion: @escaping (Error?) -> ()) throws {
+    public func deleteAlarmsAsync(input: CloudWatchModel.DeleteAlarmsInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteAlarmsAsyncOverride = deleteAlarmsAsyncOverride {
             return try deleteAlarmsAsyncOverride(input, completion)
         }
@@ -317,7 +317,7 @@ public struct ThrowingCloudWatchClient: CloudWatchClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disableAlarmActionsAsync(input: CloudWatchModel.DisableAlarmActionsInput, completion: @escaping (Error?) -> ()) throws {
+    public func disableAlarmActionsAsync(input: CloudWatchModel.DisableAlarmActionsInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let disableAlarmActionsAsyncOverride = disableAlarmActionsAsyncOverride {
             return try disableAlarmActionsAsyncOverride(input, completion)
         }
@@ -347,7 +347,7 @@ public struct ThrowingCloudWatchClient: CloudWatchClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func enableAlarmActionsAsync(input: CloudWatchModel.EnableAlarmActionsInput, completion: @escaping (Error?) -> ()) throws {
+    public func enableAlarmActionsAsync(input: CloudWatchModel.EnableAlarmActionsInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let enableAlarmActionsAsyncOverride = enableAlarmActionsAsyncOverride {
             return try enableAlarmActionsAsyncOverride(input, completion)
         }
@@ -621,7 +621,7 @@ public struct ThrowingCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: limitExceeded.
      */
-    public func putMetricAlarmAsync(input: CloudWatchModel.PutMetricAlarmInput, completion: @escaping (Error?) -> ()) throws {
+    public func putMetricAlarmAsync(input: CloudWatchModel.PutMetricAlarmInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let putMetricAlarmAsyncOverride = putMetricAlarmAsyncOverride {
             return try putMetricAlarmAsyncOverride(input, completion)
         }
@@ -653,7 +653,7 @@ public struct ThrowingCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: internalService, invalidParameterCombination, invalidParameterValue, missingRequiredParameter.
      */
-    public func putMetricDataAsync(input: CloudWatchModel.PutMetricDataInput, completion: @escaping (Error?) -> ()) throws {
+    public func putMetricDataAsync(input: CloudWatchModel.PutMetricDataInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let putMetricDataAsyncOverride = putMetricDataAsyncOverride {
             return try putMetricDataAsyncOverride(input, completion)
         }
@@ -685,7 +685,7 @@ public struct ThrowingCloudWatchClient: CloudWatchClientProtocol {
            is complete.
            The possible errors are: invalidFormat, resourceNotFound.
      */
-    public func setAlarmStateAsync(input: CloudWatchModel.SetAlarmStateInput, completion: @escaping (Error?) -> ()) throws {
+    public func setAlarmStateAsync(input: CloudWatchModel.SetAlarmStateInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setAlarmStateAsyncOverride = setAlarmStateAsyncOverride {
             return try setAlarmStateAsyncOverride(input, completion)
         }

--- a/Sources/DynamoDBClient/AWSDynamoDBClient.swift
+++ b/Sources/DynamoDBClient/AWSDynamoDBClient.swift
@@ -64,6 +64,22 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
     }
 
     /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times.
+     */
+    public func close() {
+        httpClient.close()
+    }
+
+    /**
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
+     */
+    public func wait() {
+        httpClient.wait()
+    }
+
+    /**
      Invokes the BatchGetItem operation returning immediately and passing the response to a callback.
 
      - Parameters:
@@ -80,7 +96,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.batchGetItem.rawValue,
                     target: target)
-        
+
         let requestInput = BatchGetItemOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -107,7 +123,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.batchGetItem.rawValue,
                     target: target)
-        
+
         let requestInput = BatchGetItemOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -134,7 +150,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.batchWriteItem.rawValue,
                     target: target)
-        
+
         let requestInput = BatchWriteItemOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -161,7 +177,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.batchWriteItem.rawValue,
                     target: target)
-        
+
         let requestInput = BatchWriteItemOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -188,7 +204,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.createBackup.rawValue,
                     target: target)
-        
+
         let requestInput = CreateBackupOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -215,7 +231,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.createBackup.rawValue,
                     target: target)
-        
+
         let requestInput = CreateBackupOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -242,7 +258,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.createGlobalTable.rawValue,
                     target: target)
-        
+
         let requestInput = CreateGlobalTableOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -269,7 +285,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.createGlobalTable.rawValue,
                     target: target)
-        
+
         let requestInput = CreateGlobalTableOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -296,7 +312,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.createTable.rawValue,
                     target: target)
-        
+
         let requestInput = CreateTableOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -323,7 +339,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.createTable.rawValue,
                     target: target)
-        
+
         let requestInput = CreateTableOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -350,7 +366,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.deleteBackup.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteBackupOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -377,7 +393,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.deleteBackup.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteBackupOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -404,7 +420,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.deleteItem.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteItemOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -431,7 +447,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.deleteItem.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteItemOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -458,7 +474,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.deleteTable.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteTableOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -485,7 +501,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.deleteTable.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteTableOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -512,7 +528,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeBackup.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeBackupOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -539,7 +555,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeBackup.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeBackupOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -566,7 +582,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeContinuousBackups.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeContinuousBackupsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -593,7 +609,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeContinuousBackups.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeContinuousBackupsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -619,7 +635,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeEndpoints.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeEndpointsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -645,7 +661,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeEndpoints.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeEndpointsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -672,7 +688,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeGlobalTable.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeGlobalTableOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -699,7 +715,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeGlobalTable.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeGlobalTableOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -726,7 +742,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeGlobalTableSettings.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeGlobalTableSettingsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -753,7 +769,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeGlobalTableSettings.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeGlobalTableSettingsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -780,7 +796,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeLimits.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeLimitsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -807,7 +823,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeLimits.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeLimitsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -834,7 +850,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeTable.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeTableOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -861,7 +877,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeTable.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeTableOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -888,7 +904,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeTimeToLive.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeTimeToLiveOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -915,7 +931,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.describeTimeToLive.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeTimeToLiveOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -942,7 +958,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.getItem.rawValue,
                     target: target)
-        
+
         let requestInput = GetItemOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -969,7 +985,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.getItem.rawValue,
                     target: target)
-        
+
         let requestInput = GetItemOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -996,7 +1012,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.listBackups.rawValue,
                     target: target)
-        
+
         let requestInput = ListBackupsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1023,7 +1039,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.listBackups.rawValue,
                     target: target)
-        
+
         let requestInput = ListBackupsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1050,7 +1066,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.listGlobalTables.rawValue,
                     target: target)
-        
+
         let requestInput = ListGlobalTablesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1077,7 +1093,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.listGlobalTables.rawValue,
                     target: target)
-        
+
         let requestInput = ListGlobalTablesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1104,7 +1120,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.listTables.rawValue,
                     target: target)
-        
+
         let requestInput = ListTablesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1131,7 +1147,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.listTables.rawValue,
                     target: target)
-        
+
         let requestInput = ListTablesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1158,7 +1174,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.listTagsOfResource.rawValue,
                     target: target)
-        
+
         let requestInput = ListTagsOfResourceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1185,7 +1201,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.listTagsOfResource.rawValue,
                     target: target)
-        
+
         let requestInput = ListTagsOfResourceOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1212,7 +1228,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.putItem.rawValue,
                     target: target)
-        
+
         let requestInput = PutItemOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1239,7 +1255,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.putItem.rawValue,
                     target: target)
-        
+
         let requestInput = PutItemOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1266,7 +1282,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.query.rawValue,
                     target: target)
-        
+
         let requestInput = QueryOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1293,7 +1309,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.query.rawValue,
                     target: target)
-        
+
         let requestInput = QueryOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1320,7 +1336,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.restoreTableFromBackup.rawValue,
                     target: target)
-        
+
         let requestInput = RestoreTableFromBackupOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1347,7 +1363,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.restoreTableFromBackup.rawValue,
                     target: target)
-        
+
         let requestInput = RestoreTableFromBackupOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1374,7 +1390,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.restoreTableToPointInTime.rawValue,
                     target: target)
-        
+
         let requestInput = RestoreTableToPointInTimeOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1401,7 +1417,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.restoreTableToPointInTime.rawValue,
                     target: target)
-        
+
         let requestInput = RestoreTableToPointInTimeOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1428,7 +1444,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.scan.rawValue,
                     target: target)
-        
+
         let requestInput = ScanOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1455,7 +1471,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.scan.rawValue,
                     target: target)
-        
+
         let requestInput = ScanOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1474,14 +1490,14 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
            is complete.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    public func tagResourceAsync(input: DynamoDBModel.TagResourceInput, completion: @escaping (Error?) -> ()) throws {
+    public func tagResourceAsync(input: DynamoDBModel.TagResourceInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: DynamoDBModelOperations.tagResource.rawValue,
                     target: target)
-        
+
         let requestInput = TagResourceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1506,7 +1522,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.tagResource.rawValue,
                     target: target)
-        
+
         let requestInput = TagResourceOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1525,14 +1541,14 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
            is complete.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    public func untagResourceAsync(input: DynamoDBModel.UntagResourceInput, completion: @escaping (Error?) -> ()) throws {
+    public func untagResourceAsync(input: DynamoDBModel.UntagResourceInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: DynamoDBModelOperations.untagResource.rawValue,
                     target: target)
-        
+
         let requestInput = UntagResourceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1557,7 +1573,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.untagResource.rawValue,
                     target: target)
-        
+
         let requestInput = UntagResourceOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1584,7 +1600,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateContinuousBackups.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateContinuousBackupsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1611,7 +1627,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateContinuousBackups.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateContinuousBackupsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1638,7 +1654,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateGlobalTable.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateGlobalTableOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1665,7 +1681,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateGlobalTable.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateGlobalTableOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1692,7 +1708,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateGlobalTableSettings.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateGlobalTableSettingsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1719,7 +1735,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateGlobalTableSettings.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateGlobalTableSettingsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1746,7 +1762,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateItem.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateItemOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1773,7 +1789,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateItem.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateItemOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1800,7 +1816,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateTable.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateTableOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1827,7 +1843,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateTable.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateTableOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1854,7 +1870,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateTimeToLive.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateTimeToLiveOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1881,7 +1897,7 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                     service: service,
                     operation: DynamoDBModelOperations.updateTimeToLive.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateTimeToLiveOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(

--- a/Sources/DynamoDBClient/DynamoDBClientProtocol.swift
+++ b/Sources/DynamoDBClient/DynamoDBClientProtocol.swift
@@ -80,9 +80,9 @@ public protocol DynamoDBClientProtocol {
     typealias ScanSyncType = (_ input: DynamoDBModel.ScanInput) throws -> DynamoDBModel.ScanOutput
     typealias ScanAsyncType = (_ input: DynamoDBModel.ScanInput, _ completion: @escaping (HTTPResult<DynamoDBModel.ScanOutput>) -> ()) throws -> ()
     typealias TagResourceSyncType = (_ input: DynamoDBModel.TagResourceInput) throws -> ()
-    typealias TagResourceAsyncType = (_ input: DynamoDBModel.TagResourceInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias TagResourceAsyncType = (_ input: DynamoDBModel.TagResourceInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias UntagResourceSyncType = (_ input: DynamoDBModel.UntagResourceInput) throws -> ()
-    typealias UntagResourceAsyncType = (_ input: DynamoDBModel.UntagResourceInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias UntagResourceAsyncType = (_ input: DynamoDBModel.UntagResourceInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias UpdateContinuousBackupsSyncType = (_ input: DynamoDBModel.UpdateContinuousBackupsInput) throws -> DynamoDBModel.UpdateContinuousBackupsOutput
     typealias UpdateContinuousBackupsAsyncType = (_ input: DynamoDBModel.UpdateContinuousBackupsInput, _ completion: @escaping (HTTPResult<DynamoDBModel.UpdateContinuousBackupsOutput>) -> ()) throws -> ()
     typealias UpdateGlobalTableSyncType = (_ input: DynamoDBModel.UpdateGlobalTableInput) throws -> DynamoDBModel.UpdateGlobalTableOutput
@@ -701,7 +701,7 @@ public protocol DynamoDBClientProtocol {
            is complete.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    func tagResourceAsync(input: DynamoDBModel.TagResourceInput, completion: @escaping (Error?) -> ()) throws
+    func tagResourceAsync(input: DynamoDBModel.TagResourceInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the TagResource operation waiting for the response before returning.
@@ -721,7 +721,7 @@ public protocol DynamoDBClientProtocol {
            is complete.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    func untagResourceAsync(input: DynamoDBModel.UntagResourceInput, completion: @escaping (Error?) -> ()) throws
+    func untagResourceAsync(input: DynamoDBModel.UntagResourceInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the UntagResource operation waiting for the response before returning.

--- a/Sources/DynamoDBClient/DynamoDBOperationsClientOutput.swift
+++ b/Sources/DynamoDBClient/DynamoDBOperationsClientOutput.swift
@@ -1,0 +1,441 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// DynamoDBOperationsClientOutput.swift
+// DynamoDBClient
+//
+
+import Foundation
+import SmokeHTTPClient
+import DynamoDBModel
+
+/**
+ Type to handle the output from the BatchGetItem operation in a HTTP client.
+ */
+extension BatchGetItemOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = BatchGetItemOutput
+    public typealias HeadersType = BatchGetItemOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> BatchGetItemOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the BatchWriteItem operation in a HTTP client.
+ */
+extension BatchWriteItemOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = BatchWriteItemOutput
+    public typealias HeadersType = BatchWriteItemOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> BatchWriteItemOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateBackup operation in a HTTP client.
+ */
+extension CreateBackupOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateBackupOutput
+    public typealias HeadersType = CreateBackupOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateBackupOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateGlobalTable operation in a HTTP client.
+ */
+extension CreateGlobalTableOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateGlobalTableOutput
+    public typealias HeadersType = CreateGlobalTableOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateGlobalTableOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateTable operation in a HTTP client.
+ */
+extension CreateTableOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateTableOutput
+    public typealias HeadersType = CreateTableOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateTableOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteBackup operation in a HTTP client.
+ */
+extension DeleteBackupOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteBackupOutput
+    public typealias HeadersType = DeleteBackupOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteBackupOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteItem operation in a HTTP client.
+ */
+extension DeleteItemOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteItemOutput
+    public typealias HeadersType = DeleteItemOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteItemOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteTable operation in a HTTP client.
+ */
+extension DeleteTableOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteTableOutput
+    public typealias HeadersType = DeleteTableOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteTableOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeBackup operation in a HTTP client.
+ */
+extension DescribeBackupOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeBackupOutput
+    public typealias HeadersType = DescribeBackupOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeBackupOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeContinuousBackups operation in a HTTP client.
+ */
+extension DescribeContinuousBackupsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeContinuousBackupsOutput
+    public typealias HeadersType = DescribeContinuousBackupsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeContinuousBackupsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeEndpoints operation in a HTTP client.
+ */
+extension DescribeEndpointsResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeEndpointsResponse
+    public typealias HeadersType = DescribeEndpointsResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeEndpointsResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeGlobalTable operation in a HTTP client.
+ */
+extension DescribeGlobalTableOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeGlobalTableOutput
+    public typealias HeadersType = DescribeGlobalTableOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeGlobalTableOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeGlobalTableSettings operation in a HTTP client.
+ */
+extension DescribeGlobalTableSettingsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeGlobalTableSettingsOutput
+    public typealias HeadersType = DescribeGlobalTableSettingsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeGlobalTableSettingsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeLimits operation in a HTTP client.
+ */
+extension DescribeLimitsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeLimitsOutput
+    public typealias HeadersType = DescribeLimitsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeLimitsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeTable operation in a HTTP client.
+ */
+extension DescribeTableOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeTableOutput
+    public typealias HeadersType = DescribeTableOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeTableOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeTimeToLive operation in a HTTP client.
+ */
+extension DescribeTimeToLiveOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeTimeToLiveOutput
+    public typealias HeadersType = DescribeTimeToLiveOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeTimeToLiveOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetItem operation in a HTTP client.
+ */
+extension GetItemOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetItemOutput
+    public typealias HeadersType = GetItemOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetItemOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListBackups operation in a HTTP client.
+ */
+extension ListBackupsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListBackupsOutput
+    public typealias HeadersType = ListBackupsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListBackupsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListGlobalTables operation in a HTTP client.
+ */
+extension ListGlobalTablesOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListGlobalTablesOutput
+    public typealias HeadersType = ListGlobalTablesOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListGlobalTablesOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListTables operation in a HTTP client.
+ */
+extension ListTablesOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListTablesOutput
+    public typealias HeadersType = ListTablesOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListTablesOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListTagsOfResource operation in a HTTP client.
+ */
+extension ListTagsOfResourceOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListTagsOfResourceOutput
+    public typealias HeadersType = ListTagsOfResourceOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListTagsOfResourceOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PutItem operation in a HTTP client.
+ */
+extension PutItemOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = PutItemOutput
+    public typealias HeadersType = PutItemOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PutItemOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the Query operation in a HTTP client.
+ */
+extension QueryOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = QueryOutput
+    public typealias HeadersType = QueryOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> QueryOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RestoreTableFromBackup operation in a HTTP client.
+ */
+extension RestoreTableFromBackupOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = RestoreTableFromBackupOutput
+    public typealias HeadersType = RestoreTableFromBackupOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RestoreTableFromBackupOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RestoreTableToPointInTime operation in a HTTP client.
+ */
+extension RestoreTableToPointInTimeOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = RestoreTableToPointInTimeOutput
+    public typealias HeadersType = RestoreTableToPointInTimeOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RestoreTableToPointInTimeOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the Scan operation in a HTTP client.
+ */
+extension ScanOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ScanOutput
+    public typealias HeadersType = ScanOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ScanOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateContinuousBackups operation in a HTTP client.
+ */
+extension UpdateContinuousBackupsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateContinuousBackupsOutput
+    public typealias HeadersType = UpdateContinuousBackupsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateContinuousBackupsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateGlobalTable operation in a HTTP client.
+ */
+extension UpdateGlobalTableOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateGlobalTableOutput
+    public typealias HeadersType = UpdateGlobalTableOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateGlobalTableOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateGlobalTableSettings operation in a HTTP client.
+ */
+extension UpdateGlobalTableSettingsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateGlobalTableSettingsOutput
+    public typealias HeadersType = UpdateGlobalTableSettingsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateGlobalTableSettingsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateItem operation in a HTTP client.
+ */
+extension UpdateItemOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateItemOutput
+    public typealias HeadersType = UpdateItemOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateItemOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateTable operation in a HTTP client.
+ */
+extension UpdateTableOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateTableOutput
+    public typealias HeadersType = UpdateTableOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateTableOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateTimeToLive operation in a HTTP client.
+ */
+extension UpdateTimeToLiveOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateTimeToLiveOutput
+    public typealias HeadersType = UpdateTimeToLiveOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateTimeToLiveOutput {
+        return try bodyDecodableProvider()
+    }
+}
+

--- a/Sources/DynamoDBClient/MockDynamoDBClient.swift
+++ b/Sources/DynamoDBClient/MockDynamoDBClient.swift
@@ -1208,7 +1208,7 @@ public struct MockDynamoDBClient: DynamoDBClientProtocol {
            is complete.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    public func tagResourceAsync(input: DynamoDBModel.TagResourceInput, completion: @escaping (Error?) -> ()) throws {
+    public func tagResourceAsync(input: DynamoDBModel.TagResourceInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let tagResourceAsyncOverride = tagResourceAsyncOverride {
             return try tagResourceAsyncOverride(input, completion)
         }
@@ -1239,7 +1239,7 @@ public struct MockDynamoDBClient: DynamoDBClientProtocol {
            is complete.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    public func untagResourceAsync(input: DynamoDBModel.UntagResourceInput, completion: @escaping (Error?) -> ()) throws {
+    public func untagResourceAsync(input: DynamoDBModel.UntagResourceInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let untagResourceAsyncOverride = untagResourceAsyncOverride {
             return try untagResourceAsyncOverride(input, completion)
         }

--- a/Sources/DynamoDBClient/ThrowingDynamoDBClient.swift
+++ b/Sources/DynamoDBClient/ThrowingDynamoDBClient.swift
@@ -1158,7 +1158,7 @@ public struct ThrowingDynamoDBClient: DynamoDBClientProtocol {
            is complete.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    public func tagResourceAsync(input: DynamoDBModel.TagResourceInput, completion: @escaping (Error?) -> ()) throws {
+    public func tagResourceAsync(input: DynamoDBModel.TagResourceInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let tagResourceAsyncOverride = tagResourceAsyncOverride {
             return try tagResourceAsyncOverride(input, completion)
         }
@@ -1190,7 +1190,7 @@ public struct ThrowingDynamoDBClient: DynamoDBClientProtocol {
            is complete.
            The possible errors are: internalServer, limitExceeded, resourceInUse, resourceNotFound.
      */
-    public func untagResourceAsync(input: DynamoDBModel.UntagResourceInput, completion: @escaping (Error?) -> ()) throws {
+    public func untagResourceAsync(input: DynamoDBModel.UntagResourceInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let untagResourceAsyncOverride = untagResourceAsyncOverride {
             return try untagResourceAsyncOverride(input, completion)
         }

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
@@ -67,6 +67,22 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
     }
 
     /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times.
+     */
+    public func close() {
+        httpClient.close()
+    }
+
+    /**
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
+     */
+    public func wait() {
+        httpClient.wait()
+    }
+
+    /**
      Invokes the AcceptReservedInstancesExchangeQuote operation returning immediately and passing the response to a callback.
 
      - Parameters:
@@ -82,7 +98,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AcceptReservedInstancesExchangeQuoteOperationHTTPRequestInput<ElasticComputeCloudModel.AcceptReservedInstancesExchangeQuoteRequest>(encodable: input)
+        let wrappedInput = AcceptReservedInstancesExchangeQuoteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -112,7 +128,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AcceptReservedInstancesExchangeQuoteOperationHTTPRequestInput<ElasticComputeCloudModel.AcceptReservedInstancesExchangeQuoteRequest>(encodable: input)
+        let wrappedInput = AcceptReservedInstancesExchangeQuoteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -142,7 +158,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AcceptVpcEndpointConnectionsOperationHTTPRequestInput<ElasticComputeCloudModel.AcceptVpcEndpointConnectionsRequest>(encodable: input)
+        let wrappedInput = AcceptVpcEndpointConnectionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -172,7 +188,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AcceptVpcEndpointConnectionsOperationHTTPRequestInput<ElasticComputeCloudModel.AcceptVpcEndpointConnectionsRequest>(encodable: input)
+        let wrappedInput = AcceptVpcEndpointConnectionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -202,7 +218,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AcceptVpcPeeringConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.AcceptVpcPeeringConnectionRequest>(encodable: input)
+        let wrappedInput = AcceptVpcPeeringConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -232,7 +248,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AcceptVpcPeeringConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.AcceptVpcPeeringConnectionRequest>(encodable: input)
+        let wrappedInput = AcceptVpcPeeringConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -262,7 +278,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AdvertiseByoipCidrOperationHTTPRequestInput<ElasticComputeCloudModel.AdvertiseByoipCidrRequest>(encodable: input)
+        let wrappedInput = AdvertiseByoipCidrOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -292,7 +308,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AdvertiseByoipCidrOperationHTTPRequestInput<ElasticComputeCloudModel.AdvertiseByoipCidrRequest>(encodable: input)
+        let wrappedInput = AdvertiseByoipCidrOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -322,7 +338,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AllocateAddressOperationHTTPRequestInput<ElasticComputeCloudModel.AllocateAddressRequest>(encodable: input)
+        let wrappedInput = AllocateAddressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -352,7 +368,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AllocateAddressOperationHTTPRequestInput<ElasticComputeCloudModel.AllocateAddressRequest>(encodable: input)
+        let wrappedInput = AllocateAddressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -382,7 +398,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AllocateHostsOperationHTTPRequestInput<ElasticComputeCloudModel.AllocateHostsRequest>(encodable: input)
+        let wrappedInput = AllocateHostsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -412,7 +428,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AllocateHostsOperationHTTPRequestInput<ElasticComputeCloudModel.AllocateHostsRequest>(encodable: input)
+        let wrappedInput = AllocateHostsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -442,7 +458,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssignIpv6AddressesOperationHTTPRequestInput<ElasticComputeCloudModel.AssignIpv6AddressesRequest>(encodable: input)
+        let wrappedInput = AssignIpv6AddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -472,7 +488,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssignIpv6AddressesOperationHTTPRequestInput<ElasticComputeCloudModel.AssignIpv6AddressesRequest>(encodable: input)
+        let wrappedInput = AssignIpv6AddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -494,14 +510,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func assignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func assignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = AssignPrivateIpAddressesOperationHTTPRequestInput<ElasticComputeCloudModel.AssignPrivateIpAddressesRequest>(encodable: input)
+        let wrappedInput = AssignPrivateIpAddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -529,7 +545,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssignPrivateIpAddressesOperationHTTPRequestInput<ElasticComputeCloudModel.AssignPrivateIpAddressesRequest>(encodable: input)
+        let wrappedInput = AssignPrivateIpAddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -559,7 +575,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateAddressOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateAddressRequest>(encodable: input)
+        let wrappedInput = AssociateAddressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -589,7 +605,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateAddressOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateAddressRequest>(encodable: input)
+        let wrappedInput = AssociateAddressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -611,14 +627,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func associateDhcpOptionsAsync(input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func associateDhcpOptionsAsync(input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateDhcpOptionsOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateDhcpOptionsRequest>(encodable: input)
+        let wrappedInput = AssociateDhcpOptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -646,7 +662,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateDhcpOptionsOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateDhcpOptionsRequest>(encodable: input)
+        let wrappedInput = AssociateDhcpOptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -676,7 +692,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateIamInstanceProfileOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateIamInstanceProfileRequest>(encodable: input)
+        let wrappedInput = AssociateIamInstanceProfileOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -706,7 +722,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateIamInstanceProfileOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateIamInstanceProfileRequest>(encodable: input)
+        let wrappedInput = AssociateIamInstanceProfileOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -736,7 +752,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateRouteTableOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateRouteTableRequest>(encodable: input)
+        let wrappedInput = AssociateRouteTableOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -766,7 +782,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateRouteTableOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateRouteTableRequest>(encodable: input)
+        let wrappedInput = AssociateRouteTableOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -796,7 +812,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateSubnetCidrBlockOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateSubnetCidrBlockRequest>(encodable: input)
+        let wrappedInput = AssociateSubnetCidrBlockOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -826,7 +842,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateSubnetCidrBlockOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateSubnetCidrBlockRequest>(encodable: input)
+        let wrappedInput = AssociateSubnetCidrBlockOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -856,7 +872,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateVpcCidrBlockOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateVpcCidrBlockRequest>(encodable: input)
+        let wrappedInput = AssociateVpcCidrBlockOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -886,7 +902,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssociateVpcCidrBlockOperationHTTPRequestInput<ElasticComputeCloudModel.AssociateVpcCidrBlockRequest>(encodable: input)
+        let wrappedInput = AssociateVpcCidrBlockOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -916,7 +932,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AttachClassicLinkVpcOperationHTTPRequestInput<ElasticComputeCloudModel.AttachClassicLinkVpcRequest>(encodable: input)
+        let wrappedInput = AttachClassicLinkVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -946,7 +962,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AttachClassicLinkVpcOperationHTTPRequestInput<ElasticComputeCloudModel.AttachClassicLinkVpcRequest>(encodable: input)
+        let wrappedInput = AttachClassicLinkVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -968,14 +984,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func attachInternetGatewayAsync(input: ElasticComputeCloudModel.AttachInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func attachInternetGatewayAsync(input: ElasticComputeCloudModel.AttachInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = AttachInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.AttachInternetGatewayRequest>(encodable: input)
+        let wrappedInput = AttachInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1003,7 +1019,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AttachInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.AttachInternetGatewayRequest>(encodable: input)
+        let wrappedInput = AttachInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1033,7 +1049,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AttachNetworkInterfaceOperationHTTPRequestInput<ElasticComputeCloudModel.AttachNetworkInterfaceRequest>(encodable: input)
+        let wrappedInput = AttachNetworkInterfaceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1063,7 +1079,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AttachNetworkInterfaceOperationHTTPRequestInput<ElasticComputeCloudModel.AttachNetworkInterfaceRequest>(encodable: input)
+        let wrappedInput = AttachNetworkInterfaceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1093,7 +1109,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AttachVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.AttachVolumeRequest>(encodable: input)
+        let wrappedInput = AttachVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1123,7 +1139,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AttachVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.AttachVolumeRequest>(encodable: input)
+        let wrappedInput = AttachVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1153,7 +1169,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AttachVpnGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.AttachVpnGatewayRequest>(encodable: input)
+        let wrappedInput = AttachVpnGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1183,7 +1199,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AttachVpnGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.AttachVpnGatewayRequest>(encodable: input)
+        let wrappedInput = AttachVpnGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1205,14 +1221,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func authorizeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func authorizeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = AuthorizeSecurityGroupEgressOperationHTTPRequestInput<ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest>(encodable: input)
+        let wrappedInput = AuthorizeSecurityGroupEgressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1240,7 +1256,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AuthorizeSecurityGroupEgressOperationHTTPRequestInput<ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest>(encodable: input)
+        let wrappedInput = AuthorizeSecurityGroupEgressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1262,14 +1278,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func authorizeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func authorizeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = AuthorizeSecurityGroupIngressOperationHTTPRequestInput<ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest>(encodable: input)
+        let wrappedInput = AuthorizeSecurityGroupIngressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1297,7 +1313,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AuthorizeSecurityGroupIngressOperationHTTPRequestInput<ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest>(encodable: input)
+        let wrappedInput = AuthorizeSecurityGroupIngressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1327,7 +1343,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = BundleInstanceOperationHTTPRequestInput<ElasticComputeCloudModel.BundleInstanceRequest>(encodable: input)
+        let wrappedInput = BundleInstanceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1357,7 +1373,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = BundleInstanceOperationHTTPRequestInput<ElasticComputeCloudModel.BundleInstanceRequest>(encodable: input)
+        let wrappedInput = BundleInstanceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1387,7 +1403,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelBundleTaskOperationHTTPRequestInput<ElasticComputeCloudModel.CancelBundleTaskRequest>(encodable: input)
+        let wrappedInput = CancelBundleTaskOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1417,7 +1433,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelBundleTaskOperationHTTPRequestInput<ElasticComputeCloudModel.CancelBundleTaskRequest>(encodable: input)
+        let wrappedInput = CancelBundleTaskOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1447,7 +1463,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelCapacityReservationOperationHTTPRequestInput<ElasticComputeCloudModel.CancelCapacityReservationRequest>(encodable: input)
+        let wrappedInput = CancelCapacityReservationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1477,7 +1493,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelCapacityReservationOperationHTTPRequestInput<ElasticComputeCloudModel.CancelCapacityReservationRequest>(encodable: input)
+        let wrappedInput = CancelCapacityReservationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1499,14 +1515,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func cancelConversionTaskAsync(input: ElasticComputeCloudModel.CancelConversionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func cancelConversionTaskAsync(input: ElasticComputeCloudModel.CancelConversionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelConversionTaskOperationHTTPRequestInput<ElasticComputeCloudModel.CancelConversionRequest>(encodable: input)
+        let wrappedInput = CancelConversionTaskOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1534,7 +1550,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelConversionTaskOperationHTTPRequestInput<ElasticComputeCloudModel.CancelConversionRequest>(encodable: input)
+        let wrappedInput = CancelConversionTaskOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1556,14 +1572,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func cancelExportTaskAsync(input: ElasticComputeCloudModel.CancelExportTaskRequest, completion: @escaping (Error?) -> ()) throws {
+    public func cancelExportTaskAsync(input: ElasticComputeCloudModel.CancelExportTaskRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelExportTaskOperationHTTPRequestInput<ElasticComputeCloudModel.CancelExportTaskRequest>(encodable: input)
+        let wrappedInput = CancelExportTaskOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1591,7 +1607,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelExportTaskOperationHTTPRequestInput<ElasticComputeCloudModel.CancelExportTaskRequest>(encodable: input)
+        let wrappedInput = CancelExportTaskOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1621,7 +1637,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelImportTaskOperationHTTPRequestInput<ElasticComputeCloudModel.CancelImportTaskRequest>(encodable: input)
+        let wrappedInput = CancelImportTaskOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1651,7 +1667,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelImportTaskOperationHTTPRequestInput<ElasticComputeCloudModel.CancelImportTaskRequest>(encodable: input)
+        let wrappedInput = CancelImportTaskOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1681,7 +1697,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelReservedInstancesListingOperationHTTPRequestInput<ElasticComputeCloudModel.CancelReservedInstancesListingRequest>(encodable: input)
+        let wrappedInput = CancelReservedInstancesListingOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1711,7 +1727,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelReservedInstancesListingOperationHTTPRequestInput<ElasticComputeCloudModel.CancelReservedInstancesListingRequest>(encodable: input)
+        let wrappedInput = CancelReservedInstancesListingOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1741,7 +1757,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelSpotFleetRequestsOperationHTTPRequestInput<ElasticComputeCloudModel.CancelSpotFleetRequestsRequest>(encodable: input)
+        let wrappedInput = CancelSpotFleetRequestsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1771,7 +1787,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelSpotFleetRequestsOperationHTTPRequestInput<ElasticComputeCloudModel.CancelSpotFleetRequestsRequest>(encodable: input)
+        let wrappedInput = CancelSpotFleetRequestsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1801,7 +1817,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelSpotInstanceRequestsOperationHTTPRequestInput<ElasticComputeCloudModel.CancelSpotInstanceRequestsRequest>(encodable: input)
+        let wrappedInput = CancelSpotInstanceRequestsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1831,7 +1847,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CancelSpotInstanceRequestsOperationHTTPRequestInput<ElasticComputeCloudModel.CancelSpotInstanceRequestsRequest>(encodable: input)
+        let wrappedInput = CancelSpotInstanceRequestsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1861,7 +1877,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ConfirmProductInstanceOperationHTTPRequestInput<ElasticComputeCloudModel.ConfirmProductInstanceRequest>(encodable: input)
+        let wrappedInput = ConfirmProductInstanceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1891,7 +1907,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ConfirmProductInstanceOperationHTTPRequestInput<ElasticComputeCloudModel.ConfirmProductInstanceRequest>(encodable: input)
+        let wrappedInput = ConfirmProductInstanceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1921,7 +1937,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CopyFpgaImageOperationHTTPRequestInput<ElasticComputeCloudModel.CopyFpgaImageRequest>(encodable: input)
+        let wrappedInput = CopyFpgaImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1951,7 +1967,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CopyFpgaImageOperationHTTPRequestInput<ElasticComputeCloudModel.CopyFpgaImageRequest>(encodable: input)
+        let wrappedInput = CopyFpgaImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1981,7 +1997,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CopyImageOperationHTTPRequestInput<ElasticComputeCloudModel.CopyImageRequest>(encodable: input)
+        let wrappedInput = CopyImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2011,7 +2027,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CopyImageOperationHTTPRequestInput<ElasticComputeCloudModel.CopyImageRequest>(encodable: input)
+        let wrappedInput = CopyImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2041,7 +2057,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CopySnapshotOperationHTTPRequestInput<ElasticComputeCloudModel.CopySnapshotRequest>(encodable: input)
+        let wrappedInput = CopySnapshotOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2071,7 +2087,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CopySnapshotOperationHTTPRequestInput<ElasticComputeCloudModel.CopySnapshotRequest>(encodable: input)
+        let wrappedInput = CopySnapshotOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2101,7 +2117,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateCapacityReservationOperationHTTPRequestInput<ElasticComputeCloudModel.CreateCapacityReservationRequest>(encodable: input)
+        let wrappedInput = CreateCapacityReservationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2131,7 +2147,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateCapacityReservationOperationHTTPRequestInput<ElasticComputeCloudModel.CreateCapacityReservationRequest>(encodable: input)
+        let wrappedInput = CreateCapacityReservationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2161,7 +2177,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateCustomerGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.CreateCustomerGatewayRequest>(encodable: input)
+        let wrappedInput = CreateCustomerGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2191,7 +2207,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateCustomerGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.CreateCustomerGatewayRequest>(encodable: input)
+        let wrappedInput = CreateCustomerGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2221,7 +2237,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateDefaultSubnetOperationHTTPRequestInput<ElasticComputeCloudModel.CreateDefaultSubnetRequest>(encodable: input)
+        let wrappedInput = CreateDefaultSubnetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2251,7 +2267,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateDefaultSubnetOperationHTTPRequestInput<ElasticComputeCloudModel.CreateDefaultSubnetRequest>(encodable: input)
+        let wrappedInput = CreateDefaultSubnetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2281,7 +2297,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateDefaultVpcOperationHTTPRequestInput<ElasticComputeCloudModel.CreateDefaultVpcRequest>(encodable: input)
+        let wrappedInput = CreateDefaultVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2311,7 +2327,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateDefaultVpcOperationHTTPRequestInput<ElasticComputeCloudModel.CreateDefaultVpcRequest>(encodable: input)
+        let wrappedInput = CreateDefaultVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2341,7 +2357,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateDhcpOptionsOperationHTTPRequestInput<ElasticComputeCloudModel.CreateDhcpOptionsRequest>(encodable: input)
+        let wrappedInput = CreateDhcpOptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2371,7 +2387,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateDhcpOptionsOperationHTTPRequestInput<ElasticComputeCloudModel.CreateDhcpOptionsRequest>(encodable: input)
+        let wrappedInput = CreateDhcpOptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2401,7 +2417,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateEgressOnlyInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.CreateEgressOnlyInternetGatewayRequest>(encodable: input)
+        let wrappedInput = CreateEgressOnlyInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2431,7 +2447,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateEgressOnlyInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.CreateEgressOnlyInternetGatewayRequest>(encodable: input)
+        let wrappedInput = CreateEgressOnlyInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2461,7 +2477,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateFleetOperationHTTPRequestInput<ElasticComputeCloudModel.CreateFleetRequest>(encodable: input)
+        let wrappedInput = CreateFleetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2491,7 +2507,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateFleetOperationHTTPRequestInput<ElasticComputeCloudModel.CreateFleetRequest>(encodable: input)
+        let wrappedInput = CreateFleetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2521,7 +2537,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateFlowLogsOperationHTTPRequestInput<ElasticComputeCloudModel.CreateFlowLogsRequest>(encodable: input)
+        let wrappedInput = CreateFlowLogsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2551,7 +2567,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateFlowLogsOperationHTTPRequestInput<ElasticComputeCloudModel.CreateFlowLogsRequest>(encodable: input)
+        let wrappedInput = CreateFlowLogsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2581,7 +2597,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateFpgaImageOperationHTTPRequestInput<ElasticComputeCloudModel.CreateFpgaImageRequest>(encodable: input)
+        let wrappedInput = CreateFpgaImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2611,7 +2627,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateFpgaImageOperationHTTPRequestInput<ElasticComputeCloudModel.CreateFpgaImageRequest>(encodable: input)
+        let wrappedInput = CreateFpgaImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2641,7 +2657,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateImageOperationHTTPRequestInput<ElasticComputeCloudModel.CreateImageRequest>(encodable: input)
+        let wrappedInput = CreateImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2671,7 +2687,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateImageOperationHTTPRequestInput<ElasticComputeCloudModel.CreateImageRequest>(encodable: input)
+        let wrappedInput = CreateImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2701,7 +2717,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateInstanceExportTaskOperationHTTPRequestInput<ElasticComputeCloudModel.CreateInstanceExportTaskRequest>(encodable: input)
+        let wrappedInput = CreateInstanceExportTaskOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2731,7 +2747,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateInstanceExportTaskOperationHTTPRequestInput<ElasticComputeCloudModel.CreateInstanceExportTaskRequest>(encodable: input)
+        let wrappedInput = CreateInstanceExportTaskOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2761,7 +2777,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.CreateInternetGatewayRequest>(encodable: input)
+        let wrappedInput = CreateInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2791,7 +2807,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.CreateInternetGatewayRequest>(encodable: input)
+        let wrappedInput = CreateInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2821,7 +2837,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateKeyPairOperationHTTPRequestInput<ElasticComputeCloudModel.CreateKeyPairRequest>(encodable: input)
+        let wrappedInput = CreateKeyPairOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2851,7 +2867,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateKeyPairOperationHTTPRequestInput<ElasticComputeCloudModel.CreateKeyPairRequest>(encodable: input)
+        let wrappedInput = CreateKeyPairOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2881,7 +2897,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateLaunchTemplateOperationHTTPRequestInput<ElasticComputeCloudModel.CreateLaunchTemplateRequest>(encodable: input)
+        let wrappedInput = CreateLaunchTemplateOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2911,7 +2927,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateLaunchTemplateOperationHTTPRequestInput<ElasticComputeCloudModel.CreateLaunchTemplateRequest>(encodable: input)
+        let wrappedInput = CreateLaunchTemplateOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2941,7 +2957,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateLaunchTemplateVersionOperationHTTPRequestInput<ElasticComputeCloudModel.CreateLaunchTemplateVersionRequest>(encodable: input)
+        let wrappedInput = CreateLaunchTemplateVersionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -2971,7 +2987,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateLaunchTemplateVersionOperationHTTPRequestInput<ElasticComputeCloudModel.CreateLaunchTemplateVersionRequest>(encodable: input)
+        let wrappedInput = CreateLaunchTemplateVersionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3001,7 +3017,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateNatGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.CreateNatGatewayRequest>(encodable: input)
+        let wrappedInput = CreateNatGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3031,7 +3047,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateNatGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.CreateNatGatewayRequest>(encodable: input)
+        let wrappedInput = CreateNatGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3061,7 +3077,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateNetworkAclOperationHTTPRequestInput<ElasticComputeCloudModel.CreateNetworkAclRequest>(encodable: input)
+        let wrappedInput = CreateNetworkAclOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3091,7 +3107,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateNetworkAclOperationHTTPRequestInput<ElasticComputeCloudModel.CreateNetworkAclRequest>(encodable: input)
+        let wrappedInput = CreateNetworkAclOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3113,14 +3129,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createNetworkAclEntryAsync(input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createNetworkAclEntryAsync(input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateNetworkAclEntryOperationHTTPRequestInput<ElasticComputeCloudModel.CreateNetworkAclEntryRequest>(encodable: input)
+        let wrappedInput = CreateNetworkAclEntryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3148,7 +3164,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateNetworkAclEntryOperationHTTPRequestInput<ElasticComputeCloudModel.CreateNetworkAclEntryRequest>(encodable: input)
+        let wrappedInput = CreateNetworkAclEntryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3178,7 +3194,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateNetworkInterfaceOperationHTTPRequestInput<ElasticComputeCloudModel.CreateNetworkInterfaceRequest>(encodable: input)
+        let wrappedInput = CreateNetworkInterfaceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3208,7 +3224,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateNetworkInterfaceOperationHTTPRequestInput<ElasticComputeCloudModel.CreateNetworkInterfaceRequest>(encodable: input)
+        let wrappedInput = CreateNetworkInterfaceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3238,7 +3254,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateNetworkInterfacePermissionOperationHTTPRequestInput<ElasticComputeCloudModel.CreateNetworkInterfacePermissionRequest>(encodable: input)
+        let wrappedInput = CreateNetworkInterfacePermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3268,7 +3284,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateNetworkInterfacePermissionOperationHTTPRequestInput<ElasticComputeCloudModel.CreateNetworkInterfacePermissionRequest>(encodable: input)
+        let wrappedInput = CreateNetworkInterfacePermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3290,14 +3306,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createPlacementGroupAsync(input: ElasticComputeCloudModel.CreatePlacementGroupRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createPlacementGroupAsync(input: ElasticComputeCloudModel.CreatePlacementGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = CreatePlacementGroupOperationHTTPRequestInput<ElasticComputeCloudModel.CreatePlacementGroupRequest>(encodable: input)
+        let wrappedInput = CreatePlacementGroupOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3325,7 +3341,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreatePlacementGroupOperationHTTPRequestInput<ElasticComputeCloudModel.CreatePlacementGroupRequest>(encodable: input)
+        let wrappedInput = CreatePlacementGroupOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3355,7 +3371,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateReservedInstancesListingOperationHTTPRequestInput<ElasticComputeCloudModel.CreateReservedInstancesListingRequest>(encodable: input)
+        let wrappedInput = CreateReservedInstancesListingOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3385,7 +3401,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateReservedInstancesListingOperationHTTPRequestInput<ElasticComputeCloudModel.CreateReservedInstancesListingRequest>(encodable: input)
+        let wrappedInput = CreateReservedInstancesListingOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3415,7 +3431,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateRouteOperationHTTPRequestInput<ElasticComputeCloudModel.CreateRouteRequest>(encodable: input)
+        let wrappedInput = CreateRouteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3445,7 +3461,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateRouteOperationHTTPRequestInput<ElasticComputeCloudModel.CreateRouteRequest>(encodable: input)
+        let wrappedInput = CreateRouteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3475,7 +3491,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateRouteTableOperationHTTPRequestInput<ElasticComputeCloudModel.CreateRouteTableRequest>(encodable: input)
+        let wrappedInput = CreateRouteTableOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3505,7 +3521,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateRouteTableOperationHTTPRequestInput<ElasticComputeCloudModel.CreateRouteTableRequest>(encodable: input)
+        let wrappedInput = CreateRouteTableOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3535,7 +3551,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateSecurityGroupOperationHTTPRequestInput<ElasticComputeCloudModel.CreateSecurityGroupRequest>(encodable: input)
+        let wrappedInput = CreateSecurityGroupOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3565,7 +3581,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateSecurityGroupOperationHTTPRequestInput<ElasticComputeCloudModel.CreateSecurityGroupRequest>(encodable: input)
+        let wrappedInput = CreateSecurityGroupOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3595,7 +3611,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateSnapshotOperationHTTPRequestInput<ElasticComputeCloudModel.CreateSnapshotRequest>(encodable: input)
+        let wrappedInput = CreateSnapshotOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3625,7 +3641,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateSnapshotOperationHTTPRequestInput<ElasticComputeCloudModel.CreateSnapshotRequest>(encodable: input)
+        let wrappedInput = CreateSnapshotOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3655,7 +3671,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateSpotDatafeedSubscriptionOperationHTTPRequestInput<ElasticComputeCloudModel.CreateSpotDatafeedSubscriptionRequest>(encodable: input)
+        let wrappedInput = CreateSpotDatafeedSubscriptionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3685,7 +3701,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateSpotDatafeedSubscriptionOperationHTTPRequestInput<ElasticComputeCloudModel.CreateSpotDatafeedSubscriptionRequest>(encodable: input)
+        let wrappedInput = CreateSpotDatafeedSubscriptionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3715,7 +3731,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateSubnetOperationHTTPRequestInput<ElasticComputeCloudModel.CreateSubnetRequest>(encodable: input)
+        let wrappedInput = CreateSubnetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3745,7 +3761,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateSubnetOperationHTTPRequestInput<ElasticComputeCloudModel.CreateSubnetRequest>(encodable: input)
+        let wrappedInput = CreateSubnetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3767,14 +3783,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createTagsAsync(input: ElasticComputeCloudModel.CreateTagsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createTagsAsync(input: ElasticComputeCloudModel.CreateTagsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateTagsOperationHTTPRequestInput<ElasticComputeCloudModel.CreateTagsRequest>(encodable: input)
+        let wrappedInput = CreateTagsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3802,7 +3818,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateTagsOperationHTTPRequestInput<ElasticComputeCloudModel.CreateTagsRequest>(encodable: input)
+        let wrappedInput = CreateTagsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3832,7 +3848,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVolumeRequest>(encodable: input)
+        let wrappedInput = CreateVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3862,7 +3878,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVolumeRequest>(encodable: input)
+        let wrappedInput = CreateVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3892,7 +3908,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpcOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpcRequest>(encodable: input)
+        let wrappedInput = CreateVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3922,7 +3938,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpcOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpcRequest>(encodable: input)
+        let wrappedInput = CreateVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3952,7 +3968,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpcEndpointOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpcEndpointRequest>(encodable: input)
+        let wrappedInput = CreateVpcEndpointOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -3982,7 +3998,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpcEndpointOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpcEndpointRequest>(encodable: input)
+        let wrappedInput = CreateVpcEndpointOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4012,7 +4028,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpcEndpointConnectionNotificationOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpcEndpointConnectionNotificationRequest>(encodable: input)
+        let wrappedInput = CreateVpcEndpointConnectionNotificationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4042,7 +4058,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpcEndpointConnectionNotificationOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpcEndpointConnectionNotificationRequest>(encodable: input)
+        let wrappedInput = CreateVpcEndpointConnectionNotificationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4072,7 +4088,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpcEndpointServiceConfigurationOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpcEndpointServiceConfigurationRequest>(encodable: input)
+        let wrappedInput = CreateVpcEndpointServiceConfigurationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4102,7 +4118,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpcEndpointServiceConfigurationOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpcEndpointServiceConfigurationRequest>(encodable: input)
+        let wrappedInput = CreateVpcEndpointServiceConfigurationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4132,7 +4148,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpcPeeringConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpcPeeringConnectionRequest>(encodable: input)
+        let wrappedInput = CreateVpcPeeringConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4162,7 +4178,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpcPeeringConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpcPeeringConnectionRequest>(encodable: input)
+        let wrappedInput = CreateVpcPeeringConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4192,7 +4208,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpnConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpnConnectionRequest>(encodable: input)
+        let wrappedInput = CreateVpnConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4222,7 +4238,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpnConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpnConnectionRequest>(encodable: input)
+        let wrappedInput = CreateVpnConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4244,14 +4260,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createVpnConnectionRouteAsync(input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createVpnConnectionRouteAsync(input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpnConnectionRouteOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpnConnectionRouteRequest>(encodable: input)
+        let wrappedInput = CreateVpnConnectionRouteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4279,7 +4295,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpnConnectionRouteOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpnConnectionRouteRequest>(encodable: input)
+        let wrappedInput = CreateVpnConnectionRouteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4309,7 +4325,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpnGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpnGatewayRequest>(encodable: input)
+        let wrappedInput = CreateVpnGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4339,7 +4355,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateVpnGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.CreateVpnGatewayRequest>(encodable: input)
+        let wrappedInput = CreateVpnGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4361,14 +4377,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteCustomerGatewayAsync(input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteCustomerGatewayAsync(input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteCustomerGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteCustomerGatewayRequest>(encodable: input)
+        let wrappedInput = DeleteCustomerGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4396,7 +4412,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteCustomerGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteCustomerGatewayRequest>(encodable: input)
+        let wrappedInput = DeleteCustomerGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4418,14 +4434,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteDhcpOptionsAsync(input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteDhcpOptionsAsync(input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteDhcpOptionsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteDhcpOptionsRequest>(encodable: input)
+        let wrappedInput = DeleteDhcpOptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4453,7 +4469,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteDhcpOptionsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteDhcpOptionsRequest>(encodable: input)
+        let wrappedInput = DeleteDhcpOptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4483,7 +4499,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteEgressOnlyInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteEgressOnlyInternetGatewayRequest>(encodable: input)
+        let wrappedInput = DeleteEgressOnlyInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4513,7 +4529,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteEgressOnlyInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteEgressOnlyInternetGatewayRequest>(encodable: input)
+        let wrappedInput = DeleteEgressOnlyInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4543,7 +4559,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteFleetsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteFleetsRequest>(encodable: input)
+        let wrappedInput = DeleteFleetsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4573,7 +4589,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteFleetsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteFleetsRequest>(encodable: input)
+        let wrappedInput = DeleteFleetsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4603,7 +4619,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteFlowLogsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteFlowLogsRequest>(encodable: input)
+        let wrappedInput = DeleteFlowLogsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4633,7 +4649,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteFlowLogsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteFlowLogsRequest>(encodable: input)
+        let wrappedInput = DeleteFlowLogsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4663,7 +4679,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteFpgaImageOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteFpgaImageRequest>(encodable: input)
+        let wrappedInput = DeleteFpgaImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4693,7 +4709,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteFpgaImageOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteFpgaImageRequest>(encodable: input)
+        let wrappedInput = DeleteFpgaImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4715,14 +4731,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteInternetGatewayAsync(input: ElasticComputeCloudModel.DeleteInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteInternetGatewayAsync(input: ElasticComputeCloudModel.DeleteInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteInternetGatewayRequest>(encodable: input)
+        let wrappedInput = DeleteInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4750,7 +4766,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteInternetGatewayRequest>(encodable: input)
+        let wrappedInput = DeleteInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4772,14 +4788,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteKeyPairAsync(input: ElasticComputeCloudModel.DeleteKeyPairRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteKeyPairAsync(input: ElasticComputeCloudModel.DeleteKeyPairRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteKeyPairOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteKeyPairRequest>(encodable: input)
+        let wrappedInput = DeleteKeyPairOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4807,7 +4823,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteKeyPairOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteKeyPairRequest>(encodable: input)
+        let wrappedInput = DeleteKeyPairOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4837,7 +4853,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteLaunchTemplateOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteLaunchTemplateRequest>(encodable: input)
+        let wrappedInput = DeleteLaunchTemplateOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4867,7 +4883,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteLaunchTemplateOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteLaunchTemplateRequest>(encodable: input)
+        let wrappedInput = DeleteLaunchTemplateOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4897,7 +4913,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteLaunchTemplateVersionsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteLaunchTemplateVersionsRequest>(encodable: input)
+        let wrappedInput = DeleteLaunchTemplateVersionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4927,7 +4943,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteLaunchTemplateVersionsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteLaunchTemplateVersionsRequest>(encodable: input)
+        let wrappedInput = DeleteLaunchTemplateVersionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4957,7 +4973,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteNatGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteNatGatewayRequest>(encodable: input)
+        let wrappedInput = DeleteNatGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -4987,7 +5003,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteNatGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteNatGatewayRequest>(encodable: input)
+        let wrappedInput = DeleteNatGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5009,14 +5025,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteNetworkAclAsync(input: ElasticComputeCloudModel.DeleteNetworkAclRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteNetworkAclAsync(input: ElasticComputeCloudModel.DeleteNetworkAclRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteNetworkAclOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteNetworkAclRequest>(encodable: input)
+        let wrappedInput = DeleteNetworkAclOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5044,7 +5060,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteNetworkAclOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteNetworkAclRequest>(encodable: input)
+        let wrappedInput = DeleteNetworkAclOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5066,14 +5082,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteNetworkAclEntryAsync(input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteNetworkAclEntryAsync(input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteNetworkAclEntryOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteNetworkAclEntryRequest>(encodable: input)
+        let wrappedInput = DeleteNetworkAclEntryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5101,7 +5117,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteNetworkAclEntryOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteNetworkAclEntryRequest>(encodable: input)
+        let wrappedInput = DeleteNetworkAclEntryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5123,14 +5139,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteNetworkInterfaceAsync(input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteNetworkInterfaceAsync(input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteNetworkInterfaceOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteNetworkInterfaceRequest>(encodable: input)
+        let wrappedInput = DeleteNetworkInterfaceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5158,7 +5174,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteNetworkInterfaceOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteNetworkInterfaceRequest>(encodable: input)
+        let wrappedInput = DeleteNetworkInterfaceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5188,7 +5204,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteNetworkInterfacePermissionOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteNetworkInterfacePermissionRequest>(encodable: input)
+        let wrappedInput = DeleteNetworkInterfacePermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5218,7 +5234,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteNetworkInterfacePermissionOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteNetworkInterfacePermissionRequest>(encodable: input)
+        let wrappedInput = DeleteNetworkInterfacePermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5240,14 +5256,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deletePlacementGroupAsync(input: ElasticComputeCloudModel.DeletePlacementGroupRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deletePlacementGroupAsync(input: ElasticComputeCloudModel.DeletePlacementGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeletePlacementGroupOperationHTTPRequestInput<ElasticComputeCloudModel.DeletePlacementGroupRequest>(encodable: input)
+        let wrappedInput = DeletePlacementGroupOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5275,7 +5291,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeletePlacementGroupOperationHTTPRequestInput<ElasticComputeCloudModel.DeletePlacementGroupRequest>(encodable: input)
+        let wrappedInput = DeletePlacementGroupOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5297,14 +5313,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteRouteAsync(input: ElasticComputeCloudModel.DeleteRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteRouteAsync(input: ElasticComputeCloudModel.DeleteRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteRouteOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteRouteRequest>(encodable: input)
+        let wrappedInput = DeleteRouteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5332,7 +5348,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteRouteOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteRouteRequest>(encodable: input)
+        let wrappedInput = DeleteRouteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5354,14 +5370,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteRouteTableAsync(input: ElasticComputeCloudModel.DeleteRouteTableRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteRouteTableAsync(input: ElasticComputeCloudModel.DeleteRouteTableRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteRouteTableOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteRouteTableRequest>(encodable: input)
+        let wrappedInput = DeleteRouteTableOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5389,7 +5405,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteRouteTableOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteRouteTableRequest>(encodable: input)
+        let wrappedInput = DeleteRouteTableOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5411,14 +5427,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSecurityGroupAsync(input: ElasticComputeCloudModel.DeleteSecurityGroupRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSecurityGroupAsync(input: ElasticComputeCloudModel.DeleteSecurityGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteSecurityGroupOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteSecurityGroupRequest>(encodable: input)
+        let wrappedInput = DeleteSecurityGroupOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5446,7 +5462,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteSecurityGroupOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteSecurityGroupRequest>(encodable: input)
+        let wrappedInput = DeleteSecurityGroupOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5468,14 +5484,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSnapshotAsync(input: ElasticComputeCloudModel.DeleteSnapshotRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSnapshotAsync(input: ElasticComputeCloudModel.DeleteSnapshotRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteSnapshotOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteSnapshotRequest>(encodable: input)
+        let wrappedInput = DeleteSnapshotOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5503,7 +5519,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteSnapshotOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteSnapshotRequest>(encodable: input)
+        let wrappedInput = DeleteSnapshotOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5525,14 +5541,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSpotDatafeedSubscriptionAsync(input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSpotDatafeedSubscriptionAsync(input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteSpotDatafeedSubscriptionOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest>(encodable: input)
+        let wrappedInput = DeleteSpotDatafeedSubscriptionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5560,7 +5576,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteSpotDatafeedSubscriptionOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest>(encodable: input)
+        let wrappedInput = DeleteSpotDatafeedSubscriptionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5582,14 +5598,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSubnetAsync(input: ElasticComputeCloudModel.DeleteSubnetRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSubnetAsync(input: ElasticComputeCloudModel.DeleteSubnetRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteSubnetOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteSubnetRequest>(encodable: input)
+        let wrappedInput = DeleteSubnetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5617,7 +5633,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteSubnetOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteSubnetRequest>(encodable: input)
+        let wrappedInput = DeleteSubnetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5639,14 +5655,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteTagsAsync(input: ElasticComputeCloudModel.DeleteTagsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteTagsAsync(input: ElasticComputeCloudModel.DeleteTagsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteTagsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteTagsRequest>(encodable: input)
+        let wrappedInput = DeleteTagsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5674,7 +5690,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteTagsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteTagsRequest>(encodable: input)
+        let wrappedInput = DeleteTagsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5696,14 +5712,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVolumeAsync(input: ElasticComputeCloudModel.DeleteVolumeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVolumeAsync(input: ElasticComputeCloudModel.DeleteVolumeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVolumeRequest>(encodable: input)
+        let wrappedInput = DeleteVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5731,7 +5747,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVolumeRequest>(encodable: input)
+        let wrappedInput = DeleteVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5753,14 +5769,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpcAsync(input: ElasticComputeCloudModel.DeleteVpcRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpcAsync(input: ElasticComputeCloudModel.DeleteVpcRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpcOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpcRequest>(encodable: input)
+        let wrappedInput = DeleteVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5788,7 +5804,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpcOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpcRequest>(encodable: input)
+        let wrappedInput = DeleteVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5818,7 +5834,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpcEndpointConnectionNotificationsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpcEndpointConnectionNotificationsRequest>(encodable: input)
+        let wrappedInput = DeleteVpcEndpointConnectionNotificationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5848,7 +5864,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpcEndpointConnectionNotificationsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpcEndpointConnectionNotificationsRequest>(encodable: input)
+        let wrappedInput = DeleteVpcEndpointConnectionNotificationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5878,7 +5894,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpcEndpointServiceConfigurationsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpcEndpointServiceConfigurationsRequest>(encodable: input)
+        let wrappedInput = DeleteVpcEndpointServiceConfigurationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5908,7 +5924,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpcEndpointServiceConfigurationsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpcEndpointServiceConfigurationsRequest>(encodable: input)
+        let wrappedInput = DeleteVpcEndpointServiceConfigurationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5938,7 +5954,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpcEndpointsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpcEndpointsRequest>(encodable: input)
+        let wrappedInput = DeleteVpcEndpointsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5968,7 +5984,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpcEndpointsOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpcEndpointsRequest>(encodable: input)
+        let wrappedInput = DeleteVpcEndpointsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -5998,7 +6014,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpcPeeringConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpcPeeringConnectionRequest>(encodable: input)
+        let wrappedInput = DeleteVpcPeeringConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6028,7 +6044,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpcPeeringConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpcPeeringConnectionRequest>(encodable: input)
+        let wrappedInput = DeleteVpcPeeringConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6050,14 +6066,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpnConnectionAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpnConnectionAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpnConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpnConnectionRequest>(encodable: input)
+        let wrappedInput = DeleteVpnConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6085,7 +6101,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpnConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpnConnectionRequest>(encodable: input)
+        let wrappedInput = DeleteVpnConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6107,14 +6123,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpnConnectionRouteAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpnConnectionRouteAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpnConnectionRouteOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest>(encodable: input)
+        let wrappedInput = DeleteVpnConnectionRouteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6142,7 +6158,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpnConnectionRouteOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest>(encodable: input)
+        let wrappedInput = DeleteVpnConnectionRouteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6164,14 +6180,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpnGatewayAsync(input: ElasticComputeCloudModel.DeleteVpnGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpnGatewayAsync(input: ElasticComputeCloudModel.DeleteVpnGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpnGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpnGatewayRequest>(encodable: input)
+        let wrappedInput = DeleteVpnGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6199,7 +6215,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteVpnGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DeleteVpnGatewayRequest>(encodable: input)
+        let wrappedInput = DeleteVpnGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6229,7 +6245,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeprovisionByoipCidrOperationHTTPRequestInput<ElasticComputeCloudModel.DeprovisionByoipCidrRequest>(encodable: input)
+        let wrappedInput = DeprovisionByoipCidrOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6259,7 +6275,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeprovisionByoipCidrOperationHTTPRequestInput<ElasticComputeCloudModel.DeprovisionByoipCidrRequest>(encodable: input)
+        let wrappedInput = DeprovisionByoipCidrOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6281,14 +6297,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deregisterImageAsync(input: ElasticComputeCloudModel.DeregisterImageRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deregisterImageAsync(input: ElasticComputeCloudModel.DeregisterImageRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeregisterImageOperationHTTPRequestInput<ElasticComputeCloudModel.DeregisterImageRequest>(encodable: input)
+        let wrappedInput = DeregisterImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6316,7 +6332,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeregisterImageOperationHTTPRequestInput<ElasticComputeCloudModel.DeregisterImageRequest>(encodable: input)
+        let wrappedInput = DeregisterImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6346,7 +6362,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAccountAttributesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeAccountAttributesRequest>(encodable: input)
+        let wrappedInput = DescribeAccountAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6376,7 +6392,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAccountAttributesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeAccountAttributesRequest>(encodable: input)
+        let wrappedInput = DescribeAccountAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6406,7 +6422,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAddressesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeAddressesRequest>(encodable: input)
+        let wrappedInput = DescribeAddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6436,7 +6452,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAddressesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeAddressesRequest>(encodable: input)
+        let wrappedInput = DescribeAddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6466,7 +6482,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAggregateIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeAggregateIdFormatRequest>(encodable: input)
+        let wrappedInput = DescribeAggregateIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6496,7 +6512,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAggregateIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeAggregateIdFormatRequest>(encodable: input)
+        let wrappedInput = DescribeAggregateIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6526,7 +6542,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAvailabilityZonesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeAvailabilityZonesRequest>(encodable: input)
+        let wrappedInput = DescribeAvailabilityZonesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6556,7 +6572,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeAvailabilityZonesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeAvailabilityZonesRequest>(encodable: input)
+        let wrappedInput = DescribeAvailabilityZonesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6586,7 +6602,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeBundleTasksOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeBundleTasksRequest>(encodable: input)
+        let wrappedInput = DescribeBundleTasksOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6616,7 +6632,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeBundleTasksOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeBundleTasksRequest>(encodable: input)
+        let wrappedInput = DescribeBundleTasksOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6646,7 +6662,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeByoipCidrsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeByoipCidrsRequest>(encodable: input)
+        let wrappedInput = DescribeByoipCidrsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6676,7 +6692,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeByoipCidrsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeByoipCidrsRequest>(encodable: input)
+        let wrappedInput = DescribeByoipCidrsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6706,7 +6722,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeCapacityReservationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeCapacityReservationsRequest>(encodable: input)
+        let wrappedInput = DescribeCapacityReservationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6736,7 +6752,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeCapacityReservationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeCapacityReservationsRequest>(encodable: input)
+        let wrappedInput = DescribeCapacityReservationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6766,7 +6782,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeClassicLinkInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeClassicLinkInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeClassicLinkInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6796,7 +6812,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeClassicLinkInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeClassicLinkInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeClassicLinkInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6826,7 +6842,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeConversionTasksOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeConversionTasksRequest>(encodable: input)
+        let wrappedInput = DescribeConversionTasksOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6856,7 +6872,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeConversionTasksOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeConversionTasksRequest>(encodable: input)
+        let wrappedInput = DescribeConversionTasksOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6886,7 +6902,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeCustomerGatewaysOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeCustomerGatewaysRequest>(encodable: input)
+        let wrappedInput = DescribeCustomerGatewaysOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6916,7 +6932,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeCustomerGatewaysOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeCustomerGatewaysRequest>(encodable: input)
+        let wrappedInput = DescribeCustomerGatewaysOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6946,7 +6962,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeDhcpOptionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeDhcpOptionsRequest>(encodable: input)
+        let wrappedInput = DescribeDhcpOptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -6976,7 +6992,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeDhcpOptionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeDhcpOptionsRequest>(encodable: input)
+        let wrappedInput = DescribeDhcpOptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7006,7 +7022,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeEgressOnlyInternetGatewaysOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeEgressOnlyInternetGatewaysRequest>(encodable: input)
+        let wrappedInput = DescribeEgressOnlyInternetGatewaysOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7036,7 +7052,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeEgressOnlyInternetGatewaysOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeEgressOnlyInternetGatewaysRequest>(encodable: input)
+        let wrappedInput = DescribeEgressOnlyInternetGatewaysOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7066,7 +7082,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeElasticGpusOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeElasticGpusRequest>(encodable: input)
+        let wrappedInput = DescribeElasticGpusOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7096,7 +7112,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeElasticGpusOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeElasticGpusRequest>(encodable: input)
+        let wrappedInput = DescribeElasticGpusOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7126,7 +7142,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeExportTasksOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeExportTasksRequest>(encodable: input)
+        let wrappedInput = DescribeExportTasksOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7156,7 +7172,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeExportTasksOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeExportTasksRequest>(encodable: input)
+        let wrappedInput = DescribeExportTasksOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7186,7 +7202,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFleetHistoryOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFleetHistoryRequest>(encodable: input)
+        let wrappedInput = DescribeFleetHistoryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7216,7 +7232,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFleetHistoryOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFleetHistoryRequest>(encodable: input)
+        let wrappedInput = DescribeFleetHistoryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7246,7 +7262,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFleetInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFleetInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeFleetInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7276,7 +7292,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFleetInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFleetInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeFleetInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7306,7 +7322,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFleetsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFleetsRequest>(encodable: input)
+        let wrappedInput = DescribeFleetsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7336,7 +7352,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFleetsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFleetsRequest>(encodable: input)
+        let wrappedInput = DescribeFleetsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7366,7 +7382,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFlowLogsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFlowLogsRequest>(encodable: input)
+        let wrappedInput = DescribeFlowLogsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7396,7 +7412,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFlowLogsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFlowLogsRequest>(encodable: input)
+        let wrappedInput = DescribeFlowLogsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7426,7 +7442,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFpgaImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFpgaImageAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeFpgaImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7456,7 +7472,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFpgaImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFpgaImageAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeFpgaImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7486,7 +7502,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFpgaImagesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFpgaImagesRequest>(encodable: input)
+        let wrappedInput = DescribeFpgaImagesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7516,7 +7532,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeFpgaImagesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeFpgaImagesRequest>(encodable: input)
+        let wrappedInput = DescribeFpgaImagesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7546,7 +7562,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeHostReservationOfferingsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeHostReservationOfferingsRequest>(encodable: input)
+        let wrappedInput = DescribeHostReservationOfferingsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7576,7 +7592,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeHostReservationOfferingsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeHostReservationOfferingsRequest>(encodable: input)
+        let wrappedInput = DescribeHostReservationOfferingsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7606,7 +7622,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeHostReservationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeHostReservationsRequest>(encodable: input)
+        let wrappedInput = DescribeHostReservationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7636,7 +7652,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeHostReservationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeHostReservationsRequest>(encodable: input)
+        let wrappedInput = DescribeHostReservationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7666,7 +7682,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeHostsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeHostsRequest>(encodable: input)
+        let wrappedInput = DescribeHostsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7696,7 +7712,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeHostsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeHostsRequest>(encodable: input)
+        let wrappedInput = DescribeHostsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7726,7 +7742,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeIamInstanceProfileAssociationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeIamInstanceProfileAssociationsRequest>(encodable: input)
+        let wrappedInput = DescribeIamInstanceProfileAssociationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7756,7 +7772,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeIamInstanceProfileAssociationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeIamInstanceProfileAssociationsRequest>(encodable: input)
+        let wrappedInput = DescribeIamInstanceProfileAssociationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7786,7 +7802,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeIdFormatRequest>(encodable: input)
+        let wrappedInput = DescribeIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7816,7 +7832,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeIdFormatRequest>(encodable: input)
+        let wrappedInput = DescribeIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7846,7 +7862,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeIdentityIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeIdentityIdFormatRequest>(encodable: input)
+        let wrappedInput = DescribeIdentityIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7876,7 +7892,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeIdentityIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeIdentityIdFormatRequest>(encodable: input)
+        let wrappedInput = DescribeIdentityIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7906,7 +7922,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeImageAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7936,7 +7952,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeImageAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7966,7 +7982,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeImagesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeImagesRequest>(encodable: input)
+        let wrappedInput = DescribeImagesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -7996,7 +8012,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeImagesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeImagesRequest>(encodable: input)
+        let wrappedInput = DescribeImagesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8026,7 +8042,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeImportImageTasksOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeImportImageTasksRequest>(encodable: input)
+        let wrappedInput = DescribeImportImageTasksOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8056,7 +8072,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeImportImageTasksOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeImportImageTasksRequest>(encodable: input)
+        let wrappedInput = DescribeImportImageTasksOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8086,7 +8102,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeImportSnapshotTasksOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeImportSnapshotTasksRequest>(encodable: input)
+        let wrappedInput = DescribeImportSnapshotTasksOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8116,7 +8132,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeImportSnapshotTasksOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeImportSnapshotTasksRequest>(encodable: input)
+        let wrappedInput = DescribeImportSnapshotTasksOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8146,7 +8162,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeInstanceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeInstanceAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeInstanceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8176,7 +8192,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeInstanceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeInstanceAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeInstanceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8206,7 +8222,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeInstanceCreditSpecificationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeInstanceCreditSpecificationsRequest>(encodable: input)
+        let wrappedInput = DescribeInstanceCreditSpecificationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8236,7 +8252,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeInstanceCreditSpecificationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeInstanceCreditSpecificationsRequest>(encodable: input)
+        let wrappedInput = DescribeInstanceCreditSpecificationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8266,7 +8282,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeInstanceStatusOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeInstanceStatusRequest>(encodable: input)
+        let wrappedInput = DescribeInstanceStatusOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8296,7 +8312,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeInstanceStatusOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeInstanceStatusRequest>(encodable: input)
+        let wrappedInput = DescribeInstanceStatusOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8326,7 +8342,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8356,7 +8372,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8386,7 +8402,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeInternetGatewaysOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeInternetGatewaysRequest>(encodable: input)
+        let wrappedInput = DescribeInternetGatewaysOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8416,7 +8432,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeInternetGatewaysOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeInternetGatewaysRequest>(encodable: input)
+        let wrappedInput = DescribeInternetGatewaysOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8446,7 +8462,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeKeyPairsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeKeyPairsRequest>(encodable: input)
+        let wrappedInput = DescribeKeyPairsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8476,7 +8492,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeKeyPairsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeKeyPairsRequest>(encodable: input)
+        let wrappedInput = DescribeKeyPairsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8506,7 +8522,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeLaunchTemplateVersionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeLaunchTemplateVersionsRequest>(encodable: input)
+        let wrappedInput = DescribeLaunchTemplateVersionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8536,7 +8552,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeLaunchTemplateVersionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeLaunchTemplateVersionsRequest>(encodable: input)
+        let wrappedInput = DescribeLaunchTemplateVersionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8566,7 +8582,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeLaunchTemplatesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeLaunchTemplatesRequest>(encodable: input)
+        let wrappedInput = DescribeLaunchTemplatesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8596,7 +8612,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeLaunchTemplatesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeLaunchTemplatesRequest>(encodable: input)
+        let wrappedInput = DescribeLaunchTemplatesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8626,7 +8642,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeMovingAddressesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeMovingAddressesRequest>(encodable: input)
+        let wrappedInput = DescribeMovingAddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8656,7 +8672,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeMovingAddressesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeMovingAddressesRequest>(encodable: input)
+        let wrappedInput = DescribeMovingAddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8686,7 +8702,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeNatGatewaysOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeNatGatewaysRequest>(encodable: input)
+        let wrappedInput = DescribeNatGatewaysOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8716,7 +8732,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeNatGatewaysOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeNatGatewaysRequest>(encodable: input)
+        let wrappedInput = DescribeNatGatewaysOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8746,7 +8762,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeNetworkAclsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeNetworkAclsRequest>(encodable: input)
+        let wrappedInput = DescribeNetworkAclsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8776,7 +8792,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeNetworkAclsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeNetworkAclsRequest>(encodable: input)
+        let wrappedInput = DescribeNetworkAclsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8806,7 +8822,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeNetworkInterfaceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeNetworkInterfaceAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeNetworkInterfaceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8836,7 +8852,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeNetworkInterfaceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeNetworkInterfaceAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeNetworkInterfaceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8866,7 +8882,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeNetworkInterfacePermissionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeNetworkInterfacePermissionsRequest>(encodable: input)
+        let wrappedInput = DescribeNetworkInterfacePermissionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8896,7 +8912,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeNetworkInterfacePermissionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeNetworkInterfacePermissionsRequest>(encodable: input)
+        let wrappedInput = DescribeNetworkInterfacePermissionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8926,7 +8942,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeNetworkInterfacesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeNetworkInterfacesRequest>(encodable: input)
+        let wrappedInput = DescribeNetworkInterfacesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8956,7 +8972,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeNetworkInterfacesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeNetworkInterfacesRequest>(encodable: input)
+        let wrappedInput = DescribeNetworkInterfacesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -8986,7 +9002,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribePlacementGroupsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribePlacementGroupsRequest>(encodable: input)
+        let wrappedInput = DescribePlacementGroupsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9016,7 +9032,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribePlacementGroupsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribePlacementGroupsRequest>(encodable: input)
+        let wrappedInput = DescribePlacementGroupsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9046,7 +9062,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribePrefixListsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribePrefixListsRequest>(encodable: input)
+        let wrappedInput = DescribePrefixListsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9076,7 +9092,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribePrefixListsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribePrefixListsRequest>(encodable: input)
+        let wrappedInput = DescribePrefixListsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9106,7 +9122,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribePrincipalIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.DescribePrincipalIdFormatRequest>(encodable: input)
+        let wrappedInput = DescribePrincipalIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9136,7 +9152,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribePrincipalIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.DescribePrincipalIdFormatRequest>(encodable: input)
+        let wrappedInput = DescribePrincipalIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9166,7 +9182,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribePublicIpv4PoolsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribePublicIpv4PoolsRequest>(encodable: input)
+        let wrappedInput = DescribePublicIpv4PoolsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9196,7 +9212,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribePublicIpv4PoolsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribePublicIpv4PoolsRequest>(encodable: input)
+        let wrappedInput = DescribePublicIpv4PoolsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9226,7 +9242,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeRegionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeRegionsRequest>(encodable: input)
+        let wrappedInput = DescribeRegionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9256,7 +9272,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeRegionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeRegionsRequest>(encodable: input)
+        let wrappedInput = DescribeRegionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9286,7 +9302,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeReservedInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeReservedInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeReservedInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9316,7 +9332,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeReservedInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeReservedInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeReservedInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9346,7 +9362,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeReservedInstancesListingsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeReservedInstancesListingsRequest>(encodable: input)
+        let wrappedInput = DescribeReservedInstancesListingsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9376,7 +9392,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeReservedInstancesListingsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeReservedInstancesListingsRequest>(encodable: input)
+        let wrappedInput = DescribeReservedInstancesListingsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9406,7 +9422,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeReservedInstancesModificationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeReservedInstancesModificationsRequest>(encodable: input)
+        let wrappedInput = DescribeReservedInstancesModificationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9436,7 +9452,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeReservedInstancesModificationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeReservedInstancesModificationsRequest>(encodable: input)
+        let wrappedInput = DescribeReservedInstancesModificationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9466,7 +9482,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeReservedInstancesOfferingsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeReservedInstancesOfferingsRequest>(encodable: input)
+        let wrappedInput = DescribeReservedInstancesOfferingsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9496,7 +9512,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeReservedInstancesOfferingsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeReservedInstancesOfferingsRequest>(encodable: input)
+        let wrappedInput = DescribeReservedInstancesOfferingsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9526,7 +9542,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeRouteTablesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeRouteTablesRequest>(encodable: input)
+        let wrappedInput = DescribeRouteTablesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9556,7 +9572,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeRouteTablesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeRouteTablesRequest>(encodable: input)
+        let wrappedInput = DescribeRouteTablesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9586,7 +9602,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeScheduledInstanceAvailabilityOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeScheduledInstanceAvailabilityRequest>(encodable: input)
+        let wrappedInput = DescribeScheduledInstanceAvailabilityOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9616,7 +9632,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeScheduledInstanceAvailabilityOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeScheduledInstanceAvailabilityRequest>(encodable: input)
+        let wrappedInput = DescribeScheduledInstanceAvailabilityOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9646,7 +9662,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeScheduledInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeScheduledInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeScheduledInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9676,7 +9692,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeScheduledInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeScheduledInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeScheduledInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9706,7 +9722,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSecurityGroupReferencesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSecurityGroupReferencesRequest>(encodable: input)
+        let wrappedInput = DescribeSecurityGroupReferencesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9736,7 +9752,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSecurityGroupReferencesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSecurityGroupReferencesRequest>(encodable: input)
+        let wrappedInput = DescribeSecurityGroupReferencesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9766,7 +9782,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSecurityGroupsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSecurityGroupsRequest>(encodable: input)
+        let wrappedInput = DescribeSecurityGroupsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9796,7 +9812,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSecurityGroupsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSecurityGroupsRequest>(encodable: input)
+        let wrappedInput = DescribeSecurityGroupsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9826,7 +9842,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSnapshotAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSnapshotAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeSnapshotAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9856,7 +9872,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSnapshotAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSnapshotAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeSnapshotAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9886,7 +9902,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSnapshotsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSnapshotsRequest>(encodable: input)
+        let wrappedInput = DescribeSnapshotsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9916,7 +9932,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSnapshotsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSnapshotsRequest>(encodable: input)
+        let wrappedInput = DescribeSnapshotsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9946,7 +9962,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotDatafeedSubscriptionOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotDatafeedSubscriptionRequest>(encodable: input)
+        let wrappedInput = DescribeSpotDatafeedSubscriptionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -9976,7 +9992,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotDatafeedSubscriptionOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotDatafeedSubscriptionRequest>(encodable: input)
+        let wrappedInput = DescribeSpotDatafeedSubscriptionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10006,7 +10022,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotFleetInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotFleetInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeSpotFleetInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10036,7 +10052,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotFleetInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotFleetInstancesRequest>(encodable: input)
+        let wrappedInput = DescribeSpotFleetInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10066,7 +10082,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotFleetRequestHistoryOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotFleetRequestHistoryRequest>(encodable: input)
+        let wrappedInput = DescribeSpotFleetRequestHistoryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10096,7 +10112,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotFleetRequestHistoryOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotFleetRequestHistoryRequest>(encodable: input)
+        let wrappedInput = DescribeSpotFleetRequestHistoryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10126,7 +10142,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotFleetRequestsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotFleetRequestsRequest>(encodable: input)
+        let wrappedInput = DescribeSpotFleetRequestsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10156,7 +10172,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotFleetRequestsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotFleetRequestsRequest>(encodable: input)
+        let wrappedInput = DescribeSpotFleetRequestsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10186,7 +10202,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotInstanceRequestsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotInstanceRequestsRequest>(encodable: input)
+        let wrappedInput = DescribeSpotInstanceRequestsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10216,7 +10232,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotInstanceRequestsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotInstanceRequestsRequest>(encodable: input)
+        let wrappedInput = DescribeSpotInstanceRequestsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10246,7 +10262,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotPriceHistoryOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotPriceHistoryRequest>(encodable: input)
+        let wrappedInput = DescribeSpotPriceHistoryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10276,7 +10292,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSpotPriceHistoryOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSpotPriceHistoryRequest>(encodable: input)
+        let wrappedInput = DescribeSpotPriceHistoryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10306,7 +10322,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeStaleSecurityGroupsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeStaleSecurityGroupsRequest>(encodable: input)
+        let wrappedInput = DescribeStaleSecurityGroupsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10336,7 +10352,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeStaleSecurityGroupsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeStaleSecurityGroupsRequest>(encodable: input)
+        let wrappedInput = DescribeStaleSecurityGroupsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10366,7 +10382,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSubnetsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSubnetsRequest>(encodable: input)
+        let wrappedInput = DescribeSubnetsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10396,7 +10412,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeSubnetsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeSubnetsRequest>(encodable: input)
+        let wrappedInput = DescribeSubnetsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10426,7 +10442,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeTagsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeTagsRequest>(encodable: input)
+        let wrappedInput = DescribeTagsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10456,7 +10472,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeTagsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeTagsRequest>(encodable: input)
+        let wrappedInput = DescribeTagsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10486,7 +10502,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVolumeAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVolumeAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeVolumeAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10516,7 +10532,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVolumeAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVolumeAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeVolumeAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10546,7 +10562,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVolumeStatusOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVolumeStatusRequest>(encodable: input)
+        let wrappedInput = DescribeVolumeStatusOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10576,7 +10592,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVolumeStatusOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVolumeStatusRequest>(encodable: input)
+        let wrappedInput = DescribeVolumeStatusOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10606,7 +10622,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVolumesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVolumesRequest>(encodable: input)
+        let wrappedInput = DescribeVolumesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10636,7 +10652,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVolumesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVolumesRequest>(encodable: input)
+        let wrappedInput = DescribeVolumesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10666,7 +10682,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVolumesModificationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVolumesModificationsRequest>(encodable: input)
+        let wrappedInput = DescribeVolumesModificationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10696,7 +10712,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVolumesModificationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVolumesModificationsRequest>(encodable: input)
+        let wrappedInput = DescribeVolumesModificationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10726,7 +10742,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeVpcAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10756,7 +10772,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcAttributeRequest>(encodable: input)
+        let wrappedInput = DescribeVpcAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10786,7 +10802,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcClassicLinkOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcClassicLinkRequest>(encodable: input)
+        let wrappedInput = DescribeVpcClassicLinkOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10816,7 +10832,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcClassicLinkOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcClassicLinkRequest>(encodable: input)
+        let wrappedInput = DescribeVpcClassicLinkOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10846,7 +10862,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcClassicLinkDnsSupportOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcClassicLinkDnsSupportRequest>(encodable: input)
+        let wrappedInput = DescribeVpcClassicLinkDnsSupportOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10876,7 +10892,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcClassicLinkDnsSupportOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcClassicLinkDnsSupportRequest>(encodable: input)
+        let wrappedInput = DescribeVpcClassicLinkDnsSupportOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10906,7 +10922,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointConnectionNotificationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointConnectionNotificationsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointConnectionNotificationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10936,7 +10952,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointConnectionNotificationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointConnectionNotificationsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointConnectionNotificationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10966,7 +10982,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointConnectionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointConnectionsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointConnectionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -10996,7 +11012,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointConnectionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointConnectionsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointConnectionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11026,7 +11042,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointServiceConfigurationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointServiceConfigurationsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointServiceConfigurationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11056,7 +11072,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointServiceConfigurationsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointServiceConfigurationsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointServiceConfigurationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11086,7 +11102,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointServicePermissionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointServicePermissionsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointServicePermissionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11116,7 +11132,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointServicePermissionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointServicePermissionsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointServicePermissionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11146,7 +11162,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointServicesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointServicesRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointServicesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11176,7 +11192,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointServicesOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointServicesRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointServicesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11206,7 +11222,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11236,7 +11252,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcEndpointsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcEndpointsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcEndpointsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11266,7 +11282,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcPeeringConnectionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcPeeringConnectionsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcPeeringConnectionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11296,7 +11312,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcPeeringConnectionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcPeeringConnectionsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcPeeringConnectionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11326,7 +11342,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11356,7 +11372,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpcsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpcsRequest>(encodable: input)
+        let wrappedInput = DescribeVpcsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11386,7 +11402,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpnConnectionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpnConnectionsRequest>(encodable: input)
+        let wrappedInput = DescribeVpnConnectionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11416,7 +11432,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpnConnectionsOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpnConnectionsRequest>(encodable: input)
+        let wrappedInput = DescribeVpnConnectionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11446,7 +11462,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpnGatewaysOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpnGatewaysRequest>(encodable: input)
+        let wrappedInput = DescribeVpnGatewaysOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11476,7 +11492,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DescribeVpnGatewaysOperationHTTPRequestInput<ElasticComputeCloudModel.DescribeVpnGatewaysRequest>(encodable: input)
+        let wrappedInput = DescribeVpnGatewaysOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11506,7 +11522,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DetachClassicLinkVpcOperationHTTPRequestInput<ElasticComputeCloudModel.DetachClassicLinkVpcRequest>(encodable: input)
+        let wrappedInput = DetachClassicLinkVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11536,7 +11552,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DetachClassicLinkVpcOperationHTTPRequestInput<ElasticComputeCloudModel.DetachClassicLinkVpcRequest>(encodable: input)
+        let wrappedInput = DetachClassicLinkVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11558,14 +11574,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func detachInternetGatewayAsync(input: ElasticComputeCloudModel.DetachInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func detachInternetGatewayAsync(input: ElasticComputeCloudModel.DetachInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DetachInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DetachInternetGatewayRequest>(encodable: input)
+        let wrappedInput = DetachInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11593,7 +11609,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DetachInternetGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DetachInternetGatewayRequest>(encodable: input)
+        let wrappedInput = DetachInternetGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11615,14 +11631,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func detachNetworkInterfaceAsync(input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest, completion: @escaping (Error?) -> ()) throws {
+    public func detachNetworkInterfaceAsync(input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DetachNetworkInterfaceOperationHTTPRequestInput<ElasticComputeCloudModel.DetachNetworkInterfaceRequest>(encodable: input)
+        let wrappedInput = DetachNetworkInterfaceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11650,7 +11666,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DetachNetworkInterfaceOperationHTTPRequestInput<ElasticComputeCloudModel.DetachNetworkInterfaceRequest>(encodable: input)
+        let wrappedInput = DetachNetworkInterfaceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11680,7 +11696,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DetachVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.DetachVolumeRequest>(encodable: input)
+        let wrappedInput = DetachVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11710,7 +11726,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DetachVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.DetachVolumeRequest>(encodable: input)
+        let wrappedInput = DetachVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11732,14 +11748,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func detachVpnGatewayAsync(input: ElasticComputeCloudModel.DetachVpnGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func detachVpnGatewayAsync(input: ElasticComputeCloudModel.DetachVpnGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DetachVpnGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DetachVpnGatewayRequest>(encodable: input)
+        let wrappedInput = DetachVpnGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11767,7 +11783,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DetachVpnGatewayOperationHTTPRequestInput<ElasticComputeCloudModel.DetachVpnGatewayRequest>(encodable: input)
+        let wrappedInput = DetachVpnGatewayOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11789,14 +11805,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest, completion: @escaping (Error?) -> ()) throws {
+    public func disableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DisableVgwRoutePropagationOperationHTTPRequestInput<ElasticComputeCloudModel.DisableVgwRoutePropagationRequest>(encodable: input)
+        let wrappedInput = DisableVgwRoutePropagationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11824,7 +11840,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisableVgwRoutePropagationOperationHTTPRequestInput<ElasticComputeCloudModel.DisableVgwRoutePropagationRequest>(encodable: input)
+        let wrappedInput = DisableVgwRoutePropagationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11854,7 +11870,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisableVpcClassicLinkOperationHTTPRequestInput<ElasticComputeCloudModel.DisableVpcClassicLinkRequest>(encodable: input)
+        let wrappedInput = DisableVpcClassicLinkOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11884,7 +11900,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisableVpcClassicLinkOperationHTTPRequestInput<ElasticComputeCloudModel.DisableVpcClassicLinkRequest>(encodable: input)
+        let wrappedInput = DisableVpcClassicLinkOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11914,7 +11930,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisableVpcClassicLinkDnsSupportOperationHTTPRequestInput<ElasticComputeCloudModel.DisableVpcClassicLinkDnsSupportRequest>(encodable: input)
+        let wrappedInput = DisableVpcClassicLinkDnsSupportOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11944,7 +11960,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisableVpcClassicLinkDnsSupportOperationHTTPRequestInput<ElasticComputeCloudModel.DisableVpcClassicLinkDnsSupportRequest>(encodable: input)
+        let wrappedInput = DisableVpcClassicLinkDnsSupportOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -11966,14 +11982,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disassociateAddressAsync(input: ElasticComputeCloudModel.DisassociateAddressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func disassociateAddressAsync(input: ElasticComputeCloudModel.DisassociateAddressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DisassociateAddressOperationHTTPRequestInput<ElasticComputeCloudModel.DisassociateAddressRequest>(encodable: input)
+        let wrappedInput = DisassociateAddressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12001,7 +12017,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisassociateAddressOperationHTTPRequestInput<ElasticComputeCloudModel.DisassociateAddressRequest>(encodable: input)
+        let wrappedInput = DisassociateAddressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12031,7 +12047,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisassociateIamInstanceProfileOperationHTTPRequestInput<ElasticComputeCloudModel.DisassociateIamInstanceProfileRequest>(encodable: input)
+        let wrappedInput = DisassociateIamInstanceProfileOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12061,7 +12077,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisassociateIamInstanceProfileOperationHTTPRequestInput<ElasticComputeCloudModel.DisassociateIamInstanceProfileRequest>(encodable: input)
+        let wrappedInput = DisassociateIamInstanceProfileOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12083,14 +12099,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disassociateRouteTableAsync(input: ElasticComputeCloudModel.DisassociateRouteTableRequest, completion: @escaping (Error?) -> ()) throws {
+    public func disassociateRouteTableAsync(input: ElasticComputeCloudModel.DisassociateRouteTableRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DisassociateRouteTableOperationHTTPRequestInput<ElasticComputeCloudModel.DisassociateRouteTableRequest>(encodable: input)
+        let wrappedInput = DisassociateRouteTableOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12118,7 +12134,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisassociateRouteTableOperationHTTPRequestInput<ElasticComputeCloudModel.DisassociateRouteTableRequest>(encodable: input)
+        let wrappedInput = DisassociateRouteTableOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12148,7 +12164,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisassociateSubnetCidrBlockOperationHTTPRequestInput<ElasticComputeCloudModel.DisassociateSubnetCidrBlockRequest>(encodable: input)
+        let wrappedInput = DisassociateSubnetCidrBlockOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12178,7 +12194,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisassociateSubnetCidrBlockOperationHTTPRequestInput<ElasticComputeCloudModel.DisassociateSubnetCidrBlockRequest>(encodable: input)
+        let wrappedInput = DisassociateSubnetCidrBlockOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12208,7 +12224,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisassociateVpcCidrBlockOperationHTTPRequestInput<ElasticComputeCloudModel.DisassociateVpcCidrBlockRequest>(encodable: input)
+        let wrappedInput = DisassociateVpcCidrBlockOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12238,7 +12254,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DisassociateVpcCidrBlockOperationHTTPRequestInput<ElasticComputeCloudModel.DisassociateVpcCidrBlockRequest>(encodable: input)
+        let wrappedInput = DisassociateVpcCidrBlockOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12260,14 +12276,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func enableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest, completion: @escaping (Error?) -> ()) throws {
+    public func enableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = EnableVgwRoutePropagationOperationHTTPRequestInput<ElasticComputeCloudModel.EnableVgwRoutePropagationRequest>(encodable: input)
+        let wrappedInput = EnableVgwRoutePropagationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12295,7 +12311,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = EnableVgwRoutePropagationOperationHTTPRequestInput<ElasticComputeCloudModel.EnableVgwRoutePropagationRequest>(encodable: input)
+        let wrappedInput = EnableVgwRoutePropagationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12317,14 +12333,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func enableVolumeIOAsync(input: ElasticComputeCloudModel.EnableVolumeIORequest, completion: @escaping (Error?) -> ()) throws {
+    public func enableVolumeIOAsync(input: ElasticComputeCloudModel.EnableVolumeIORequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = EnableVolumeIOOperationHTTPRequestInput<ElasticComputeCloudModel.EnableVolumeIORequest>(encodable: input)
+        let wrappedInput = EnableVolumeIOOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12352,7 +12368,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = EnableVolumeIOOperationHTTPRequestInput<ElasticComputeCloudModel.EnableVolumeIORequest>(encodable: input)
+        let wrappedInput = EnableVolumeIOOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12382,7 +12398,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = EnableVpcClassicLinkOperationHTTPRequestInput<ElasticComputeCloudModel.EnableVpcClassicLinkRequest>(encodable: input)
+        let wrappedInput = EnableVpcClassicLinkOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12412,7 +12428,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = EnableVpcClassicLinkOperationHTTPRequestInput<ElasticComputeCloudModel.EnableVpcClassicLinkRequest>(encodable: input)
+        let wrappedInput = EnableVpcClassicLinkOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12442,7 +12458,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = EnableVpcClassicLinkDnsSupportOperationHTTPRequestInput<ElasticComputeCloudModel.EnableVpcClassicLinkDnsSupportRequest>(encodable: input)
+        let wrappedInput = EnableVpcClassicLinkDnsSupportOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12472,7 +12488,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = EnableVpcClassicLinkDnsSupportOperationHTTPRequestInput<ElasticComputeCloudModel.EnableVpcClassicLinkDnsSupportRequest>(encodable: input)
+        let wrappedInput = EnableVpcClassicLinkDnsSupportOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12502,7 +12518,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetConsoleOutputOperationHTTPRequestInput<ElasticComputeCloudModel.GetConsoleOutputRequest>(encodable: input)
+        let wrappedInput = GetConsoleOutputOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12532,7 +12548,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetConsoleOutputOperationHTTPRequestInput<ElasticComputeCloudModel.GetConsoleOutputRequest>(encodable: input)
+        let wrappedInput = GetConsoleOutputOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12562,7 +12578,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetConsoleScreenshotOperationHTTPRequestInput<ElasticComputeCloudModel.GetConsoleScreenshotRequest>(encodable: input)
+        let wrappedInput = GetConsoleScreenshotOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12592,7 +12608,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetConsoleScreenshotOperationHTTPRequestInput<ElasticComputeCloudModel.GetConsoleScreenshotRequest>(encodable: input)
+        let wrappedInput = GetConsoleScreenshotOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12622,7 +12638,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetHostReservationPurchasePreviewOperationHTTPRequestInput<ElasticComputeCloudModel.GetHostReservationPurchasePreviewRequest>(encodable: input)
+        let wrappedInput = GetHostReservationPurchasePreviewOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12652,7 +12668,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetHostReservationPurchasePreviewOperationHTTPRequestInput<ElasticComputeCloudModel.GetHostReservationPurchasePreviewRequest>(encodable: input)
+        let wrappedInput = GetHostReservationPurchasePreviewOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12682,7 +12698,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetLaunchTemplateDataOperationHTTPRequestInput<ElasticComputeCloudModel.GetLaunchTemplateDataRequest>(encodable: input)
+        let wrappedInput = GetLaunchTemplateDataOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12712,7 +12728,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetLaunchTemplateDataOperationHTTPRequestInput<ElasticComputeCloudModel.GetLaunchTemplateDataRequest>(encodable: input)
+        let wrappedInput = GetLaunchTemplateDataOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12742,7 +12758,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetPasswordDataOperationHTTPRequestInput<ElasticComputeCloudModel.GetPasswordDataRequest>(encodable: input)
+        let wrappedInput = GetPasswordDataOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12772,7 +12788,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetPasswordDataOperationHTTPRequestInput<ElasticComputeCloudModel.GetPasswordDataRequest>(encodable: input)
+        let wrappedInput = GetPasswordDataOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12802,7 +12818,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetReservedInstancesExchangeQuoteOperationHTTPRequestInput<ElasticComputeCloudModel.GetReservedInstancesExchangeQuoteRequest>(encodable: input)
+        let wrappedInput = GetReservedInstancesExchangeQuoteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12832,7 +12848,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetReservedInstancesExchangeQuoteOperationHTTPRequestInput<ElasticComputeCloudModel.GetReservedInstancesExchangeQuoteRequest>(encodable: input)
+        let wrappedInput = GetReservedInstancesExchangeQuoteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12862,7 +12878,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ImportImageOperationHTTPRequestInput<ElasticComputeCloudModel.ImportImageRequest>(encodable: input)
+        let wrappedInput = ImportImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12892,7 +12908,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ImportImageOperationHTTPRequestInput<ElasticComputeCloudModel.ImportImageRequest>(encodable: input)
+        let wrappedInput = ImportImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12922,7 +12938,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ImportInstanceOperationHTTPRequestInput<ElasticComputeCloudModel.ImportInstanceRequest>(encodable: input)
+        let wrappedInput = ImportInstanceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12952,7 +12968,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ImportInstanceOperationHTTPRequestInput<ElasticComputeCloudModel.ImportInstanceRequest>(encodable: input)
+        let wrappedInput = ImportInstanceOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -12982,7 +12998,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ImportKeyPairOperationHTTPRequestInput<ElasticComputeCloudModel.ImportKeyPairRequest>(encodable: input)
+        let wrappedInput = ImportKeyPairOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13012,7 +13028,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ImportKeyPairOperationHTTPRequestInput<ElasticComputeCloudModel.ImportKeyPairRequest>(encodable: input)
+        let wrappedInput = ImportKeyPairOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13042,7 +13058,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ImportSnapshotOperationHTTPRequestInput<ElasticComputeCloudModel.ImportSnapshotRequest>(encodable: input)
+        let wrappedInput = ImportSnapshotOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13072,7 +13088,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ImportSnapshotOperationHTTPRequestInput<ElasticComputeCloudModel.ImportSnapshotRequest>(encodable: input)
+        let wrappedInput = ImportSnapshotOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13102,7 +13118,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ImportVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.ImportVolumeRequest>(encodable: input)
+        let wrappedInput = ImportVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13132,7 +13148,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ImportVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.ImportVolumeRequest>(encodable: input)
+        let wrappedInput = ImportVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13162,7 +13178,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyCapacityReservationOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyCapacityReservationRequest>(encodable: input)
+        let wrappedInput = ModifyCapacityReservationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13192,7 +13208,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyCapacityReservationOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyCapacityReservationRequest>(encodable: input)
+        let wrappedInput = ModifyCapacityReservationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13222,7 +13238,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyFleetOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyFleetRequest>(encodable: input)
+        let wrappedInput = ModifyFleetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13252,7 +13268,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyFleetOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyFleetRequest>(encodable: input)
+        let wrappedInput = ModifyFleetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13282,7 +13298,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyFpgaImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyFpgaImageAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyFpgaImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13312,7 +13328,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyFpgaImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyFpgaImageAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyFpgaImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13342,7 +13358,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyHostsOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyHostsRequest>(encodable: input)
+        let wrappedInput = ModifyHostsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13372,7 +13388,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyHostsOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyHostsRequest>(encodable: input)
+        let wrappedInput = ModifyHostsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13394,14 +13410,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdFormatRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdFormatRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyIdFormatRequest>(encodable: input)
+        let wrappedInput = ModifyIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13429,7 +13445,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyIdFormatRequest>(encodable: input)
+        let wrappedInput = ModifyIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13451,14 +13467,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyIdentityIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyIdentityIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyIdentityIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyIdentityIdFormatRequest>(encodable: input)
+        let wrappedInput = ModifyIdentityIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13486,7 +13502,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyIdentityIdFormatOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyIdentityIdFormatRequest>(encodable: input)
+        let wrappedInput = ModifyIdentityIdFormatOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13508,14 +13524,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyImageAttributeAsync(input: ElasticComputeCloudModel.ModifyImageAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyImageAttributeAsync(input: ElasticComputeCloudModel.ModifyImageAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyImageAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13543,7 +13559,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyImageAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13565,14 +13581,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyInstanceAttributeAsync(input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyInstanceAttributeAsync(input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyInstanceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyInstanceAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyInstanceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13600,7 +13616,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyInstanceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyInstanceAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyInstanceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13630,7 +13646,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyInstanceCapacityReservationAttributesOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyInstanceCapacityReservationAttributesRequest>(encodable: input)
+        let wrappedInput = ModifyInstanceCapacityReservationAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13660,7 +13676,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyInstanceCapacityReservationAttributesOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyInstanceCapacityReservationAttributesRequest>(encodable: input)
+        let wrappedInput = ModifyInstanceCapacityReservationAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13690,7 +13706,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyInstanceCreditSpecificationOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyInstanceCreditSpecificationRequest>(encodable: input)
+        let wrappedInput = ModifyInstanceCreditSpecificationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13720,7 +13736,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyInstanceCreditSpecificationOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyInstanceCreditSpecificationRequest>(encodable: input)
+        let wrappedInput = ModifyInstanceCreditSpecificationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13750,7 +13766,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyInstancePlacementOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyInstancePlacementRequest>(encodable: input)
+        let wrappedInput = ModifyInstancePlacementOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13780,7 +13796,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyInstancePlacementOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyInstancePlacementRequest>(encodable: input)
+        let wrappedInput = ModifyInstancePlacementOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13810,7 +13826,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyLaunchTemplateOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyLaunchTemplateRequest>(encodable: input)
+        let wrappedInput = ModifyLaunchTemplateOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13840,7 +13856,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyLaunchTemplateOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyLaunchTemplateRequest>(encodable: input)
+        let wrappedInput = ModifyLaunchTemplateOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13862,14 +13878,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyNetworkInterfaceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyNetworkInterfaceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13897,7 +13913,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyNetworkInterfaceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyNetworkInterfaceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13927,7 +13943,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyReservedInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyReservedInstancesRequest>(encodable: input)
+        let wrappedInput = ModifyReservedInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13957,7 +13973,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyReservedInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyReservedInstancesRequest>(encodable: input)
+        let wrappedInput = ModifyReservedInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -13979,14 +13995,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifySnapshotAttributeAsync(input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifySnapshotAttributeAsync(input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifySnapshotAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifySnapshotAttributeRequest>(encodable: input)
+        let wrappedInput = ModifySnapshotAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14014,7 +14030,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifySnapshotAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifySnapshotAttributeRequest>(encodable: input)
+        let wrappedInput = ModifySnapshotAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14044,7 +14060,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifySpotFleetRequestOperationHTTPRequestInput<ElasticComputeCloudModel.ModifySpotFleetRequestRequest>(encodable: input)
+        let wrappedInput = ModifySpotFleetRequestOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14074,7 +14090,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifySpotFleetRequestOperationHTTPRequestInput<ElasticComputeCloudModel.ModifySpotFleetRequestRequest>(encodable: input)
+        let wrappedInput = ModifySpotFleetRequestOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14096,14 +14112,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifySubnetAttributeAsync(input: ElasticComputeCloudModel.ModifySubnetAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifySubnetAttributeAsync(input: ElasticComputeCloudModel.ModifySubnetAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifySubnetAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifySubnetAttributeRequest>(encodable: input)
+        let wrappedInput = ModifySubnetAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14131,7 +14147,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifySubnetAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifySubnetAttributeRequest>(encodable: input)
+        let wrappedInput = ModifySubnetAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14161,7 +14177,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVolumeRequest>(encodable: input)
+        let wrappedInput = ModifyVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14191,7 +14207,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVolumeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVolumeRequest>(encodable: input)
+        let wrappedInput = ModifyVolumeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14213,14 +14229,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyVolumeAttributeAsync(input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyVolumeAttributeAsync(input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVolumeAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVolumeAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyVolumeAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14248,7 +14264,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVolumeAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVolumeAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyVolumeAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14270,14 +14286,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyVpcAttributeAsync(input: ElasticComputeCloudModel.ModifyVpcAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyVpcAttributeAsync(input: ElasticComputeCloudModel.ModifyVpcAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyVpcAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14305,7 +14321,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcAttributeRequest>(encodable: input)
+        let wrappedInput = ModifyVpcAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14335,7 +14351,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcEndpointOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcEndpointRequest>(encodable: input)
+        let wrappedInput = ModifyVpcEndpointOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14365,7 +14381,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcEndpointOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcEndpointRequest>(encodable: input)
+        let wrappedInput = ModifyVpcEndpointOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14395,7 +14411,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcEndpointConnectionNotificationOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcEndpointConnectionNotificationRequest>(encodable: input)
+        let wrappedInput = ModifyVpcEndpointConnectionNotificationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14425,7 +14441,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcEndpointConnectionNotificationOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcEndpointConnectionNotificationRequest>(encodable: input)
+        let wrappedInput = ModifyVpcEndpointConnectionNotificationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14455,7 +14471,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcEndpointServiceConfigurationOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcEndpointServiceConfigurationRequest>(encodable: input)
+        let wrappedInput = ModifyVpcEndpointServiceConfigurationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14485,7 +14501,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcEndpointServiceConfigurationOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcEndpointServiceConfigurationRequest>(encodable: input)
+        let wrappedInput = ModifyVpcEndpointServiceConfigurationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14515,7 +14531,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcEndpointServicePermissionsOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcEndpointServicePermissionsRequest>(encodable: input)
+        let wrappedInput = ModifyVpcEndpointServicePermissionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14545,7 +14561,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcEndpointServicePermissionsOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcEndpointServicePermissionsRequest>(encodable: input)
+        let wrappedInput = ModifyVpcEndpointServicePermissionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14575,7 +14591,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcPeeringConnectionOptionsOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcPeeringConnectionOptionsRequest>(encodable: input)
+        let wrappedInput = ModifyVpcPeeringConnectionOptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14605,7 +14621,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcPeeringConnectionOptionsOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcPeeringConnectionOptionsRequest>(encodable: input)
+        let wrappedInput = ModifyVpcPeeringConnectionOptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14635,7 +14651,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcTenancyOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcTenancyRequest>(encodable: input)
+        let wrappedInput = ModifyVpcTenancyOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14665,7 +14681,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ModifyVpcTenancyOperationHTTPRequestInput<ElasticComputeCloudModel.ModifyVpcTenancyRequest>(encodable: input)
+        let wrappedInput = ModifyVpcTenancyOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14695,7 +14711,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = MonitorInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.MonitorInstancesRequest>(encodable: input)
+        let wrappedInput = MonitorInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14725,7 +14741,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = MonitorInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.MonitorInstancesRequest>(encodable: input)
+        let wrappedInput = MonitorInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14755,7 +14771,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = MoveAddressToVpcOperationHTTPRequestInput<ElasticComputeCloudModel.MoveAddressToVpcRequest>(encodable: input)
+        let wrappedInput = MoveAddressToVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14785,7 +14801,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = MoveAddressToVpcOperationHTTPRequestInput<ElasticComputeCloudModel.MoveAddressToVpcRequest>(encodable: input)
+        let wrappedInput = MoveAddressToVpcOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14815,7 +14831,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ProvisionByoipCidrOperationHTTPRequestInput<ElasticComputeCloudModel.ProvisionByoipCidrRequest>(encodable: input)
+        let wrappedInput = ProvisionByoipCidrOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14845,7 +14861,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ProvisionByoipCidrOperationHTTPRequestInput<ElasticComputeCloudModel.ProvisionByoipCidrRequest>(encodable: input)
+        let wrappedInput = ProvisionByoipCidrOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14875,7 +14891,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PurchaseHostReservationOperationHTTPRequestInput<ElasticComputeCloudModel.PurchaseHostReservationRequest>(encodable: input)
+        let wrappedInput = PurchaseHostReservationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14905,7 +14921,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PurchaseHostReservationOperationHTTPRequestInput<ElasticComputeCloudModel.PurchaseHostReservationRequest>(encodable: input)
+        let wrappedInput = PurchaseHostReservationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14935,7 +14951,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PurchaseReservedInstancesOfferingOperationHTTPRequestInput<ElasticComputeCloudModel.PurchaseReservedInstancesOfferingRequest>(encodable: input)
+        let wrappedInput = PurchaseReservedInstancesOfferingOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14965,7 +14981,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PurchaseReservedInstancesOfferingOperationHTTPRequestInput<ElasticComputeCloudModel.PurchaseReservedInstancesOfferingRequest>(encodable: input)
+        let wrappedInput = PurchaseReservedInstancesOfferingOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -14995,7 +15011,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PurchaseScheduledInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.PurchaseScheduledInstancesRequest>(encodable: input)
+        let wrappedInput = PurchaseScheduledInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15025,7 +15041,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PurchaseScheduledInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.PurchaseScheduledInstancesRequest>(encodable: input)
+        let wrappedInput = PurchaseScheduledInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15047,14 +15063,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func rebootInstancesAsync(input: ElasticComputeCloudModel.RebootInstancesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func rebootInstancesAsync(input: ElasticComputeCloudModel.RebootInstancesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = RebootInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.RebootInstancesRequest>(encodable: input)
+        let wrappedInput = RebootInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15082,7 +15098,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RebootInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.RebootInstancesRequest>(encodable: input)
+        let wrappedInput = RebootInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15112,7 +15128,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RegisterImageOperationHTTPRequestInput<ElasticComputeCloudModel.RegisterImageRequest>(encodable: input)
+        let wrappedInput = RegisterImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15142,7 +15158,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RegisterImageOperationHTTPRequestInput<ElasticComputeCloudModel.RegisterImageRequest>(encodable: input)
+        let wrappedInput = RegisterImageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15172,7 +15188,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RejectVpcEndpointConnectionsOperationHTTPRequestInput<ElasticComputeCloudModel.RejectVpcEndpointConnectionsRequest>(encodable: input)
+        let wrappedInput = RejectVpcEndpointConnectionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15202,7 +15218,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RejectVpcEndpointConnectionsOperationHTTPRequestInput<ElasticComputeCloudModel.RejectVpcEndpointConnectionsRequest>(encodable: input)
+        let wrappedInput = RejectVpcEndpointConnectionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15232,7 +15248,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RejectVpcPeeringConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.RejectVpcPeeringConnectionRequest>(encodable: input)
+        let wrappedInput = RejectVpcPeeringConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15262,7 +15278,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RejectVpcPeeringConnectionOperationHTTPRequestInput<ElasticComputeCloudModel.RejectVpcPeeringConnectionRequest>(encodable: input)
+        let wrappedInput = RejectVpcPeeringConnectionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15284,14 +15300,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func releaseAddressAsync(input: ElasticComputeCloudModel.ReleaseAddressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func releaseAddressAsync(input: ElasticComputeCloudModel.ReleaseAddressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ReleaseAddressOperationHTTPRequestInput<ElasticComputeCloudModel.ReleaseAddressRequest>(encodable: input)
+        let wrappedInput = ReleaseAddressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15319,7 +15335,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReleaseAddressOperationHTTPRequestInput<ElasticComputeCloudModel.ReleaseAddressRequest>(encodable: input)
+        let wrappedInput = ReleaseAddressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15349,7 +15365,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReleaseHostsOperationHTTPRequestInput<ElasticComputeCloudModel.ReleaseHostsRequest>(encodable: input)
+        let wrappedInput = ReleaseHostsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15379,7 +15395,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReleaseHostsOperationHTTPRequestInput<ElasticComputeCloudModel.ReleaseHostsRequest>(encodable: input)
+        let wrappedInput = ReleaseHostsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15409,7 +15425,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReplaceIamInstanceProfileAssociationOperationHTTPRequestInput<ElasticComputeCloudModel.ReplaceIamInstanceProfileAssociationRequest>(encodable: input)
+        let wrappedInput = ReplaceIamInstanceProfileAssociationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15439,7 +15455,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReplaceIamInstanceProfileAssociationOperationHTTPRequestInput<ElasticComputeCloudModel.ReplaceIamInstanceProfileAssociationRequest>(encodable: input)
+        let wrappedInput = ReplaceIamInstanceProfileAssociationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15469,7 +15485,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReplaceNetworkAclAssociationOperationHTTPRequestInput<ElasticComputeCloudModel.ReplaceNetworkAclAssociationRequest>(encodable: input)
+        let wrappedInput = ReplaceNetworkAclAssociationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15499,7 +15515,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReplaceNetworkAclAssociationOperationHTTPRequestInput<ElasticComputeCloudModel.ReplaceNetworkAclAssociationRequest>(encodable: input)
+        let wrappedInput = ReplaceNetworkAclAssociationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15521,14 +15537,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func replaceNetworkAclEntryAsync(input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws {
+    public func replaceNetworkAclEntryAsync(input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ReplaceNetworkAclEntryOperationHTTPRequestInput<ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest>(encodable: input)
+        let wrappedInput = ReplaceNetworkAclEntryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15556,7 +15572,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReplaceNetworkAclEntryOperationHTTPRequestInput<ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest>(encodable: input)
+        let wrappedInput = ReplaceNetworkAclEntryOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15578,14 +15594,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func replaceRouteAsync(input: ElasticComputeCloudModel.ReplaceRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func replaceRouteAsync(input: ElasticComputeCloudModel.ReplaceRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ReplaceRouteOperationHTTPRequestInput<ElasticComputeCloudModel.ReplaceRouteRequest>(encodable: input)
+        let wrappedInput = ReplaceRouteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15613,7 +15629,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReplaceRouteOperationHTTPRequestInput<ElasticComputeCloudModel.ReplaceRouteRequest>(encodable: input)
+        let wrappedInput = ReplaceRouteOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15643,7 +15659,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReplaceRouteTableAssociationOperationHTTPRequestInput<ElasticComputeCloudModel.ReplaceRouteTableAssociationRequest>(encodable: input)
+        let wrappedInput = ReplaceRouteTableAssociationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15673,7 +15689,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReplaceRouteTableAssociationOperationHTTPRequestInput<ElasticComputeCloudModel.ReplaceRouteTableAssociationRequest>(encodable: input)
+        let wrappedInput = ReplaceRouteTableAssociationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15695,14 +15711,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func reportInstanceStatusAsync(input: ElasticComputeCloudModel.ReportInstanceStatusRequest, completion: @escaping (Error?) -> ()) throws {
+    public func reportInstanceStatusAsync(input: ElasticComputeCloudModel.ReportInstanceStatusRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ReportInstanceStatusOperationHTTPRequestInput<ElasticComputeCloudModel.ReportInstanceStatusRequest>(encodable: input)
+        let wrappedInput = ReportInstanceStatusOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15730,7 +15746,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReportInstanceStatusOperationHTTPRequestInput<ElasticComputeCloudModel.ReportInstanceStatusRequest>(encodable: input)
+        let wrappedInput = ReportInstanceStatusOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15760,7 +15776,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RequestSpotFleetOperationHTTPRequestInput<ElasticComputeCloudModel.RequestSpotFleetRequest>(encodable: input)
+        let wrappedInput = RequestSpotFleetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15790,7 +15806,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RequestSpotFleetOperationHTTPRequestInput<ElasticComputeCloudModel.RequestSpotFleetRequest>(encodable: input)
+        let wrappedInput = RequestSpotFleetOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15820,7 +15836,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RequestSpotInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.RequestSpotInstancesRequest>(encodable: input)
+        let wrappedInput = RequestSpotInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15850,7 +15866,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RequestSpotInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.RequestSpotInstancesRequest>(encodable: input)
+        let wrappedInput = RequestSpotInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15880,7 +15896,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ResetFpgaImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ResetFpgaImageAttributeRequest>(encodable: input)
+        let wrappedInput = ResetFpgaImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15910,7 +15926,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ResetFpgaImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ResetFpgaImageAttributeRequest>(encodable: input)
+        let wrappedInput = ResetFpgaImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15932,14 +15948,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetImageAttributeAsync(input: ElasticComputeCloudModel.ResetImageAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetImageAttributeAsync(input: ElasticComputeCloudModel.ResetImageAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ResetImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ResetImageAttributeRequest>(encodable: input)
+        let wrappedInput = ResetImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15967,7 +15983,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ResetImageAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ResetImageAttributeRequest>(encodable: input)
+        let wrappedInput = ResetImageAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -15989,14 +16005,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetInstanceAttributeAsync(input: ElasticComputeCloudModel.ResetInstanceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetInstanceAttributeAsync(input: ElasticComputeCloudModel.ResetInstanceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ResetInstanceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ResetInstanceAttributeRequest>(encodable: input)
+        let wrappedInput = ResetInstanceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16024,7 +16040,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ResetInstanceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ResetInstanceAttributeRequest>(encodable: input)
+        let wrappedInput = ResetInstanceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16046,14 +16062,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ResetNetworkInterfaceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest>(encodable: input)
+        let wrappedInput = ResetNetworkInterfaceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16081,7 +16097,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ResetNetworkInterfaceAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest>(encodable: input)
+        let wrappedInput = ResetNetworkInterfaceAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16103,14 +16119,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetSnapshotAttributeAsync(input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetSnapshotAttributeAsync(input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ResetSnapshotAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ResetSnapshotAttributeRequest>(encodable: input)
+        let wrappedInput = ResetSnapshotAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16138,7 +16154,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ResetSnapshotAttributeOperationHTTPRequestInput<ElasticComputeCloudModel.ResetSnapshotAttributeRequest>(encodable: input)
+        let wrappedInput = ResetSnapshotAttributeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16168,7 +16184,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RestoreAddressToClassicOperationHTTPRequestInput<ElasticComputeCloudModel.RestoreAddressToClassicRequest>(encodable: input)
+        let wrappedInput = RestoreAddressToClassicOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16198,7 +16214,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RestoreAddressToClassicOperationHTTPRequestInput<ElasticComputeCloudModel.RestoreAddressToClassicRequest>(encodable: input)
+        let wrappedInput = RestoreAddressToClassicOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16220,14 +16236,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func revokeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func revokeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = RevokeSecurityGroupEgressOperationHTTPRequestInput<ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest>(encodable: input)
+        let wrappedInput = RevokeSecurityGroupEgressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16255,7 +16271,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RevokeSecurityGroupEgressOperationHTTPRequestInput<ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest>(encodable: input)
+        let wrappedInput = RevokeSecurityGroupEgressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16277,14 +16293,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func revokeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func revokeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = RevokeSecurityGroupIngressOperationHTTPRequestInput<ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest>(encodable: input)
+        let wrappedInput = RevokeSecurityGroupIngressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16312,7 +16328,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RevokeSecurityGroupIngressOperationHTTPRequestInput<ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest>(encodable: input)
+        let wrappedInput = RevokeSecurityGroupIngressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16342,7 +16358,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RunInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.RunInstancesRequest>(encodable: input)
+        let wrappedInput = RunInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16372,7 +16388,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RunInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.RunInstancesRequest>(encodable: input)
+        let wrappedInput = RunInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16402,7 +16418,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RunScheduledInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.RunScheduledInstancesRequest>(encodable: input)
+        let wrappedInput = RunScheduledInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16432,7 +16448,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RunScheduledInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.RunScheduledInstancesRequest>(encodable: input)
+        let wrappedInput = RunScheduledInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16462,7 +16478,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = StartInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.StartInstancesRequest>(encodable: input)
+        let wrappedInput = StartInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16492,7 +16508,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = StartInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.StartInstancesRequest>(encodable: input)
+        let wrappedInput = StartInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16522,7 +16538,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = StopInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.StopInstancesRequest>(encodable: input)
+        let wrappedInput = StopInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16552,7 +16568,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = StopInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.StopInstancesRequest>(encodable: input)
+        let wrappedInput = StopInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16582,7 +16598,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = TerminateInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.TerminateInstancesRequest>(encodable: input)
+        let wrappedInput = TerminateInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16612,7 +16628,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = TerminateInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.TerminateInstancesRequest>(encodable: input)
+        let wrappedInput = TerminateInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16642,7 +16658,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UnassignIpv6AddressesOperationHTTPRequestInput<ElasticComputeCloudModel.UnassignIpv6AddressesRequest>(encodable: input)
+        let wrappedInput = UnassignIpv6AddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16672,7 +16688,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UnassignIpv6AddressesOperationHTTPRequestInput<ElasticComputeCloudModel.UnassignIpv6AddressesRequest>(encodable: input)
+        let wrappedInput = UnassignIpv6AddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16694,14 +16710,14 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func unassignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func unassignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = UnassignPrivateIpAddressesOperationHTTPRequestInput<ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest>(encodable: input)
+        let wrappedInput = UnassignPrivateIpAddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16729,7 +16745,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UnassignPrivateIpAddressesOperationHTTPRequestInput<ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest>(encodable: input)
+        let wrappedInput = UnassignPrivateIpAddressesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16759,7 +16775,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UnmonitorInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.UnmonitorInstancesRequest>(encodable: input)
+        let wrappedInput = UnmonitorInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16789,7 +16805,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UnmonitorInstancesOperationHTTPRequestInput<ElasticComputeCloudModel.UnmonitorInstancesRequest>(encodable: input)
+        let wrappedInput = UnmonitorInstancesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16819,7 +16835,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UpdateSecurityGroupRuleDescriptionsEgressOperationHTTPRequestInput<ElasticComputeCloudModel.UpdateSecurityGroupRuleDescriptionsEgressRequest>(encodable: input)
+        let wrappedInput = UpdateSecurityGroupRuleDescriptionsEgressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16849,7 +16865,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UpdateSecurityGroupRuleDescriptionsEgressOperationHTTPRequestInput<ElasticComputeCloudModel.UpdateSecurityGroupRuleDescriptionsEgressRequest>(encodable: input)
+        let wrappedInput = UpdateSecurityGroupRuleDescriptionsEgressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16879,7 +16895,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UpdateSecurityGroupRuleDescriptionsIngressOperationHTTPRequestInput<ElasticComputeCloudModel.UpdateSecurityGroupRuleDescriptionsIngressRequest>(encodable: input)
+        let wrappedInput = UpdateSecurityGroupRuleDescriptionsIngressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16909,7 +16925,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UpdateSecurityGroupRuleDescriptionsIngressOperationHTTPRequestInput<ElasticComputeCloudModel.UpdateSecurityGroupRuleDescriptionsIngressRequest>(encodable: input)
+        let wrappedInput = UpdateSecurityGroupRuleDescriptionsIngressOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16939,7 +16955,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = WithdrawByoipCidrOperationHTTPRequestInput<ElasticComputeCloudModel.WithdrawByoipCidrRequest>(encodable: input)
+        let wrappedInput = WithdrawByoipCidrOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -16969,7 +16985,7 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = WithdrawByoipCidrOperationHTTPRequestInput<ElasticComputeCloudModel.WithdrawByoipCidrRequest>(encodable: input)
+        let wrappedInput = WithdrawByoipCidrOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,

--- a/Sources/ElasticComputeCloudClient/ElasticComputeCloudClientProtocol.swift
+++ b/Sources/ElasticComputeCloudClient/ElasticComputeCloudClientProtocol.swift
@@ -42,11 +42,11 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias AssignIpv6AddressesSyncType = (_ input: ElasticComputeCloudModel.AssignIpv6AddressesRequest) throws -> ElasticComputeCloudModel.AssignIpv6AddressesResult
     typealias AssignIpv6AddressesAsyncType = (_ input: ElasticComputeCloudModel.AssignIpv6AddressesRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.AssignIpv6AddressesResult>) -> ()) throws -> ()
     typealias AssignPrivateIpAddressesSyncType = (_ input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest) throws -> ()
-    typealias AssignPrivateIpAddressesAsyncType = (_ input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias AssignPrivateIpAddressesAsyncType = (_ input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias AssociateAddressSyncType = (_ input: ElasticComputeCloudModel.AssociateAddressRequest) throws -> ElasticComputeCloudModel.AssociateAddressResult
     typealias AssociateAddressAsyncType = (_ input: ElasticComputeCloudModel.AssociateAddressRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.AssociateAddressResult>) -> ()) throws -> ()
     typealias AssociateDhcpOptionsSyncType = (_ input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest) throws -> ()
-    typealias AssociateDhcpOptionsAsyncType = (_ input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias AssociateDhcpOptionsAsyncType = (_ input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias AssociateIamInstanceProfileSyncType = (_ input: ElasticComputeCloudModel.AssociateIamInstanceProfileRequest) throws -> ElasticComputeCloudModel.AssociateIamInstanceProfileResult
     typealias AssociateIamInstanceProfileAsyncType = (_ input: ElasticComputeCloudModel.AssociateIamInstanceProfileRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.AssociateIamInstanceProfileResult>) -> ()) throws -> ()
     typealias AssociateRouteTableSyncType = (_ input: ElasticComputeCloudModel.AssociateRouteTableRequest) throws -> ElasticComputeCloudModel.AssociateRouteTableResult
@@ -58,7 +58,7 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias AttachClassicLinkVpcSyncType = (_ input: ElasticComputeCloudModel.AttachClassicLinkVpcRequest) throws -> ElasticComputeCloudModel.AttachClassicLinkVpcResult
     typealias AttachClassicLinkVpcAsyncType = (_ input: ElasticComputeCloudModel.AttachClassicLinkVpcRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.AttachClassicLinkVpcResult>) -> ()) throws -> ()
     typealias AttachInternetGatewaySyncType = (_ input: ElasticComputeCloudModel.AttachInternetGatewayRequest) throws -> ()
-    typealias AttachInternetGatewayAsyncType = (_ input: ElasticComputeCloudModel.AttachInternetGatewayRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias AttachInternetGatewayAsyncType = (_ input: ElasticComputeCloudModel.AttachInternetGatewayRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias AttachNetworkInterfaceSyncType = (_ input: ElasticComputeCloudModel.AttachNetworkInterfaceRequest) throws -> ElasticComputeCloudModel.AttachNetworkInterfaceResult
     typealias AttachNetworkInterfaceAsyncType = (_ input: ElasticComputeCloudModel.AttachNetworkInterfaceRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.AttachNetworkInterfaceResult>) -> ()) throws -> ()
     typealias AttachVolumeSyncType = (_ input: ElasticComputeCloudModel.AttachVolumeRequest) throws -> ElasticComputeCloudModel.VolumeAttachment
@@ -66,9 +66,9 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias AttachVpnGatewaySyncType = (_ input: ElasticComputeCloudModel.AttachVpnGatewayRequest) throws -> ElasticComputeCloudModel.AttachVpnGatewayResult
     typealias AttachVpnGatewayAsyncType = (_ input: ElasticComputeCloudModel.AttachVpnGatewayRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.AttachVpnGatewayResult>) -> ()) throws -> ()
     typealias AuthorizeSecurityGroupEgressSyncType = (_ input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest) throws -> ()
-    typealias AuthorizeSecurityGroupEgressAsyncType = (_ input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias AuthorizeSecurityGroupEgressAsyncType = (_ input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias AuthorizeSecurityGroupIngressSyncType = (_ input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest) throws -> ()
-    typealias AuthorizeSecurityGroupIngressAsyncType = (_ input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias AuthorizeSecurityGroupIngressAsyncType = (_ input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias BundleInstanceSyncType = (_ input: ElasticComputeCloudModel.BundleInstanceRequest) throws -> ElasticComputeCloudModel.BundleInstanceResult
     typealias BundleInstanceAsyncType = (_ input: ElasticComputeCloudModel.BundleInstanceRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.BundleInstanceResult>) -> ()) throws -> ()
     typealias CancelBundleTaskSyncType = (_ input: ElasticComputeCloudModel.CancelBundleTaskRequest) throws -> ElasticComputeCloudModel.CancelBundleTaskResult
@@ -76,9 +76,9 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias CancelCapacityReservationSyncType = (_ input: ElasticComputeCloudModel.CancelCapacityReservationRequest) throws -> ElasticComputeCloudModel.CancelCapacityReservationResult
     typealias CancelCapacityReservationAsyncType = (_ input: ElasticComputeCloudModel.CancelCapacityReservationRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.CancelCapacityReservationResult>) -> ()) throws -> ()
     typealias CancelConversionTaskSyncType = (_ input: ElasticComputeCloudModel.CancelConversionRequest) throws -> ()
-    typealias CancelConversionTaskAsyncType = (_ input: ElasticComputeCloudModel.CancelConversionRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias CancelConversionTaskAsyncType = (_ input: ElasticComputeCloudModel.CancelConversionRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias CancelExportTaskSyncType = (_ input: ElasticComputeCloudModel.CancelExportTaskRequest) throws -> ()
-    typealias CancelExportTaskAsyncType = (_ input: ElasticComputeCloudModel.CancelExportTaskRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias CancelExportTaskAsyncType = (_ input: ElasticComputeCloudModel.CancelExportTaskRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias CancelImportTaskSyncType = (_ input: ElasticComputeCloudModel.CancelImportTaskRequest) throws -> ElasticComputeCloudModel.CancelImportTaskResult
     typealias CancelImportTaskAsyncType = (_ input: ElasticComputeCloudModel.CancelImportTaskRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.CancelImportTaskResult>) -> ()) throws -> ()
     typealias CancelReservedInstancesListingSyncType = (_ input: ElasticComputeCloudModel.CancelReservedInstancesListingRequest) throws -> ElasticComputeCloudModel.CancelReservedInstancesListingResult
@@ -130,13 +130,13 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias CreateNetworkAclSyncType = (_ input: ElasticComputeCloudModel.CreateNetworkAclRequest) throws -> ElasticComputeCloudModel.CreateNetworkAclResult
     typealias CreateNetworkAclAsyncType = (_ input: ElasticComputeCloudModel.CreateNetworkAclRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.CreateNetworkAclResult>) -> ()) throws -> ()
     typealias CreateNetworkAclEntrySyncType = (_ input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest) throws -> ()
-    typealias CreateNetworkAclEntryAsyncType = (_ input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias CreateNetworkAclEntryAsyncType = (_ input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias CreateNetworkInterfaceSyncType = (_ input: ElasticComputeCloudModel.CreateNetworkInterfaceRequest) throws -> ElasticComputeCloudModel.CreateNetworkInterfaceResult
     typealias CreateNetworkInterfaceAsyncType = (_ input: ElasticComputeCloudModel.CreateNetworkInterfaceRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.CreateNetworkInterfaceResult>) -> ()) throws -> ()
     typealias CreateNetworkInterfacePermissionSyncType = (_ input: ElasticComputeCloudModel.CreateNetworkInterfacePermissionRequest) throws -> ElasticComputeCloudModel.CreateNetworkInterfacePermissionResult
     typealias CreateNetworkInterfacePermissionAsyncType = (_ input: ElasticComputeCloudModel.CreateNetworkInterfacePermissionRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.CreateNetworkInterfacePermissionResult>) -> ()) throws -> ()
     typealias CreatePlacementGroupSyncType = (_ input: ElasticComputeCloudModel.CreatePlacementGroupRequest) throws -> ()
-    typealias CreatePlacementGroupAsyncType = (_ input: ElasticComputeCloudModel.CreatePlacementGroupRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias CreatePlacementGroupAsyncType = (_ input: ElasticComputeCloudModel.CreatePlacementGroupRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias CreateReservedInstancesListingSyncType = (_ input: ElasticComputeCloudModel.CreateReservedInstancesListingRequest) throws -> ElasticComputeCloudModel.CreateReservedInstancesListingResult
     typealias CreateReservedInstancesListingAsyncType = (_ input: ElasticComputeCloudModel.CreateReservedInstancesListingRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.CreateReservedInstancesListingResult>) -> ()) throws -> ()
     typealias CreateRouteSyncType = (_ input: ElasticComputeCloudModel.CreateRouteRequest) throws -> ElasticComputeCloudModel.CreateRouteResult
@@ -152,7 +152,7 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias CreateSubnetSyncType = (_ input: ElasticComputeCloudModel.CreateSubnetRequest) throws -> ElasticComputeCloudModel.CreateSubnetResult
     typealias CreateSubnetAsyncType = (_ input: ElasticComputeCloudModel.CreateSubnetRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.CreateSubnetResult>) -> ()) throws -> ()
     typealias CreateTagsSyncType = (_ input: ElasticComputeCloudModel.CreateTagsRequest) throws -> ()
-    typealias CreateTagsAsyncType = (_ input: ElasticComputeCloudModel.CreateTagsRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias CreateTagsAsyncType = (_ input: ElasticComputeCloudModel.CreateTagsRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias CreateVolumeSyncType = (_ input: ElasticComputeCloudModel.CreateVolumeRequest) throws -> ElasticComputeCloudModel.Volume
     typealias CreateVolumeAsyncType = (_ input: ElasticComputeCloudModel.CreateVolumeRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.Volume>) -> ()) throws -> ()
     typealias CreateVpcSyncType = (_ input: ElasticComputeCloudModel.CreateVpcRequest) throws -> ElasticComputeCloudModel.CreateVpcResult
@@ -168,13 +168,13 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias CreateVpnConnectionSyncType = (_ input: ElasticComputeCloudModel.CreateVpnConnectionRequest) throws -> ElasticComputeCloudModel.CreateVpnConnectionResult
     typealias CreateVpnConnectionAsyncType = (_ input: ElasticComputeCloudModel.CreateVpnConnectionRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.CreateVpnConnectionResult>) -> ()) throws -> ()
     typealias CreateVpnConnectionRouteSyncType = (_ input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest) throws -> ()
-    typealias CreateVpnConnectionRouteAsyncType = (_ input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias CreateVpnConnectionRouteAsyncType = (_ input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias CreateVpnGatewaySyncType = (_ input: ElasticComputeCloudModel.CreateVpnGatewayRequest) throws -> ElasticComputeCloudModel.CreateVpnGatewayResult
     typealias CreateVpnGatewayAsyncType = (_ input: ElasticComputeCloudModel.CreateVpnGatewayRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.CreateVpnGatewayResult>) -> ()) throws -> ()
     typealias DeleteCustomerGatewaySyncType = (_ input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest) throws -> ()
-    typealias DeleteCustomerGatewayAsyncType = (_ input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteCustomerGatewayAsyncType = (_ input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteDhcpOptionsSyncType = (_ input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest) throws -> ()
-    typealias DeleteDhcpOptionsAsyncType = (_ input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteDhcpOptionsAsyncType = (_ input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteEgressOnlyInternetGatewaySyncType = (_ input: ElasticComputeCloudModel.DeleteEgressOnlyInternetGatewayRequest) throws -> ElasticComputeCloudModel.DeleteEgressOnlyInternetGatewayResult
     typealias DeleteEgressOnlyInternetGatewayAsyncType = (_ input: ElasticComputeCloudModel.DeleteEgressOnlyInternetGatewayRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DeleteEgressOnlyInternetGatewayResult>) -> ()) throws -> ()
     typealias DeleteFleetsSyncType = (_ input: ElasticComputeCloudModel.DeleteFleetsRequest) throws -> ElasticComputeCloudModel.DeleteFleetsResult
@@ -184,9 +184,9 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias DeleteFpgaImageSyncType = (_ input: ElasticComputeCloudModel.DeleteFpgaImageRequest) throws -> ElasticComputeCloudModel.DeleteFpgaImageResult
     typealias DeleteFpgaImageAsyncType = (_ input: ElasticComputeCloudModel.DeleteFpgaImageRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DeleteFpgaImageResult>) -> ()) throws -> ()
     typealias DeleteInternetGatewaySyncType = (_ input: ElasticComputeCloudModel.DeleteInternetGatewayRequest) throws -> ()
-    typealias DeleteInternetGatewayAsyncType = (_ input: ElasticComputeCloudModel.DeleteInternetGatewayRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteInternetGatewayAsyncType = (_ input: ElasticComputeCloudModel.DeleteInternetGatewayRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteKeyPairSyncType = (_ input: ElasticComputeCloudModel.DeleteKeyPairRequest) throws -> ()
-    typealias DeleteKeyPairAsyncType = (_ input: ElasticComputeCloudModel.DeleteKeyPairRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteKeyPairAsyncType = (_ input: ElasticComputeCloudModel.DeleteKeyPairRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteLaunchTemplateSyncType = (_ input: ElasticComputeCloudModel.DeleteLaunchTemplateRequest) throws -> ElasticComputeCloudModel.DeleteLaunchTemplateResult
     typealias DeleteLaunchTemplateAsyncType = (_ input: ElasticComputeCloudModel.DeleteLaunchTemplateRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DeleteLaunchTemplateResult>) -> ()) throws -> ()
     typealias DeleteLaunchTemplateVersionsSyncType = (_ input: ElasticComputeCloudModel.DeleteLaunchTemplateVersionsRequest) throws -> ElasticComputeCloudModel.DeleteLaunchTemplateVersionsResult
@@ -194,33 +194,33 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias DeleteNatGatewaySyncType = (_ input: ElasticComputeCloudModel.DeleteNatGatewayRequest) throws -> ElasticComputeCloudModel.DeleteNatGatewayResult
     typealias DeleteNatGatewayAsyncType = (_ input: ElasticComputeCloudModel.DeleteNatGatewayRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DeleteNatGatewayResult>) -> ()) throws -> ()
     typealias DeleteNetworkAclSyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkAclRequest) throws -> ()
-    typealias DeleteNetworkAclAsyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkAclRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteNetworkAclAsyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkAclRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteNetworkAclEntrySyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest) throws -> ()
-    typealias DeleteNetworkAclEntryAsyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteNetworkAclEntryAsyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteNetworkInterfaceSyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest) throws -> ()
-    typealias DeleteNetworkInterfaceAsyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteNetworkInterfaceAsyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteNetworkInterfacePermissionSyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkInterfacePermissionRequest) throws -> ElasticComputeCloudModel.DeleteNetworkInterfacePermissionResult
     typealias DeleteNetworkInterfacePermissionAsyncType = (_ input: ElasticComputeCloudModel.DeleteNetworkInterfacePermissionRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DeleteNetworkInterfacePermissionResult>) -> ()) throws -> ()
     typealias DeletePlacementGroupSyncType = (_ input: ElasticComputeCloudModel.DeletePlacementGroupRequest) throws -> ()
-    typealias DeletePlacementGroupAsyncType = (_ input: ElasticComputeCloudModel.DeletePlacementGroupRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeletePlacementGroupAsyncType = (_ input: ElasticComputeCloudModel.DeletePlacementGroupRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteRouteSyncType = (_ input: ElasticComputeCloudModel.DeleteRouteRequest) throws -> ()
-    typealias DeleteRouteAsyncType = (_ input: ElasticComputeCloudModel.DeleteRouteRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteRouteAsyncType = (_ input: ElasticComputeCloudModel.DeleteRouteRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteRouteTableSyncType = (_ input: ElasticComputeCloudModel.DeleteRouteTableRequest) throws -> ()
-    typealias DeleteRouteTableAsyncType = (_ input: ElasticComputeCloudModel.DeleteRouteTableRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteRouteTableAsyncType = (_ input: ElasticComputeCloudModel.DeleteRouteTableRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteSecurityGroupSyncType = (_ input: ElasticComputeCloudModel.DeleteSecurityGroupRequest) throws -> ()
-    typealias DeleteSecurityGroupAsyncType = (_ input: ElasticComputeCloudModel.DeleteSecurityGroupRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteSecurityGroupAsyncType = (_ input: ElasticComputeCloudModel.DeleteSecurityGroupRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteSnapshotSyncType = (_ input: ElasticComputeCloudModel.DeleteSnapshotRequest) throws -> ()
-    typealias DeleteSnapshotAsyncType = (_ input: ElasticComputeCloudModel.DeleteSnapshotRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteSnapshotAsyncType = (_ input: ElasticComputeCloudModel.DeleteSnapshotRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteSpotDatafeedSubscriptionSyncType = (_ input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest) throws -> ()
-    typealias DeleteSpotDatafeedSubscriptionAsyncType = (_ input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteSpotDatafeedSubscriptionAsyncType = (_ input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteSubnetSyncType = (_ input: ElasticComputeCloudModel.DeleteSubnetRequest) throws -> ()
-    typealias DeleteSubnetAsyncType = (_ input: ElasticComputeCloudModel.DeleteSubnetRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteSubnetAsyncType = (_ input: ElasticComputeCloudModel.DeleteSubnetRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteTagsSyncType = (_ input: ElasticComputeCloudModel.DeleteTagsRequest) throws -> ()
-    typealias DeleteTagsAsyncType = (_ input: ElasticComputeCloudModel.DeleteTagsRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteTagsAsyncType = (_ input: ElasticComputeCloudModel.DeleteTagsRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteVolumeSyncType = (_ input: ElasticComputeCloudModel.DeleteVolumeRequest) throws -> ()
-    typealias DeleteVolumeAsyncType = (_ input: ElasticComputeCloudModel.DeleteVolumeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteVolumeAsyncType = (_ input: ElasticComputeCloudModel.DeleteVolumeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteVpcSyncType = (_ input: ElasticComputeCloudModel.DeleteVpcRequest) throws -> ()
-    typealias DeleteVpcAsyncType = (_ input: ElasticComputeCloudModel.DeleteVpcRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteVpcAsyncType = (_ input: ElasticComputeCloudModel.DeleteVpcRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteVpcEndpointConnectionNotificationsSyncType = (_ input: ElasticComputeCloudModel.DeleteVpcEndpointConnectionNotificationsRequest) throws -> ElasticComputeCloudModel.DeleteVpcEndpointConnectionNotificationsResult
     typealias DeleteVpcEndpointConnectionNotificationsAsyncType = (_ input: ElasticComputeCloudModel.DeleteVpcEndpointConnectionNotificationsRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DeleteVpcEndpointConnectionNotificationsResult>) -> ()) throws -> ()
     typealias DeleteVpcEndpointServiceConfigurationsSyncType = (_ input: ElasticComputeCloudModel.DeleteVpcEndpointServiceConfigurationsRequest) throws -> ElasticComputeCloudModel.DeleteVpcEndpointServiceConfigurationsResult
@@ -230,15 +230,15 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias DeleteVpcPeeringConnectionSyncType = (_ input: ElasticComputeCloudModel.DeleteVpcPeeringConnectionRequest) throws -> ElasticComputeCloudModel.DeleteVpcPeeringConnectionResult
     typealias DeleteVpcPeeringConnectionAsyncType = (_ input: ElasticComputeCloudModel.DeleteVpcPeeringConnectionRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DeleteVpcPeeringConnectionResult>) -> ()) throws -> ()
     typealias DeleteVpnConnectionSyncType = (_ input: ElasticComputeCloudModel.DeleteVpnConnectionRequest) throws -> ()
-    typealias DeleteVpnConnectionAsyncType = (_ input: ElasticComputeCloudModel.DeleteVpnConnectionRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteVpnConnectionAsyncType = (_ input: ElasticComputeCloudModel.DeleteVpnConnectionRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteVpnConnectionRouteSyncType = (_ input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest) throws -> ()
-    typealias DeleteVpnConnectionRouteAsyncType = (_ input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteVpnConnectionRouteAsyncType = (_ input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteVpnGatewaySyncType = (_ input: ElasticComputeCloudModel.DeleteVpnGatewayRequest) throws -> ()
-    typealias DeleteVpnGatewayAsyncType = (_ input: ElasticComputeCloudModel.DeleteVpnGatewayRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteVpnGatewayAsyncType = (_ input: ElasticComputeCloudModel.DeleteVpnGatewayRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeprovisionByoipCidrSyncType = (_ input: ElasticComputeCloudModel.DeprovisionByoipCidrRequest) throws -> ElasticComputeCloudModel.DeprovisionByoipCidrResult
     typealias DeprovisionByoipCidrAsyncType = (_ input: ElasticComputeCloudModel.DeprovisionByoipCidrRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DeprovisionByoipCidrResult>) -> ()) throws -> ()
     typealias DeregisterImageSyncType = (_ input: ElasticComputeCloudModel.DeregisterImageRequest) throws -> ()
-    typealias DeregisterImageAsyncType = (_ input: ElasticComputeCloudModel.DeregisterImageRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeregisterImageAsyncType = (_ input: ElasticComputeCloudModel.DeregisterImageRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DescribeAccountAttributesSyncType = (_ input: ElasticComputeCloudModel.DescribeAccountAttributesRequest) throws -> ElasticComputeCloudModel.DescribeAccountAttributesResult
     typealias DescribeAccountAttributesAsyncType = (_ input: ElasticComputeCloudModel.DescribeAccountAttributesRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DescribeAccountAttributesResult>) -> ()) throws -> ()
     typealias DescribeAddressesSyncType = (_ input: ElasticComputeCloudModel.DescribeAddressesRequest) throws -> ElasticComputeCloudModel.DescribeAddressesResult
@@ -414,33 +414,33 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias DetachClassicLinkVpcSyncType = (_ input: ElasticComputeCloudModel.DetachClassicLinkVpcRequest) throws -> ElasticComputeCloudModel.DetachClassicLinkVpcResult
     typealias DetachClassicLinkVpcAsyncType = (_ input: ElasticComputeCloudModel.DetachClassicLinkVpcRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DetachClassicLinkVpcResult>) -> ()) throws -> ()
     typealias DetachInternetGatewaySyncType = (_ input: ElasticComputeCloudModel.DetachInternetGatewayRequest) throws -> ()
-    typealias DetachInternetGatewayAsyncType = (_ input: ElasticComputeCloudModel.DetachInternetGatewayRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DetachInternetGatewayAsyncType = (_ input: ElasticComputeCloudModel.DetachInternetGatewayRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DetachNetworkInterfaceSyncType = (_ input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest) throws -> ()
-    typealias DetachNetworkInterfaceAsyncType = (_ input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DetachNetworkInterfaceAsyncType = (_ input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DetachVolumeSyncType = (_ input: ElasticComputeCloudModel.DetachVolumeRequest) throws -> ElasticComputeCloudModel.VolumeAttachment
     typealias DetachVolumeAsyncType = (_ input: ElasticComputeCloudModel.DetachVolumeRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.VolumeAttachment>) -> ()) throws -> ()
     typealias DetachVpnGatewaySyncType = (_ input: ElasticComputeCloudModel.DetachVpnGatewayRequest) throws -> ()
-    typealias DetachVpnGatewayAsyncType = (_ input: ElasticComputeCloudModel.DetachVpnGatewayRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DetachVpnGatewayAsyncType = (_ input: ElasticComputeCloudModel.DetachVpnGatewayRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DisableVgwRoutePropagationSyncType = (_ input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest) throws -> ()
-    typealias DisableVgwRoutePropagationAsyncType = (_ input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DisableVgwRoutePropagationAsyncType = (_ input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DisableVpcClassicLinkSyncType = (_ input: ElasticComputeCloudModel.DisableVpcClassicLinkRequest) throws -> ElasticComputeCloudModel.DisableVpcClassicLinkResult
     typealias DisableVpcClassicLinkAsyncType = (_ input: ElasticComputeCloudModel.DisableVpcClassicLinkRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DisableVpcClassicLinkResult>) -> ()) throws -> ()
     typealias DisableVpcClassicLinkDnsSupportSyncType = (_ input: ElasticComputeCloudModel.DisableVpcClassicLinkDnsSupportRequest) throws -> ElasticComputeCloudModel.DisableVpcClassicLinkDnsSupportResult
     typealias DisableVpcClassicLinkDnsSupportAsyncType = (_ input: ElasticComputeCloudModel.DisableVpcClassicLinkDnsSupportRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DisableVpcClassicLinkDnsSupportResult>) -> ()) throws -> ()
     typealias DisassociateAddressSyncType = (_ input: ElasticComputeCloudModel.DisassociateAddressRequest) throws -> ()
-    typealias DisassociateAddressAsyncType = (_ input: ElasticComputeCloudModel.DisassociateAddressRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DisassociateAddressAsyncType = (_ input: ElasticComputeCloudModel.DisassociateAddressRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DisassociateIamInstanceProfileSyncType = (_ input: ElasticComputeCloudModel.DisassociateIamInstanceProfileRequest) throws -> ElasticComputeCloudModel.DisassociateIamInstanceProfileResult
     typealias DisassociateIamInstanceProfileAsyncType = (_ input: ElasticComputeCloudModel.DisassociateIamInstanceProfileRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DisassociateIamInstanceProfileResult>) -> ()) throws -> ()
     typealias DisassociateRouteTableSyncType = (_ input: ElasticComputeCloudModel.DisassociateRouteTableRequest) throws -> ()
-    typealias DisassociateRouteTableAsyncType = (_ input: ElasticComputeCloudModel.DisassociateRouteTableRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DisassociateRouteTableAsyncType = (_ input: ElasticComputeCloudModel.DisassociateRouteTableRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DisassociateSubnetCidrBlockSyncType = (_ input: ElasticComputeCloudModel.DisassociateSubnetCidrBlockRequest) throws -> ElasticComputeCloudModel.DisassociateSubnetCidrBlockResult
     typealias DisassociateSubnetCidrBlockAsyncType = (_ input: ElasticComputeCloudModel.DisassociateSubnetCidrBlockRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DisassociateSubnetCidrBlockResult>) -> ()) throws -> ()
     typealias DisassociateVpcCidrBlockSyncType = (_ input: ElasticComputeCloudModel.DisassociateVpcCidrBlockRequest) throws -> ElasticComputeCloudModel.DisassociateVpcCidrBlockResult
     typealias DisassociateVpcCidrBlockAsyncType = (_ input: ElasticComputeCloudModel.DisassociateVpcCidrBlockRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.DisassociateVpcCidrBlockResult>) -> ()) throws -> ()
     typealias EnableVgwRoutePropagationSyncType = (_ input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest) throws -> ()
-    typealias EnableVgwRoutePropagationAsyncType = (_ input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias EnableVgwRoutePropagationAsyncType = (_ input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias EnableVolumeIOSyncType = (_ input: ElasticComputeCloudModel.EnableVolumeIORequest) throws -> ()
-    typealias EnableVolumeIOAsyncType = (_ input: ElasticComputeCloudModel.EnableVolumeIORequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias EnableVolumeIOAsyncType = (_ input: ElasticComputeCloudModel.EnableVolumeIORequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias EnableVpcClassicLinkSyncType = (_ input: ElasticComputeCloudModel.EnableVpcClassicLinkRequest) throws -> ElasticComputeCloudModel.EnableVpcClassicLinkResult
     typealias EnableVpcClassicLinkAsyncType = (_ input: ElasticComputeCloudModel.EnableVpcClassicLinkRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.EnableVpcClassicLinkResult>) -> ()) throws -> ()
     typealias EnableVpcClassicLinkDnsSupportSyncType = (_ input: ElasticComputeCloudModel.EnableVpcClassicLinkDnsSupportRequest) throws -> ElasticComputeCloudModel.EnableVpcClassicLinkDnsSupportResult
@@ -476,13 +476,13 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias ModifyHostsSyncType = (_ input: ElasticComputeCloudModel.ModifyHostsRequest) throws -> ElasticComputeCloudModel.ModifyHostsResult
     typealias ModifyHostsAsyncType = (_ input: ElasticComputeCloudModel.ModifyHostsRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ModifyHostsResult>) -> ()) throws -> ()
     typealias ModifyIdFormatSyncType = (_ input: ElasticComputeCloudModel.ModifyIdFormatRequest) throws -> ()
-    typealias ModifyIdFormatAsyncType = (_ input: ElasticComputeCloudModel.ModifyIdFormatRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ModifyIdFormatAsyncType = (_ input: ElasticComputeCloudModel.ModifyIdFormatRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ModifyIdentityIdFormatSyncType = (_ input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest) throws -> ()
-    typealias ModifyIdentityIdFormatAsyncType = (_ input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ModifyIdentityIdFormatAsyncType = (_ input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ModifyImageAttributeSyncType = (_ input: ElasticComputeCloudModel.ModifyImageAttributeRequest) throws -> ()
-    typealias ModifyImageAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifyImageAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ModifyImageAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifyImageAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ModifyInstanceAttributeSyncType = (_ input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest) throws -> ()
-    typealias ModifyInstanceAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ModifyInstanceAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ModifyInstanceCapacityReservationAttributesSyncType = (_ input: ElasticComputeCloudModel.ModifyInstanceCapacityReservationAttributesRequest) throws -> ElasticComputeCloudModel.ModifyInstanceCapacityReservationAttributesResult
     typealias ModifyInstanceCapacityReservationAttributesAsyncType = (_ input: ElasticComputeCloudModel.ModifyInstanceCapacityReservationAttributesRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ModifyInstanceCapacityReservationAttributesResult>) -> ()) throws -> ()
     typealias ModifyInstanceCreditSpecificationSyncType = (_ input: ElasticComputeCloudModel.ModifyInstanceCreditSpecificationRequest) throws -> ElasticComputeCloudModel.ModifyInstanceCreditSpecificationResult
@@ -492,21 +492,21 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias ModifyLaunchTemplateSyncType = (_ input: ElasticComputeCloudModel.ModifyLaunchTemplateRequest) throws -> ElasticComputeCloudModel.ModifyLaunchTemplateResult
     typealias ModifyLaunchTemplateAsyncType = (_ input: ElasticComputeCloudModel.ModifyLaunchTemplateRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ModifyLaunchTemplateResult>) -> ()) throws -> ()
     typealias ModifyNetworkInterfaceAttributeSyncType = (_ input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest) throws -> ()
-    typealias ModifyNetworkInterfaceAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ModifyNetworkInterfaceAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ModifyReservedInstancesSyncType = (_ input: ElasticComputeCloudModel.ModifyReservedInstancesRequest) throws -> ElasticComputeCloudModel.ModifyReservedInstancesResult
     typealias ModifyReservedInstancesAsyncType = (_ input: ElasticComputeCloudModel.ModifyReservedInstancesRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ModifyReservedInstancesResult>) -> ()) throws -> ()
     typealias ModifySnapshotAttributeSyncType = (_ input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest) throws -> ()
-    typealias ModifySnapshotAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ModifySnapshotAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ModifySpotFleetRequestSyncType = (_ input: ElasticComputeCloudModel.ModifySpotFleetRequestRequest) throws -> ElasticComputeCloudModel.ModifySpotFleetRequestResponse
     typealias ModifySpotFleetRequestAsyncType = (_ input: ElasticComputeCloudModel.ModifySpotFleetRequestRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ModifySpotFleetRequestResponse>) -> ()) throws -> ()
     typealias ModifySubnetAttributeSyncType = (_ input: ElasticComputeCloudModel.ModifySubnetAttributeRequest) throws -> ()
-    typealias ModifySubnetAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifySubnetAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ModifySubnetAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifySubnetAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ModifyVolumeSyncType = (_ input: ElasticComputeCloudModel.ModifyVolumeRequest) throws -> ElasticComputeCloudModel.ModifyVolumeResult
     typealias ModifyVolumeAsyncType = (_ input: ElasticComputeCloudModel.ModifyVolumeRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ModifyVolumeResult>) -> ()) throws -> ()
     typealias ModifyVolumeAttributeSyncType = (_ input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest) throws -> ()
-    typealias ModifyVolumeAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ModifyVolumeAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ModifyVpcAttributeSyncType = (_ input: ElasticComputeCloudModel.ModifyVpcAttributeRequest) throws -> ()
-    typealias ModifyVpcAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifyVpcAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ModifyVpcAttributeAsyncType = (_ input: ElasticComputeCloudModel.ModifyVpcAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ModifyVpcEndpointSyncType = (_ input: ElasticComputeCloudModel.ModifyVpcEndpointRequest) throws -> ElasticComputeCloudModel.ModifyVpcEndpointResult
     typealias ModifyVpcEndpointAsyncType = (_ input: ElasticComputeCloudModel.ModifyVpcEndpointRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ModifyVpcEndpointResult>) -> ()) throws -> ()
     typealias ModifyVpcEndpointConnectionNotificationSyncType = (_ input: ElasticComputeCloudModel.ModifyVpcEndpointConnectionNotificationRequest) throws -> ElasticComputeCloudModel.ModifyVpcEndpointConnectionNotificationResult
@@ -532,7 +532,7 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias PurchaseScheduledInstancesSyncType = (_ input: ElasticComputeCloudModel.PurchaseScheduledInstancesRequest) throws -> ElasticComputeCloudModel.PurchaseScheduledInstancesResult
     typealias PurchaseScheduledInstancesAsyncType = (_ input: ElasticComputeCloudModel.PurchaseScheduledInstancesRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.PurchaseScheduledInstancesResult>) -> ()) throws -> ()
     typealias RebootInstancesSyncType = (_ input: ElasticComputeCloudModel.RebootInstancesRequest) throws -> ()
-    typealias RebootInstancesAsyncType = (_ input: ElasticComputeCloudModel.RebootInstancesRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RebootInstancesAsyncType = (_ input: ElasticComputeCloudModel.RebootInstancesRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RegisterImageSyncType = (_ input: ElasticComputeCloudModel.RegisterImageRequest) throws -> ElasticComputeCloudModel.RegisterImageResult
     typealias RegisterImageAsyncType = (_ input: ElasticComputeCloudModel.RegisterImageRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.RegisterImageResult>) -> ()) throws -> ()
     typealias RejectVpcEndpointConnectionsSyncType = (_ input: ElasticComputeCloudModel.RejectVpcEndpointConnectionsRequest) throws -> ElasticComputeCloudModel.RejectVpcEndpointConnectionsResult
@@ -540,7 +540,7 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias RejectVpcPeeringConnectionSyncType = (_ input: ElasticComputeCloudModel.RejectVpcPeeringConnectionRequest) throws -> ElasticComputeCloudModel.RejectVpcPeeringConnectionResult
     typealias RejectVpcPeeringConnectionAsyncType = (_ input: ElasticComputeCloudModel.RejectVpcPeeringConnectionRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.RejectVpcPeeringConnectionResult>) -> ()) throws -> ()
     typealias ReleaseAddressSyncType = (_ input: ElasticComputeCloudModel.ReleaseAddressRequest) throws -> ()
-    typealias ReleaseAddressAsyncType = (_ input: ElasticComputeCloudModel.ReleaseAddressRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ReleaseAddressAsyncType = (_ input: ElasticComputeCloudModel.ReleaseAddressRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ReleaseHostsSyncType = (_ input: ElasticComputeCloudModel.ReleaseHostsRequest) throws -> ElasticComputeCloudModel.ReleaseHostsResult
     typealias ReleaseHostsAsyncType = (_ input: ElasticComputeCloudModel.ReleaseHostsRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ReleaseHostsResult>) -> ()) throws -> ()
     typealias ReplaceIamInstanceProfileAssociationSyncType = (_ input: ElasticComputeCloudModel.ReplaceIamInstanceProfileAssociationRequest) throws -> ElasticComputeCloudModel.ReplaceIamInstanceProfileAssociationResult
@@ -548,13 +548,13 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias ReplaceNetworkAclAssociationSyncType = (_ input: ElasticComputeCloudModel.ReplaceNetworkAclAssociationRequest) throws -> ElasticComputeCloudModel.ReplaceNetworkAclAssociationResult
     typealias ReplaceNetworkAclAssociationAsyncType = (_ input: ElasticComputeCloudModel.ReplaceNetworkAclAssociationRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ReplaceNetworkAclAssociationResult>) -> ()) throws -> ()
     typealias ReplaceNetworkAclEntrySyncType = (_ input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest) throws -> ()
-    typealias ReplaceNetworkAclEntryAsyncType = (_ input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ReplaceNetworkAclEntryAsyncType = (_ input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ReplaceRouteSyncType = (_ input: ElasticComputeCloudModel.ReplaceRouteRequest) throws -> ()
-    typealias ReplaceRouteAsyncType = (_ input: ElasticComputeCloudModel.ReplaceRouteRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ReplaceRouteAsyncType = (_ input: ElasticComputeCloudModel.ReplaceRouteRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ReplaceRouteTableAssociationSyncType = (_ input: ElasticComputeCloudModel.ReplaceRouteTableAssociationRequest) throws -> ElasticComputeCloudModel.ReplaceRouteTableAssociationResult
     typealias ReplaceRouteTableAssociationAsyncType = (_ input: ElasticComputeCloudModel.ReplaceRouteTableAssociationRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ReplaceRouteTableAssociationResult>) -> ()) throws -> ()
     typealias ReportInstanceStatusSyncType = (_ input: ElasticComputeCloudModel.ReportInstanceStatusRequest) throws -> ()
-    typealias ReportInstanceStatusAsyncType = (_ input: ElasticComputeCloudModel.ReportInstanceStatusRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ReportInstanceStatusAsyncType = (_ input: ElasticComputeCloudModel.ReportInstanceStatusRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RequestSpotFleetSyncType = (_ input: ElasticComputeCloudModel.RequestSpotFleetRequest) throws -> ElasticComputeCloudModel.RequestSpotFleetResponse
     typealias RequestSpotFleetAsyncType = (_ input: ElasticComputeCloudModel.RequestSpotFleetRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.RequestSpotFleetResponse>) -> ()) throws -> ()
     typealias RequestSpotInstancesSyncType = (_ input: ElasticComputeCloudModel.RequestSpotInstancesRequest) throws -> ElasticComputeCloudModel.RequestSpotInstancesResult
@@ -562,19 +562,19 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias ResetFpgaImageAttributeSyncType = (_ input: ElasticComputeCloudModel.ResetFpgaImageAttributeRequest) throws -> ElasticComputeCloudModel.ResetFpgaImageAttributeResult
     typealias ResetFpgaImageAttributeAsyncType = (_ input: ElasticComputeCloudModel.ResetFpgaImageAttributeRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.ResetFpgaImageAttributeResult>) -> ()) throws -> ()
     typealias ResetImageAttributeSyncType = (_ input: ElasticComputeCloudModel.ResetImageAttributeRequest) throws -> ()
-    typealias ResetImageAttributeAsyncType = (_ input: ElasticComputeCloudModel.ResetImageAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ResetImageAttributeAsyncType = (_ input: ElasticComputeCloudModel.ResetImageAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ResetInstanceAttributeSyncType = (_ input: ElasticComputeCloudModel.ResetInstanceAttributeRequest) throws -> ()
-    typealias ResetInstanceAttributeAsyncType = (_ input: ElasticComputeCloudModel.ResetInstanceAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ResetInstanceAttributeAsyncType = (_ input: ElasticComputeCloudModel.ResetInstanceAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ResetNetworkInterfaceAttributeSyncType = (_ input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest) throws -> ()
-    typealias ResetNetworkInterfaceAttributeAsyncType = (_ input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ResetNetworkInterfaceAttributeAsyncType = (_ input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ResetSnapshotAttributeSyncType = (_ input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest) throws -> ()
-    typealias ResetSnapshotAttributeAsyncType = (_ input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ResetSnapshotAttributeAsyncType = (_ input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RestoreAddressToClassicSyncType = (_ input: ElasticComputeCloudModel.RestoreAddressToClassicRequest) throws -> ElasticComputeCloudModel.RestoreAddressToClassicResult
     typealias RestoreAddressToClassicAsyncType = (_ input: ElasticComputeCloudModel.RestoreAddressToClassicRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.RestoreAddressToClassicResult>) -> ()) throws -> ()
     typealias RevokeSecurityGroupEgressSyncType = (_ input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest) throws -> ()
-    typealias RevokeSecurityGroupEgressAsyncType = (_ input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RevokeSecurityGroupEgressAsyncType = (_ input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RevokeSecurityGroupIngressSyncType = (_ input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest) throws -> ()
-    typealias RevokeSecurityGroupIngressAsyncType = (_ input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RevokeSecurityGroupIngressAsyncType = (_ input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RunInstancesSyncType = (_ input: ElasticComputeCloudModel.RunInstancesRequest) throws -> ElasticComputeCloudModel.Reservation
     typealias RunInstancesAsyncType = (_ input: ElasticComputeCloudModel.RunInstancesRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.Reservation>) -> ()) throws -> ()
     typealias RunScheduledInstancesSyncType = (_ input: ElasticComputeCloudModel.RunScheduledInstancesRequest) throws -> ElasticComputeCloudModel.RunScheduledInstancesResult
@@ -588,7 +588,7 @@ public protocol ElasticComputeCloudClientProtocol {
     typealias UnassignIpv6AddressesSyncType = (_ input: ElasticComputeCloudModel.UnassignIpv6AddressesRequest) throws -> ElasticComputeCloudModel.UnassignIpv6AddressesResult
     typealias UnassignIpv6AddressesAsyncType = (_ input: ElasticComputeCloudModel.UnassignIpv6AddressesRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.UnassignIpv6AddressesResult>) -> ()) throws -> ()
     typealias UnassignPrivateIpAddressesSyncType = (_ input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest) throws -> ()
-    typealias UnassignPrivateIpAddressesAsyncType = (_ input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias UnassignPrivateIpAddressesAsyncType = (_ input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias UnmonitorInstancesSyncType = (_ input: ElasticComputeCloudModel.UnmonitorInstancesRequest) throws -> ElasticComputeCloudModel.UnmonitorInstancesResult
     typealias UnmonitorInstancesAsyncType = (_ input: ElasticComputeCloudModel.UnmonitorInstancesRequest, _ completion: @escaping (HTTPResult<ElasticComputeCloudModel.UnmonitorInstancesResult>) -> ()) throws -> ()
     typealias UpdateSecurityGroupRuleDescriptionsEgressSyncType = (_ input: ElasticComputeCloudModel.UpdateSecurityGroupRuleDescriptionsEgressRequest) throws -> ElasticComputeCloudModel.UpdateSecurityGroupRuleDescriptionsEgressResult
@@ -753,7 +753,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func assignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest, completion: @escaping (Error?) -> ()) throws
+    func assignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the AssignPrivateIpAddresses operation waiting for the response before returning.
@@ -792,7 +792,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func associateDhcpOptionsAsync(input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest, completion: @escaping (Error?) -> ()) throws
+    func associateDhcpOptionsAsync(input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the AssociateDhcpOptions operation waiting for the response before returning.
@@ -915,7 +915,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func attachInternetGatewayAsync(input: ElasticComputeCloudModel.AttachInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws
+    func attachInternetGatewayAsync(input: ElasticComputeCloudModel.AttachInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the AttachInternetGateway operation waiting for the response before returning.
@@ -996,7 +996,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func authorizeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest, completion: @escaping (Error?) -> ()) throws
+    func authorizeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the AuthorizeSecurityGroupEgress operation waiting for the response before returning.
@@ -1014,7 +1014,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func authorizeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest, completion: @escaping (Error?) -> ()) throws
+    func authorizeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the AuthorizeSecurityGroupIngress operation waiting for the response before returning.
@@ -1095,7 +1095,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func cancelConversionTaskAsync(input: ElasticComputeCloudModel.CancelConversionRequest, completion: @escaping (Error?) -> ()) throws
+    func cancelConversionTaskAsync(input: ElasticComputeCloudModel.CancelConversionRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the CancelConversionTask operation waiting for the response before returning.
@@ -1113,7 +1113,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func cancelExportTaskAsync(input: ElasticComputeCloudModel.CancelExportTaskRequest, completion: @escaping (Error?) -> ()) throws
+    func cancelExportTaskAsync(input: ElasticComputeCloudModel.CancelExportTaskRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the CancelExportTask operation waiting for the response before returning.
@@ -1656,7 +1656,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func createNetworkAclEntryAsync(input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws
+    func createNetworkAclEntryAsync(input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the CreateNetworkAclEntry operation waiting for the response before returning.
@@ -1716,7 +1716,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func createPlacementGroupAsync(input: ElasticComputeCloudModel.CreatePlacementGroupRequest, completion: @escaping (Error?) -> ()) throws
+    func createPlacementGroupAsync(input: ElasticComputeCloudModel.CreatePlacementGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the CreatePlacementGroup operation waiting for the response before returning.
@@ -1881,7 +1881,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func createTagsAsync(input: ElasticComputeCloudModel.CreateTagsRequest, completion: @escaping (Error?) -> ()) throws
+    func createTagsAsync(input: ElasticComputeCloudModel.CreateTagsRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the CreateTags operation waiting for the response before returning.
@@ -2046,7 +2046,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func createVpnConnectionRouteAsync(input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest, completion: @escaping (Error?) -> ()) throws
+    func createVpnConnectionRouteAsync(input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the CreateVpnConnectionRoute operation waiting for the response before returning.
@@ -2085,7 +2085,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteCustomerGatewayAsync(input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteCustomerGatewayAsync(input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteCustomerGateway operation waiting for the response before returning.
@@ -2103,7 +2103,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteDhcpOptionsAsync(input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteDhcpOptionsAsync(input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteDhcpOptions operation waiting for the response before returning.
@@ -2205,7 +2205,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteInternetGatewayAsync(input: ElasticComputeCloudModel.DeleteInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteInternetGatewayAsync(input: ElasticComputeCloudModel.DeleteInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteInternetGateway operation waiting for the response before returning.
@@ -2223,7 +2223,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteKeyPairAsync(input: ElasticComputeCloudModel.DeleteKeyPairRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteKeyPairAsync(input: ElasticComputeCloudModel.DeleteKeyPairRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteKeyPair operation waiting for the response before returning.
@@ -2304,7 +2304,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteNetworkAclAsync(input: ElasticComputeCloudModel.DeleteNetworkAclRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteNetworkAclAsync(input: ElasticComputeCloudModel.DeleteNetworkAclRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteNetworkAcl operation waiting for the response before returning.
@@ -2322,7 +2322,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteNetworkAclEntryAsync(input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteNetworkAclEntryAsync(input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteNetworkAclEntry operation waiting for the response before returning.
@@ -2340,7 +2340,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteNetworkInterfaceAsync(input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteNetworkInterfaceAsync(input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteNetworkInterface operation waiting for the response before returning.
@@ -2379,7 +2379,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deletePlacementGroupAsync(input: ElasticComputeCloudModel.DeletePlacementGroupRequest, completion: @escaping (Error?) -> ()) throws
+    func deletePlacementGroupAsync(input: ElasticComputeCloudModel.DeletePlacementGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeletePlacementGroup operation waiting for the response before returning.
@@ -2397,7 +2397,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteRouteAsync(input: ElasticComputeCloudModel.DeleteRouteRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteRouteAsync(input: ElasticComputeCloudModel.DeleteRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteRoute operation waiting for the response before returning.
@@ -2415,7 +2415,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteRouteTableAsync(input: ElasticComputeCloudModel.DeleteRouteTableRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteRouteTableAsync(input: ElasticComputeCloudModel.DeleteRouteTableRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteRouteTable operation waiting for the response before returning.
@@ -2433,7 +2433,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteSecurityGroupAsync(input: ElasticComputeCloudModel.DeleteSecurityGroupRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteSecurityGroupAsync(input: ElasticComputeCloudModel.DeleteSecurityGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteSecurityGroup operation waiting for the response before returning.
@@ -2451,7 +2451,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteSnapshotAsync(input: ElasticComputeCloudModel.DeleteSnapshotRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteSnapshotAsync(input: ElasticComputeCloudModel.DeleteSnapshotRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteSnapshot operation waiting for the response before returning.
@@ -2469,7 +2469,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteSpotDatafeedSubscriptionAsync(input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteSpotDatafeedSubscriptionAsync(input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteSpotDatafeedSubscription operation waiting for the response before returning.
@@ -2487,7 +2487,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteSubnetAsync(input: ElasticComputeCloudModel.DeleteSubnetRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteSubnetAsync(input: ElasticComputeCloudModel.DeleteSubnetRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteSubnet operation waiting for the response before returning.
@@ -2505,7 +2505,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteTagsAsync(input: ElasticComputeCloudModel.DeleteTagsRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteTagsAsync(input: ElasticComputeCloudModel.DeleteTagsRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteTags operation waiting for the response before returning.
@@ -2523,7 +2523,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteVolumeAsync(input: ElasticComputeCloudModel.DeleteVolumeRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteVolumeAsync(input: ElasticComputeCloudModel.DeleteVolumeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteVolume operation waiting for the response before returning.
@@ -2541,7 +2541,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteVpcAsync(input: ElasticComputeCloudModel.DeleteVpcRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteVpcAsync(input: ElasticComputeCloudModel.DeleteVpcRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteVpc operation waiting for the response before returning.
@@ -2643,7 +2643,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteVpnConnectionAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteVpnConnectionAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteVpnConnection operation waiting for the response before returning.
@@ -2661,7 +2661,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteVpnConnectionRouteAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteVpnConnectionRouteAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteVpnConnectionRoute operation waiting for the response before returning.
@@ -2679,7 +2679,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteVpnGatewayAsync(input: ElasticComputeCloudModel.DeleteVpnGatewayRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteVpnGatewayAsync(input: ElasticComputeCloudModel.DeleteVpnGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteVpnGateway operation waiting for the response before returning.
@@ -2718,7 +2718,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deregisterImageAsync(input: ElasticComputeCloudModel.DeregisterImageRequest, completion: @escaping (Error?) -> ()) throws
+    func deregisterImageAsync(input: ElasticComputeCloudModel.DeregisterImageRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeregisterImage operation waiting for the response before returning.
@@ -4563,7 +4563,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func detachInternetGatewayAsync(input: ElasticComputeCloudModel.DetachInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws
+    func detachInternetGatewayAsync(input: ElasticComputeCloudModel.DetachInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DetachInternetGateway operation waiting for the response before returning.
@@ -4581,7 +4581,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func detachNetworkInterfaceAsync(input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest, completion: @escaping (Error?) -> ()) throws
+    func detachNetworkInterfaceAsync(input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DetachNetworkInterface operation waiting for the response before returning.
@@ -4620,7 +4620,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func detachVpnGatewayAsync(input: ElasticComputeCloudModel.DetachVpnGatewayRequest, completion: @escaping (Error?) -> ()) throws
+    func detachVpnGatewayAsync(input: ElasticComputeCloudModel.DetachVpnGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DetachVpnGateway operation waiting for the response before returning.
@@ -4638,7 +4638,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func disableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest, completion: @escaping (Error?) -> ()) throws
+    func disableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DisableVgwRoutePropagation operation waiting for the response before returning.
@@ -4698,7 +4698,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func disassociateAddressAsync(input: ElasticComputeCloudModel.DisassociateAddressRequest, completion: @escaping (Error?) -> ()) throws
+    func disassociateAddressAsync(input: ElasticComputeCloudModel.DisassociateAddressRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DisassociateAddress operation waiting for the response before returning.
@@ -4737,7 +4737,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func disassociateRouteTableAsync(input: ElasticComputeCloudModel.DisassociateRouteTableRequest, completion: @escaping (Error?) -> ()) throws
+    func disassociateRouteTableAsync(input: ElasticComputeCloudModel.DisassociateRouteTableRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DisassociateRouteTable operation waiting for the response before returning.
@@ -4797,7 +4797,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func enableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest, completion: @escaping (Error?) -> ()) throws
+    func enableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the EnableVgwRoutePropagation operation waiting for the response before returning.
@@ -4815,7 +4815,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func enableVolumeIOAsync(input: ElasticComputeCloudModel.EnableVolumeIORequest, completion: @escaping (Error?) -> ()) throws
+    func enableVolumeIOAsync(input: ElasticComputeCloudModel.EnableVolumeIORequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the EnableVolumeIO operation waiting for the response before returning.
@@ -5190,7 +5190,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func modifyIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdFormatRequest, completion: @escaping (Error?) -> ()) throws
+    func modifyIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdFormatRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ModifyIdFormat operation waiting for the response before returning.
@@ -5208,7 +5208,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func modifyIdentityIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest, completion: @escaping (Error?) -> ()) throws
+    func modifyIdentityIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ModifyIdentityIdFormat operation waiting for the response before returning.
@@ -5226,7 +5226,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func modifyImageAttributeAsync(input: ElasticComputeCloudModel.ModifyImageAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func modifyImageAttributeAsync(input: ElasticComputeCloudModel.ModifyImageAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ModifyImageAttribute operation waiting for the response before returning.
@@ -5244,7 +5244,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func modifyInstanceAttributeAsync(input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func modifyInstanceAttributeAsync(input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ModifyInstanceAttribute operation waiting for the response before returning.
@@ -5346,7 +5346,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func modifyNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func modifyNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ModifyNetworkInterfaceAttribute operation waiting for the response before returning.
@@ -5385,7 +5385,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func modifySnapshotAttributeAsync(input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func modifySnapshotAttributeAsync(input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ModifySnapshotAttribute operation waiting for the response before returning.
@@ -5424,7 +5424,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func modifySubnetAttributeAsync(input: ElasticComputeCloudModel.ModifySubnetAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func modifySubnetAttributeAsync(input: ElasticComputeCloudModel.ModifySubnetAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ModifySubnetAttribute operation waiting for the response before returning.
@@ -5463,7 +5463,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func modifyVolumeAttributeAsync(input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func modifyVolumeAttributeAsync(input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ModifyVolumeAttribute operation waiting for the response before returning.
@@ -5481,7 +5481,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func modifyVpcAttributeAsync(input: ElasticComputeCloudModel.ModifyVpcAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func modifyVpcAttributeAsync(input: ElasticComputeCloudModel.ModifyVpcAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ModifyVpcAttribute operation waiting for the response before returning.
@@ -5751,7 +5751,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func rebootInstancesAsync(input: ElasticComputeCloudModel.RebootInstancesRequest, completion: @escaping (Error?) -> ()) throws
+    func rebootInstancesAsync(input: ElasticComputeCloudModel.RebootInstancesRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RebootInstances operation waiting for the response before returning.
@@ -5832,7 +5832,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func releaseAddressAsync(input: ElasticComputeCloudModel.ReleaseAddressRequest, completion: @escaping (Error?) -> ()) throws
+    func releaseAddressAsync(input: ElasticComputeCloudModel.ReleaseAddressRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ReleaseAddress operation waiting for the response before returning.
@@ -5913,7 +5913,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func replaceNetworkAclEntryAsync(input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws
+    func replaceNetworkAclEntryAsync(input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ReplaceNetworkAclEntry operation waiting for the response before returning.
@@ -5931,7 +5931,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func replaceRouteAsync(input: ElasticComputeCloudModel.ReplaceRouteRequest, completion: @escaping (Error?) -> ()) throws
+    func replaceRouteAsync(input: ElasticComputeCloudModel.ReplaceRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ReplaceRoute operation waiting for the response before returning.
@@ -5970,7 +5970,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func reportInstanceStatusAsync(input: ElasticComputeCloudModel.ReportInstanceStatusRequest, completion: @escaping (Error?) -> ()) throws
+    func reportInstanceStatusAsync(input: ElasticComputeCloudModel.ReportInstanceStatusRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ReportInstanceStatus operation waiting for the response before returning.
@@ -6051,7 +6051,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func resetImageAttributeAsync(input: ElasticComputeCloudModel.ResetImageAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func resetImageAttributeAsync(input: ElasticComputeCloudModel.ResetImageAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ResetImageAttribute operation waiting for the response before returning.
@@ -6069,7 +6069,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func resetInstanceAttributeAsync(input: ElasticComputeCloudModel.ResetInstanceAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func resetInstanceAttributeAsync(input: ElasticComputeCloudModel.ResetInstanceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ResetInstanceAttribute operation waiting for the response before returning.
@@ -6087,7 +6087,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func resetNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func resetNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ResetNetworkInterfaceAttribute operation waiting for the response before returning.
@@ -6105,7 +6105,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func resetSnapshotAttributeAsync(input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest, completion: @escaping (Error?) -> ()) throws
+    func resetSnapshotAttributeAsync(input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ResetSnapshotAttribute operation waiting for the response before returning.
@@ -6144,7 +6144,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func revokeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest, completion: @escaping (Error?) -> ()) throws
+    func revokeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RevokeSecurityGroupEgress operation waiting for the response before returning.
@@ -6162,7 +6162,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func revokeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest, completion: @escaping (Error?) -> ()) throws
+    func revokeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RevokeSecurityGroupIngress operation waiting for the response before returning.
@@ -6306,7 +6306,7 @@ public protocol ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func unassignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest, completion: @escaping (Error?) -> ()) throws
+    func unassignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the UnassignPrivateIpAddresses operation waiting for the response before returning.

--- a/Sources/ElasticComputeCloudClient/ElasticComputeCloudOperationsClientOutput.swift
+++ b/Sources/ElasticComputeCloudClient/ElasticComputeCloudOperationsClientOutput.swift
@@ -1,0 +1,2924 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// ElasticComputeCloudOperationsClientOutput.swift
+// ElasticComputeCloudClient
+//
+
+import Foundation
+import SmokeHTTPClient
+import ElasticComputeCloudModel
+
+/**
+ Type to handle the output from the AcceptReservedInstancesExchangeQuote operation in a HTTP client.
+ */
+extension AcceptReservedInstancesExchangeQuoteResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AcceptReservedInstancesExchangeQuoteResult
+    public typealias HeadersType = AcceptReservedInstancesExchangeQuoteResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AcceptReservedInstancesExchangeQuoteResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AcceptVpcEndpointConnections operation in a HTTP client.
+ */
+extension AcceptVpcEndpointConnectionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AcceptVpcEndpointConnectionsResult
+    public typealias HeadersType = AcceptVpcEndpointConnectionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AcceptVpcEndpointConnectionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AcceptVpcPeeringConnection operation in a HTTP client.
+ */
+extension AcceptVpcPeeringConnectionResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AcceptVpcPeeringConnectionResult
+    public typealias HeadersType = AcceptVpcPeeringConnectionResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AcceptVpcPeeringConnectionResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AdvertiseByoipCidr operation in a HTTP client.
+ */
+extension AdvertiseByoipCidrResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AdvertiseByoipCidrResult
+    public typealias HeadersType = AdvertiseByoipCidrResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AdvertiseByoipCidrResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AllocateAddress operation in a HTTP client.
+ */
+extension AllocateAddressResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AllocateAddressResult
+    public typealias HeadersType = AllocateAddressResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AllocateAddressResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AllocateHosts operation in a HTTP client.
+ */
+extension AllocateHostsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AllocateHostsResult
+    public typealias HeadersType = AllocateHostsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AllocateHostsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AssignIpv6Addresses operation in a HTTP client.
+ */
+extension AssignIpv6AddressesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AssignIpv6AddressesResult
+    public typealias HeadersType = AssignIpv6AddressesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AssignIpv6AddressesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AssociateAddress operation in a HTTP client.
+ */
+extension AssociateAddressResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AssociateAddressResult
+    public typealias HeadersType = AssociateAddressResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AssociateAddressResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AssociateIamInstanceProfile operation in a HTTP client.
+ */
+extension AssociateIamInstanceProfileResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AssociateIamInstanceProfileResult
+    public typealias HeadersType = AssociateIamInstanceProfileResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AssociateIamInstanceProfileResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AssociateRouteTable operation in a HTTP client.
+ */
+extension AssociateRouteTableResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AssociateRouteTableResult
+    public typealias HeadersType = AssociateRouteTableResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AssociateRouteTableResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AssociateSubnetCidrBlock operation in a HTTP client.
+ */
+extension AssociateSubnetCidrBlockResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AssociateSubnetCidrBlockResult
+    public typealias HeadersType = AssociateSubnetCidrBlockResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AssociateSubnetCidrBlockResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AssociateVpcCidrBlock operation in a HTTP client.
+ */
+extension AssociateVpcCidrBlockResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AssociateVpcCidrBlockResult
+    public typealias HeadersType = AssociateVpcCidrBlockResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AssociateVpcCidrBlockResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AttachClassicLinkVpc operation in a HTTP client.
+ */
+extension AttachClassicLinkVpcResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AttachClassicLinkVpcResult
+    public typealias HeadersType = AttachClassicLinkVpcResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AttachClassicLinkVpcResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AttachNetworkInterface operation in a HTTP client.
+ */
+extension AttachNetworkInterfaceResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AttachNetworkInterfaceResult
+    public typealias HeadersType = AttachNetworkInterfaceResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AttachNetworkInterfaceResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AttachVolume operation in a HTTP client.
+ */
+extension VolumeAttachment: HTTPResponseOutputProtocol {
+    public typealias BodyType = VolumeAttachment
+    public typealias HeadersType = VolumeAttachment
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> VolumeAttachment {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AttachVpnGateway operation in a HTTP client.
+ */
+extension AttachVpnGatewayResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = AttachVpnGatewayResult
+    public typealias HeadersType = AttachVpnGatewayResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AttachVpnGatewayResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the BundleInstance operation in a HTTP client.
+ */
+extension BundleInstanceResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = BundleInstanceResult
+    public typealias HeadersType = BundleInstanceResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> BundleInstanceResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CancelBundleTask operation in a HTTP client.
+ */
+extension CancelBundleTaskResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CancelBundleTaskResult
+    public typealias HeadersType = CancelBundleTaskResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CancelBundleTaskResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CancelCapacityReservation operation in a HTTP client.
+ */
+extension CancelCapacityReservationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CancelCapacityReservationResult
+    public typealias HeadersType = CancelCapacityReservationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CancelCapacityReservationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CancelImportTask operation in a HTTP client.
+ */
+extension CancelImportTaskResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CancelImportTaskResult
+    public typealias HeadersType = CancelImportTaskResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CancelImportTaskResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CancelReservedInstancesListing operation in a HTTP client.
+ */
+extension CancelReservedInstancesListingResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CancelReservedInstancesListingResult
+    public typealias HeadersType = CancelReservedInstancesListingResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CancelReservedInstancesListingResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CancelSpotFleetRequests operation in a HTTP client.
+ */
+extension CancelSpotFleetRequestsResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = CancelSpotFleetRequestsResponse
+    public typealias HeadersType = CancelSpotFleetRequestsResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CancelSpotFleetRequestsResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CancelSpotInstanceRequests operation in a HTTP client.
+ */
+extension CancelSpotInstanceRequestsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CancelSpotInstanceRequestsResult
+    public typealias HeadersType = CancelSpotInstanceRequestsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CancelSpotInstanceRequestsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ConfirmProductInstance operation in a HTTP client.
+ */
+extension ConfirmProductInstanceResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ConfirmProductInstanceResult
+    public typealias HeadersType = ConfirmProductInstanceResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ConfirmProductInstanceResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CopyFpgaImage operation in a HTTP client.
+ */
+extension CopyFpgaImageResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CopyFpgaImageResult
+    public typealias HeadersType = CopyFpgaImageResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CopyFpgaImageResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CopyImage operation in a HTTP client.
+ */
+extension CopyImageResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CopyImageResult
+    public typealias HeadersType = CopyImageResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CopyImageResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CopySnapshot operation in a HTTP client.
+ */
+extension CopySnapshotResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CopySnapshotResult
+    public typealias HeadersType = CopySnapshotResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CopySnapshotResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateCapacityReservation operation in a HTTP client.
+ */
+extension CreateCapacityReservationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateCapacityReservationResult
+    public typealias HeadersType = CreateCapacityReservationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateCapacityReservationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateCustomerGateway operation in a HTTP client.
+ */
+extension CreateCustomerGatewayResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateCustomerGatewayResult
+    public typealias HeadersType = CreateCustomerGatewayResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateCustomerGatewayResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateDefaultSubnet operation in a HTTP client.
+ */
+extension CreateDefaultSubnetResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateDefaultSubnetResult
+    public typealias HeadersType = CreateDefaultSubnetResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateDefaultSubnetResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateDefaultVpc operation in a HTTP client.
+ */
+extension CreateDefaultVpcResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateDefaultVpcResult
+    public typealias HeadersType = CreateDefaultVpcResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateDefaultVpcResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateDhcpOptions operation in a HTTP client.
+ */
+extension CreateDhcpOptionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateDhcpOptionsResult
+    public typealias HeadersType = CreateDhcpOptionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateDhcpOptionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateEgressOnlyInternetGateway operation in a HTTP client.
+ */
+extension CreateEgressOnlyInternetGatewayResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateEgressOnlyInternetGatewayResult
+    public typealias HeadersType = CreateEgressOnlyInternetGatewayResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateEgressOnlyInternetGatewayResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateFleet operation in a HTTP client.
+ */
+extension CreateFleetResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateFleetResult
+    public typealias HeadersType = CreateFleetResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateFleetResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateFlowLogs operation in a HTTP client.
+ */
+extension CreateFlowLogsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateFlowLogsResult
+    public typealias HeadersType = CreateFlowLogsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateFlowLogsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateFpgaImage operation in a HTTP client.
+ */
+extension CreateFpgaImageResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateFpgaImageResult
+    public typealias HeadersType = CreateFpgaImageResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateFpgaImageResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateImage operation in a HTTP client.
+ */
+extension CreateImageResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateImageResult
+    public typealias HeadersType = CreateImageResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateImageResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateInstanceExportTask operation in a HTTP client.
+ */
+extension CreateInstanceExportTaskResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateInstanceExportTaskResult
+    public typealias HeadersType = CreateInstanceExportTaskResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateInstanceExportTaskResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateInternetGateway operation in a HTTP client.
+ */
+extension CreateInternetGatewayResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateInternetGatewayResult
+    public typealias HeadersType = CreateInternetGatewayResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateInternetGatewayResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateKeyPair operation in a HTTP client.
+ */
+extension KeyPair: HTTPResponseOutputProtocol {
+    public typealias BodyType = KeyPair
+    public typealias HeadersType = KeyPair
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> KeyPair {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateLaunchTemplate operation in a HTTP client.
+ */
+extension CreateLaunchTemplateResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateLaunchTemplateResult
+    public typealias HeadersType = CreateLaunchTemplateResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateLaunchTemplateResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateLaunchTemplateVersion operation in a HTTP client.
+ */
+extension CreateLaunchTemplateVersionResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateLaunchTemplateVersionResult
+    public typealias HeadersType = CreateLaunchTemplateVersionResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateLaunchTemplateVersionResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateNatGateway operation in a HTTP client.
+ */
+extension CreateNatGatewayResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateNatGatewayResult
+    public typealias HeadersType = CreateNatGatewayResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateNatGatewayResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateNetworkAcl operation in a HTTP client.
+ */
+extension CreateNetworkAclResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateNetworkAclResult
+    public typealias HeadersType = CreateNetworkAclResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateNetworkAclResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateNetworkInterface operation in a HTTP client.
+ */
+extension CreateNetworkInterfaceResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateNetworkInterfaceResult
+    public typealias HeadersType = CreateNetworkInterfaceResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateNetworkInterfaceResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateNetworkInterfacePermission operation in a HTTP client.
+ */
+extension CreateNetworkInterfacePermissionResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateNetworkInterfacePermissionResult
+    public typealias HeadersType = CreateNetworkInterfacePermissionResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateNetworkInterfacePermissionResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateReservedInstancesListing operation in a HTTP client.
+ */
+extension CreateReservedInstancesListingResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateReservedInstancesListingResult
+    public typealias HeadersType = CreateReservedInstancesListingResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateReservedInstancesListingResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateRoute operation in a HTTP client.
+ */
+extension CreateRouteResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateRouteResult
+    public typealias HeadersType = CreateRouteResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateRouteResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateRouteTable operation in a HTTP client.
+ */
+extension CreateRouteTableResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateRouteTableResult
+    public typealias HeadersType = CreateRouteTableResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateRouteTableResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateSecurityGroup operation in a HTTP client.
+ */
+extension CreateSecurityGroupResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateSecurityGroupResult
+    public typealias HeadersType = CreateSecurityGroupResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateSecurityGroupResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateSnapshot operation in a HTTP client.
+ */
+extension Snapshot: HTTPResponseOutputProtocol {
+    public typealias BodyType = Snapshot
+    public typealias HeadersType = Snapshot
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> Snapshot {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateSpotDatafeedSubscription operation in a HTTP client.
+ */
+extension CreateSpotDatafeedSubscriptionResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateSpotDatafeedSubscriptionResult
+    public typealias HeadersType = CreateSpotDatafeedSubscriptionResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateSpotDatafeedSubscriptionResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateSubnet operation in a HTTP client.
+ */
+extension CreateSubnetResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateSubnetResult
+    public typealias HeadersType = CreateSubnetResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateSubnetResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateVolume operation in a HTTP client.
+ */
+extension Volume: HTTPResponseOutputProtocol {
+    public typealias BodyType = Volume
+    public typealias HeadersType = Volume
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> Volume {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateVpc operation in a HTTP client.
+ */
+extension CreateVpcResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateVpcResult
+    public typealias HeadersType = CreateVpcResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateVpcResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateVpcEndpoint operation in a HTTP client.
+ */
+extension CreateVpcEndpointResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateVpcEndpointResult
+    public typealias HeadersType = CreateVpcEndpointResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateVpcEndpointResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateVpcEndpointConnectionNotification operation in a HTTP client.
+ */
+extension CreateVpcEndpointConnectionNotificationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateVpcEndpointConnectionNotificationResult
+    public typealias HeadersType = CreateVpcEndpointConnectionNotificationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateVpcEndpointConnectionNotificationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateVpcEndpointServiceConfiguration operation in a HTTP client.
+ */
+extension CreateVpcEndpointServiceConfigurationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateVpcEndpointServiceConfigurationResult
+    public typealias HeadersType = CreateVpcEndpointServiceConfigurationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateVpcEndpointServiceConfigurationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateVpcPeeringConnection operation in a HTTP client.
+ */
+extension CreateVpcPeeringConnectionResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateVpcPeeringConnectionResult
+    public typealias HeadersType = CreateVpcPeeringConnectionResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateVpcPeeringConnectionResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateVpnConnection operation in a HTTP client.
+ */
+extension CreateVpnConnectionResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateVpnConnectionResult
+    public typealias HeadersType = CreateVpnConnectionResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateVpnConnectionResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateVpnGateway operation in a HTTP client.
+ */
+extension CreateVpnGatewayResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateVpnGatewayResult
+    public typealias HeadersType = CreateVpnGatewayResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateVpnGatewayResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteEgressOnlyInternetGateway operation in a HTTP client.
+ */
+extension DeleteEgressOnlyInternetGatewayResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteEgressOnlyInternetGatewayResult
+    public typealias HeadersType = DeleteEgressOnlyInternetGatewayResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteEgressOnlyInternetGatewayResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteFleets operation in a HTTP client.
+ */
+extension DeleteFleetsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteFleetsResult
+    public typealias HeadersType = DeleteFleetsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteFleetsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteFlowLogs operation in a HTTP client.
+ */
+extension DeleteFlowLogsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteFlowLogsResult
+    public typealias HeadersType = DeleteFlowLogsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteFlowLogsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteFpgaImage operation in a HTTP client.
+ */
+extension DeleteFpgaImageResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteFpgaImageResult
+    public typealias HeadersType = DeleteFpgaImageResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteFpgaImageResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteLaunchTemplate operation in a HTTP client.
+ */
+extension DeleteLaunchTemplateResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteLaunchTemplateResult
+    public typealias HeadersType = DeleteLaunchTemplateResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteLaunchTemplateResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteLaunchTemplateVersions operation in a HTTP client.
+ */
+extension DeleteLaunchTemplateVersionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteLaunchTemplateVersionsResult
+    public typealias HeadersType = DeleteLaunchTemplateVersionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteLaunchTemplateVersionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteNatGateway operation in a HTTP client.
+ */
+extension DeleteNatGatewayResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteNatGatewayResult
+    public typealias HeadersType = DeleteNatGatewayResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteNatGatewayResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteNetworkInterfacePermission operation in a HTTP client.
+ */
+extension DeleteNetworkInterfacePermissionResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteNetworkInterfacePermissionResult
+    public typealias HeadersType = DeleteNetworkInterfacePermissionResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteNetworkInterfacePermissionResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteVpcEndpointConnectionNotifications operation in a HTTP client.
+ */
+extension DeleteVpcEndpointConnectionNotificationsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteVpcEndpointConnectionNotificationsResult
+    public typealias HeadersType = DeleteVpcEndpointConnectionNotificationsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteVpcEndpointConnectionNotificationsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteVpcEndpointServiceConfigurations operation in a HTTP client.
+ */
+extension DeleteVpcEndpointServiceConfigurationsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteVpcEndpointServiceConfigurationsResult
+    public typealias HeadersType = DeleteVpcEndpointServiceConfigurationsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteVpcEndpointServiceConfigurationsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteVpcEndpoints operation in a HTTP client.
+ */
+extension DeleteVpcEndpointsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteVpcEndpointsResult
+    public typealias HeadersType = DeleteVpcEndpointsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteVpcEndpointsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteVpcPeeringConnection operation in a HTTP client.
+ */
+extension DeleteVpcPeeringConnectionResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteVpcPeeringConnectionResult
+    public typealias HeadersType = DeleteVpcPeeringConnectionResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteVpcPeeringConnectionResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeprovisionByoipCidr operation in a HTTP client.
+ */
+extension DeprovisionByoipCidrResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeprovisionByoipCidrResult
+    public typealias HeadersType = DeprovisionByoipCidrResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeprovisionByoipCidrResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeAccountAttributes operation in a HTTP client.
+ */
+extension DescribeAccountAttributesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeAccountAttributesResult
+    public typealias HeadersType = DescribeAccountAttributesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeAccountAttributesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeAddresses operation in a HTTP client.
+ */
+extension DescribeAddressesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeAddressesResult
+    public typealias HeadersType = DescribeAddressesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeAddressesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeAggregateIdFormat operation in a HTTP client.
+ */
+extension DescribeAggregateIdFormatResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeAggregateIdFormatResult
+    public typealias HeadersType = DescribeAggregateIdFormatResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeAggregateIdFormatResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeAvailabilityZones operation in a HTTP client.
+ */
+extension DescribeAvailabilityZonesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeAvailabilityZonesResult
+    public typealias HeadersType = DescribeAvailabilityZonesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeAvailabilityZonesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeBundleTasks operation in a HTTP client.
+ */
+extension DescribeBundleTasksResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeBundleTasksResult
+    public typealias HeadersType = DescribeBundleTasksResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeBundleTasksResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeByoipCidrs operation in a HTTP client.
+ */
+extension DescribeByoipCidrsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeByoipCidrsResult
+    public typealias HeadersType = DescribeByoipCidrsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeByoipCidrsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeCapacityReservations operation in a HTTP client.
+ */
+extension DescribeCapacityReservationsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeCapacityReservationsResult
+    public typealias HeadersType = DescribeCapacityReservationsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeCapacityReservationsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeClassicLinkInstances operation in a HTTP client.
+ */
+extension DescribeClassicLinkInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeClassicLinkInstancesResult
+    public typealias HeadersType = DescribeClassicLinkInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeClassicLinkInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeConversionTasks operation in a HTTP client.
+ */
+extension DescribeConversionTasksResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeConversionTasksResult
+    public typealias HeadersType = DescribeConversionTasksResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeConversionTasksResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeCustomerGateways operation in a HTTP client.
+ */
+extension DescribeCustomerGatewaysResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeCustomerGatewaysResult
+    public typealias HeadersType = DescribeCustomerGatewaysResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeCustomerGatewaysResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeDhcpOptions operation in a HTTP client.
+ */
+extension DescribeDhcpOptionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeDhcpOptionsResult
+    public typealias HeadersType = DescribeDhcpOptionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeDhcpOptionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeEgressOnlyInternetGateways operation in a HTTP client.
+ */
+extension DescribeEgressOnlyInternetGatewaysResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeEgressOnlyInternetGatewaysResult
+    public typealias HeadersType = DescribeEgressOnlyInternetGatewaysResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeEgressOnlyInternetGatewaysResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeElasticGpus operation in a HTTP client.
+ */
+extension DescribeElasticGpusResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeElasticGpusResult
+    public typealias HeadersType = DescribeElasticGpusResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeElasticGpusResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeExportTasks operation in a HTTP client.
+ */
+extension DescribeExportTasksResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeExportTasksResult
+    public typealias HeadersType = DescribeExportTasksResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeExportTasksResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeFleetHistory operation in a HTTP client.
+ */
+extension DescribeFleetHistoryResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeFleetHistoryResult
+    public typealias HeadersType = DescribeFleetHistoryResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeFleetHistoryResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeFleetInstances operation in a HTTP client.
+ */
+extension DescribeFleetInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeFleetInstancesResult
+    public typealias HeadersType = DescribeFleetInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeFleetInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeFleets operation in a HTTP client.
+ */
+extension DescribeFleetsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeFleetsResult
+    public typealias HeadersType = DescribeFleetsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeFleetsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeFlowLogs operation in a HTTP client.
+ */
+extension DescribeFlowLogsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeFlowLogsResult
+    public typealias HeadersType = DescribeFlowLogsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeFlowLogsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeFpgaImageAttribute operation in a HTTP client.
+ */
+extension DescribeFpgaImageAttributeResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeFpgaImageAttributeResult
+    public typealias HeadersType = DescribeFpgaImageAttributeResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeFpgaImageAttributeResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeFpgaImages operation in a HTTP client.
+ */
+extension DescribeFpgaImagesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeFpgaImagesResult
+    public typealias HeadersType = DescribeFpgaImagesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeFpgaImagesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeHostReservationOfferings operation in a HTTP client.
+ */
+extension DescribeHostReservationOfferingsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeHostReservationOfferingsResult
+    public typealias HeadersType = DescribeHostReservationOfferingsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeHostReservationOfferingsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeHostReservations operation in a HTTP client.
+ */
+extension DescribeHostReservationsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeHostReservationsResult
+    public typealias HeadersType = DescribeHostReservationsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeHostReservationsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeHosts operation in a HTTP client.
+ */
+extension DescribeHostsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeHostsResult
+    public typealias HeadersType = DescribeHostsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeHostsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeIamInstanceProfileAssociations operation in a HTTP client.
+ */
+extension DescribeIamInstanceProfileAssociationsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeIamInstanceProfileAssociationsResult
+    public typealias HeadersType = DescribeIamInstanceProfileAssociationsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeIamInstanceProfileAssociationsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeIdFormat operation in a HTTP client.
+ */
+extension DescribeIdFormatResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeIdFormatResult
+    public typealias HeadersType = DescribeIdFormatResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeIdFormatResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeIdentityIdFormat operation in a HTTP client.
+ */
+extension DescribeIdentityIdFormatResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeIdentityIdFormatResult
+    public typealias HeadersType = DescribeIdentityIdFormatResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeIdentityIdFormatResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeImageAttribute operation in a HTTP client.
+ */
+extension ImageAttribute: HTTPResponseOutputProtocol {
+    public typealias BodyType = ImageAttribute
+    public typealias HeadersType = ImageAttribute
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ImageAttribute {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeImages operation in a HTTP client.
+ */
+extension DescribeImagesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeImagesResult
+    public typealias HeadersType = DescribeImagesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeImagesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeImportImageTasks operation in a HTTP client.
+ */
+extension DescribeImportImageTasksResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeImportImageTasksResult
+    public typealias HeadersType = DescribeImportImageTasksResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeImportImageTasksResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeImportSnapshotTasks operation in a HTTP client.
+ */
+extension DescribeImportSnapshotTasksResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeImportSnapshotTasksResult
+    public typealias HeadersType = DescribeImportSnapshotTasksResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeImportSnapshotTasksResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeInstanceAttribute operation in a HTTP client.
+ */
+extension InstanceAttribute: HTTPResponseOutputProtocol {
+    public typealias BodyType = InstanceAttribute
+    public typealias HeadersType = InstanceAttribute
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> InstanceAttribute {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeInstanceCreditSpecifications operation in a HTTP client.
+ */
+extension DescribeInstanceCreditSpecificationsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeInstanceCreditSpecificationsResult
+    public typealias HeadersType = DescribeInstanceCreditSpecificationsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeInstanceCreditSpecificationsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeInstanceStatus operation in a HTTP client.
+ */
+extension DescribeInstanceStatusResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeInstanceStatusResult
+    public typealias HeadersType = DescribeInstanceStatusResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeInstanceStatusResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeInstances operation in a HTTP client.
+ */
+extension DescribeInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeInstancesResult
+    public typealias HeadersType = DescribeInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeInternetGateways operation in a HTTP client.
+ */
+extension DescribeInternetGatewaysResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeInternetGatewaysResult
+    public typealias HeadersType = DescribeInternetGatewaysResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeInternetGatewaysResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeKeyPairs operation in a HTTP client.
+ */
+extension DescribeKeyPairsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeKeyPairsResult
+    public typealias HeadersType = DescribeKeyPairsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeKeyPairsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeLaunchTemplateVersions operation in a HTTP client.
+ */
+extension DescribeLaunchTemplateVersionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeLaunchTemplateVersionsResult
+    public typealias HeadersType = DescribeLaunchTemplateVersionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeLaunchTemplateVersionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeLaunchTemplates operation in a HTTP client.
+ */
+extension DescribeLaunchTemplatesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeLaunchTemplatesResult
+    public typealias HeadersType = DescribeLaunchTemplatesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeLaunchTemplatesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeMovingAddresses operation in a HTTP client.
+ */
+extension DescribeMovingAddressesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeMovingAddressesResult
+    public typealias HeadersType = DescribeMovingAddressesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeMovingAddressesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeNatGateways operation in a HTTP client.
+ */
+extension DescribeNatGatewaysResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeNatGatewaysResult
+    public typealias HeadersType = DescribeNatGatewaysResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeNatGatewaysResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeNetworkAcls operation in a HTTP client.
+ */
+extension DescribeNetworkAclsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeNetworkAclsResult
+    public typealias HeadersType = DescribeNetworkAclsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeNetworkAclsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeNetworkInterfaceAttribute operation in a HTTP client.
+ */
+extension DescribeNetworkInterfaceAttributeResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeNetworkInterfaceAttributeResult
+    public typealias HeadersType = DescribeNetworkInterfaceAttributeResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeNetworkInterfaceAttributeResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeNetworkInterfacePermissions operation in a HTTP client.
+ */
+extension DescribeNetworkInterfacePermissionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeNetworkInterfacePermissionsResult
+    public typealias HeadersType = DescribeNetworkInterfacePermissionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeNetworkInterfacePermissionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeNetworkInterfaces operation in a HTTP client.
+ */
+extension DescribeNetworkInterfacesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeNetworkInterfacesResult
+    public typealias HeadersType = DescribeNetworkInterfacesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeNetworkInterfacesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribePlacementGroups operation in a HTTP client.
+ */
+extension DescribePlacementGroupsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribePlacementGroupsResult
+    public typealias HeadersType = DescribePlacementGroupsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribePlacementGroupsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribePrefixLists operation in a HTTP client.
+ */
+extension DescribePrefixListsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribePrefixListsResult
+    public typealias HeadersType = DescribePrefixListsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribePrefixListsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribePrincipalIdFormat operation in a HTTP client.
+ */
+extension DescribePrincipalIdFormatResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribePrincipalIdFormatResult
+    public typealias HeadersType = DescribePrincipalIdFormatResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribePrincipalIdFormatResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribePublicIpv4Pools operation in a HTTP client.
+ */
+extension DescribePublicIpv4PoolsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribePublicIpv4PoolsResult
+    public typealias HeadersType = DescribePublicIpv4PoolsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribePublicIpv4PoolsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeRegions operation in a HTTP client.
+ */
+extension DescribeRegionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeRegionsResult
+    public typealias HeadersType = DescribeRegionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeRegionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeReservedInstances operation in a HTTP client.
+ */
+extension DescribeReservedInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeReservedInstancesResult
+    public typealias HeadersType = DescribeReservedInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeReservedInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeReservedInstancesListings operation in a HTTP client.
+ */
+extension DescribeReservedInstancesListingsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeReservedInstancesListingsResult
+    public typealias HeadersType = DescribeReservedInstancesListingsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeReservedInstancesListingsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeReservedInstancesModifications operation in a HTTP client.
+ */
+extension DescribeReservedInstancesModificationsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeReservedInstancesModificationsResult
+    public typealias HeadersType = DescribeReservedInstancesModificationsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeReservedInstancesModificationsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeReservedInstancesOfferings operation in a HTTP client.
+ */
+extension DescribeReservedInstancesOfferingsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeReservedInstancesOfferingsResult
+    public typealias HeadersType = DescribeReservedInstancesOfferingsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeReservedInstancesOfferingsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeRouteTables operation in a HTTP client.
+ */
+extension DescribeRouteTablesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeRouteTablesResult
+    public typealias HeadersType = DescribeRouteTablesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeRouteTablesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeScheduledInstanceAvailability operation in a HTTP client.
+ */
+extension DescribeScheduledInstanceAvailabilityResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeScheduledInstanceAvailabilityResult
+    public typealias HeadersType = DescribeScheduledInstanceAvailabilityResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeScheduledInstanceAvailabilityResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeScheduledInstances operation in a HTTP client.
+ */
+extension DescribeScheduledInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeScheduledInstancesResult
+    public typealias HeadersType = DescribeScheduledInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeScheduledInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSecurityGroupReferences operation in a HTTP client.
+ */
+extension DescribeSecurityGroupReferencesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSecurityGroupReferencesResult
+    public typealias HeadersType = DescribeSecurityGroupReferencesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSecurityGroupReferencesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSecurityGroups operation in a HTTP client.
+ */
+extension DescribeSecurityGroupsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSecurityGroupsResult
+    public typealias HeadersType = DescribeSecurityGroupsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSecurityGroupsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSnapshotAttribute operation in a HTTP client.
+ */
+extension DescribeSnapshotAttributeResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSnapshotAttributeResult
+    public typealias HeadersType = DescribeSnapshotAttributeResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSnapshotAttributeResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSnapshots operation in a HTTP client.
+ */
+extension DescribeSnapshotsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSnapshotsResult
+    public typealias HeadersType = DescribeSnapshotsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSnapshotsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSpotDatafeedSubscription operation in a HTTP client.
+ */
+extension DescribeSpotDatafeedSubscriptionResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSpotDatafeedSubscriptionResult
+    public typealias HeadersType = DescribeSpotDatafeedSubscriptionResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSpotDatafeedSubscriptionResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSpotFleetInstances operation in a HTTP client.
+ */
+extension DescribeSpotFleetInstancesResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSpotFleetInstancesResponse
+    public typealias HeadersType = DescribeSpotFleetInstancesResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSpotFleetInstancesResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSpotFleetRequestHistory operation in a HTTP client.
+ */
+extension DescribeSpotFleetRequestHistoryResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSpotFleetRequestHistoryResponse
+    public typealias HeadersType = DescribeSpotFleetRequestHistoryResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSpotFleetRequestHistoryResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSpotFleetRequests operation in a HTTP client.
+ */
+extension DescribeSpotFleetRequestsResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSpotFleetRequestsResponse
+    public typealias HeadersType = DescribeSpotFleetRequestsResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSpotFleetRequestsResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSpotInstanceRequests operation in a HTTP client.
+ */
+extension DescribeSpotInstanceRequestsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSpotInstanceRequestsResult
+    public typealias HeadersType = DescribeSpotInstanceRequestsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSpotInstanceRequestsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSpotPriceHistory operation in a HTTP client.
+ */
+extension DescribeSpotPriceHistoryResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSpotPriceHistoryResult
+    public typealias HeadersType = DescribeSpotPriceHistoryResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSpotPriceHistoryResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeStaleSecurityGroups operation in a HTTP client.
+ */
+extension DescribeStaleSecurityGroupsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeStaleSecurityGroupsResult
+    public typealias HeadersType = DescribeStaleSecurityGroupsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeStaleSecurityGroupsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeSubnets operation in a HTTP client.
+ */
+extension DescribeSubnetsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeSubnetsResult
+    public typealias HeadersType = DescribeSubnetsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeSubnetsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeTags operation in a HTTP client.
+ */
+extension DescribeTagsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeTagsResult
+    public typealias HeadersType = DescribeTagsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeTagsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVolumeAttribute operation in a HTTP client.
+ */
+extension DescribeVolumeAttributeResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVolumeAttributeResult
+    public typealias HeadersType = DescribeVolumeAttributeResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVolumeAttributeResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVolumeStatus operation in a HTTP client.
+ */
+extension DescribeVolumeStatusResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVolumeStatusResult
+    public typealias HeadersType = DescribeVolumeStatusResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVolumeStatusResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVolumes operation in a HTTP client.
+ */
+extension DescribeVolumesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVolumesResult
+    public typealias HeadersType = DescribeVolumesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVolumesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVolumesModifications operation in a HTTP client.
+ */
+extension DescribeVolumesModificationsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVolumesModificationsResult
+    public typealias HeadersType = DescribeVolumesModificationsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVolumesModificationsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcAttribute operation in a HTTP client.
+ */
+extension DescribeVpcAttributeResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcAttributeResult
+    public typealias HeadersType = DescribeVpcAttributeResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcAttributeResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcClassicLink operation in a HTTP client.
+ */
+extension DescribeVpcClassicLinkResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcClassicLinkResult
+    public typealias HeadersType = DescribeVpcClassicLinkResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcClassicLinkResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcClassicLinkDnsSupport operation in a HTTP client.
+ */
+extension DescribeVpcClassicLinkDnsSupportResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcClassicLinkDnsSupportResult
+    public typealias HeadersType = DescribeVpcClassicLinkDnsSupportResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcClassicLinkDnsSupportResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcEndpointConnectionNotifications operation in a HTTP client.
+ */
+extension DescribeVpcEndpointConnectionNotificationsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcEndpointConnectionNotificationsResult
+    public typealias HeadersType = DescribeVpcEndpointConnectionNotificationsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcEndpointConnectionNotificationsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcEndpointConnections operation in a HTTP client.
+ */
+extension DescribeVpcEndpointConnectionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcEndpointConnectionsResult
+    public typealias HeadersType = DescribeVpcEndpointConnectionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcEndpointConnectionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcEndpointServiceConfigurations operation in a HTTP client.
+ */
+extension DescribeVpcEndpointServiceConfigurationsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcEndpointServiceConfigurationsResult
+    public typealias HeadersType = DescribeVpcEndpointServiceConfigurationsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcEndpointServiceConfigurationsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcEndpointServicePermissions operation in a HTTP client.
+ */
+extension DescribeVpcEndpointServicePermissionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcEndpointServicePermissionsResult
+    public typealias HeadersType = DescribeVpcEndpointServicePermissionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcEndpointServicePermissionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcEndpointServices operation in a HTTP client.
+ */
+extension DescribeVpcEndpointServicesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcEndpointServicesResult
+    public typealias HeadersType = DescribeVpcEndpointServicesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcEndpointServicesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcEndpoints operation in a HTTP client.
+ */
+extension DescribeVpcEndpointsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcEndpointsResult
+    public typealias HeadersType = DescribeVpcEndpointsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcEndpointsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcPeeringConnections operation in a HTTP client.
+ */
+extension DescribeVpcPeeringConnectionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcPeeringConnectionsResult
+    public typealias HeadersType = DescribeVpcPeeringConnectionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcPeeringConnectionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpcs operation in a HTTP client.
+ */
+extension DescribeVpcsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpcsResult
+    public typealias HeadersType = DescribeVpcsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpcsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpnConnections operation in a HTTP client.
+ */
+extension DescribeVpnConnectionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpnConnectionsResult
+    public typealias HeadersType = DescribeVpnConnectionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpnConnectionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeVpnGateways operation in a HTTP client.
+ */
+extension DescribeVpnGatewaysResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeVpnGatewaysResult
+    public typealias HeadersType = DescribeVpnGatewaysResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeVpnGatewaysResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DetachClassicLinkVpc operation in a HTTP client.
+ */
+extension DetachClassicLinkVpcResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DetachClassicLinkVpcResult
+    public typealias HeadersType = DetachClassicLinkVpcResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DetachClassicLinkVpcResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DisableVpcClassicLink operation in a HTTP client.
+ */
+extension DisableVpcClassicLinkResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DisableVpcClassicLinkResult
+    public typealias HeadersType = DisableVpcClassicLinkResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DisableVpcClassicLinkResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DisableVpcClassicLinkDnsSupport operation in a HTTP client.
+ */
+extension DisableVpcClassicLinkDnsSupportResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DisableVpcClassicLinkDnsSupportResult
+    public typealias HeadersType = DisableVpcClassicLinkDnsSupportResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DisableVpcClassicLinkDnsSupportResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DisassociateIamInstanceProfile operation in a HTTP client.
+ */
+extension DisassociateIamInstanceProfileResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DisassociateIamInstanceProfileResult
+    public typealias HeadersType = DisassociateIamInstanceProfileResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DisassociateIamInstanceProfileResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DisassociateSubnetCidrBlock operation in a HTTP client.
+ */
+extension DisassociateSubnetCidrBlockResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DisassociateSubnetCidrBlockResult
+    public typealias HeadersType = DisassociateSubnetCidrBlockResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DisassociateSubnetCidrBlockResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DisassociateVpcCidrBlock operation in a HTTP client.
+ */
+extension DisassociateVpcCidrBlockResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = DisassociateVpcCidrBlockResult
+    public typealias HeadersType = DisassociateVpcCidrBlockResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DisassociateVpcCidrBlockResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the EnableVpcClassicLink operation in a HTTP client.
+ */
+extension EnableVpcClassicLinkResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = EnableVpcClassicLinkResult
+    public typealias HeadersType = EnableVpcClassicLinkResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> EnableVpcClassicLinkResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the EnableVpcClassicLinkDnsSupport operation in a HTTP client.
+ */
+extension EnableVpcClassicLinkDnsSupportResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = EnableVpcClassicLinkDnsSupportResult
+    public typealias HeadersType = EnableVpcClassicLinkDnsSupportResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> EnableVpcClassicLinkDnsSupportResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetConsoleOutput operation in a HTTP client.
+ */
+extension GetConsoleOutputResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetConsoleOutputResult
+    public typealias HeadersType = GetConsoleOutputResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetConsoleOutputResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetConsoleScreenshot operation in a HTTP client.
+ */
+extension GetConsoleScreenshotResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetConsoleScreenshotResult
+    public typealias HeadersType = GetConsoleScreenshotResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetConsoleScreenshotResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetHostReservationPurchasePreview operation in a HTTP client.
+ */
+extension GetHostReservationPurchasePreviewResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetHostReservationPurchasePreviewResult
+    public typealias HeadersType = GetHostReservationPurchasePreviewResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetHostReservationPurchasePreviewResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetLaunchTemplateData operation in a HTTP client.
+ */
+extension GetLaunchTemplateDataResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetLaunchTemplateDataResult
+    public typealias HeadersType = GetLaunchTemplateDataResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetLaunchTemplateDataResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetPasswordData operation in a HTTP client.
+ */
+extension GetPasswordDataResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetPasswordDataResult
+    public typealias HeadersType = GetPasswordDataResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetPasswordDataResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetReservedInstancesExchangeQuote operation in a HTTP client.
+ */
+extension GetReservedInstancesExchangeQuoteResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetReservedInstancesExchangeQuoteResult
+    public typealias HeadersType = GetReservedInstancesExchangeQuoteResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetReservedInstancesExchangeQuoteResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ImportImage operation in a HTTP client.
+ */
+extension ImportImageResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ImportImageResult
+    public typealias HeadersType = ImportImageResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ImportImageResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ImportInstance operation in a HTTP client.
+ */
+extension ImportInstanceResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ImportInstanceResult
+    public typealias HeadersType = ImportInstanceResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ImportInstanceResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ImportKeyPair operation in a HTTP client.
+ */
+extension ImportKeyPairResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ImportKeyPairResult
+    public typealias HeadersType = ImportKeyPairResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ImportKeyPairResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ImportSnapshot operation in a HTTP client.
+ */
+extension ImportSnapshotResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ImportSnapshotResult
+    public typealias HeadersType = ImportSnapshotResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ImportSnapshotResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ImportVolume operation in a HTTP client.
+ */
+extension ImportVolumeResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ImportVolumeResult
+    public typealias HeadersType = ImportVolumeResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ImportVolumeResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyCapacityReservation operation in a HTTP client.
+ */
+extension ModifyCapacityReservationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyCapacityReservationResult
+    public typealias HeadersType = ModifyCapacityReservationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyCapacityReservationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyFleet operation in a HTTP client.
+ */
+extension ModifyFleetResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyFleetResult
+    public typealias HeadersType = ModifyFleetResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyFleetResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyFpgaImageAttribute operation in a HTTP client.
+ */
+extension ModifyFpgaImageAttributeResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyFpgaImageAttributeResult
+    public typealias HeadersType = ModifyFpgaImageAttributeResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyFpgaImageAttributeResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyHosts operation in a HTTP client.
+ */
+extension ModifyHostsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyHostsResult
+    public typealias HeadersType = ModifyHostsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyHostsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyInstanceCapacityReservationAttributes operation in a HTTP client.
+ */
+extension ModifyInstanceCapacityReservationAttributesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyInstanceCapacityReservationAttributesResult
+    public typealias HeadersType = ModifyInstanceCapacityReservationAttributesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyInstanceCapacityReservationAttributesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyInstanceCreditSpecification operation in a HTTP client.
+ */
+extension ModifyInstanceCreditSpecificationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyInstanceCreditSpecificationResult
+    public typealias HeadersType = ModifyInstanceCreditSpecificationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyInstanceCreditSpecificationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyInstancePlacement operation in a HTTP client.
+ */
+extension ModifyInstancePlacementResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyInstancePlacementResult
+    public typealias HeadersType = ModifyInstancePlacementResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyInstancePlacementResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyLaunchTemplate operation in a HTTP client.
+ */
+extension ModifyLaunchTemplateResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyLaunchTemplateResult
+    public typealias HeadersType = ModifyLaunchTemplateResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyLaunchTemplateResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyReservedInstances operation in a HTTP client.
+ */
+extension ModifyReservedInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyReservedInstancesResult
+    public typealias HeadersType = ModifyReservedInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyReservedInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifySpotFleetRequest operation in a HTTP client.
+ */
+extension ModifySpotFleetRequestResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifySpotFleetRequestResponse
+    public typealias HeadersType = ModifySpotFleetRequestResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifySpotFleetRequestResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyVolume operation in a HTTP client.
+ */
+extension ModifyVolumeResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyVolumeResult
+    public typealias HeadersType = ModifyVolumeResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyVolumeResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyVpcEndpoint operation in a HTTP client.
+ */
+extension ModifyVpcEndpointResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyVpcEndpointResult
+    public typealias HeadersType = ModifyVpcEndpointResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyVpcEndpointResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyVpcEndpointConnectionNotification operation in a HTTP client.
+ */
+extension ModifyVpcEndpointConnectionNotificationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyVpcEndpointConnectionNotificationResult
+    public typealias HeadersType = ModifyVpcEndpointConnectionNotificationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyVpcEndpointConnectionNotificationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyVpcEndpointServiceConfiguration operation in a HTTP client.
+ */
+extension ModifyVpcEndpointServiceConfigurationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyVpcEndpointServiceConfigurationResult
+    public typealias HeadersType = ModifyVpcEndpointServiceConfigurationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyVpcEndpointServiceConfigurationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyVpcEndpointServicePermissions operation in a HTTP client.
+ */
+extension ModifyVpcEndpointServicePermissionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyVpcEndpointServicePermissionsResult
+    public typealias HeadersType = ModifyVpcEndpointServicePermissionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyVpcEndpointServicePermissionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyVpcPeeringConnectionOptions operation in a HTTP client.
+ */
+extension ModifyVpcPeeringConnectionOptionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyVpcPeeringConnectionOptionsResult
+    public typealias HeadersType = ModifyVpcPeeringConnectionOptionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyVpcPeeringConnectionOptionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ModifyVpcTenancy operation in a HTTP client.
+ */
+extension ModifyVpcTenancyResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ModifyVpcTenancyResult
+    public typealias HeadersType = ModifyVpcTenancyResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ModifyVpcTenancyResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the MonitorInstances operation in a HTTP client.
+ */
+extension MonitorInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = MonitorInstancesResult
+    public typealias HeadersType = MonitorInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> MonitorInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the MoveAddressToVpc operation in a HTTP client.
+ */
+extension MoveAddressToVpcResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = MoveAddressToVpcResult
+    public typealias HeadersType = MoveAddressToVpcResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> MoveAddressToVpcResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ProvisionByoipCidr operation in a HTTP client.
+ */
+extension ProvisionByoipCidrResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ProvisionByoipCidrResult
+    public typealias HeadersType = ProvisionByoipCidrResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ProvisionByoipCidrResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PurchaseHostReservation operation in a HTTP client.
+ */
+extension PurchaseHostReservationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = PurchaseHostReservationResult
+    public typealias HeadersType = PurchaseHostReservationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PurchaseHostReservationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PurchaseReservedInstancesOffering operation in a HTTP client.
+ */
+extension PurchaseReservedInstancesOfferingResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = PurchaseReservedInstancesOfferingResult
+    public typealias HeadersType = PurchaseReservedInstancesOfferingResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PurchaseReservedInstancesOfferingResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PurchaseScheduledInstances operation in a HTTP client.
+ */
+extension PurchaseScheduledInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = PurchaseScheduledInstancesResult
+    public typealias HeadersType = PurchaseScheduledInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PurchaseScheduledInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RegisterImage operation in a HTTP client.
+ */
+extension RegisterImageResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = RegisterImageResult
+    public typealias HeadersType = RegisterImageResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RegisterImageResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RejectVpcEndpointConnections operation in a HTTP client.
+ */
+extension RejectVpcEndpointConnectionsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = RejectVpcEndpointConnectionsResult
+    public typealias HeadersType = RejectVpcEndpointConnectionsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RejectVpcEndpointConnectionsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RejectVpcPeeringConnection operation in a HTTP client.
+ */
+extension RejectVpcPeeringConnectionResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = RejectVpcPeeringConnectionResult
+    public typealias HeadersType = RejectVpcPeeringConnectionResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RejectVpcPeeringConnectionResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ReleaseHosts operation in a HTTP client.
+ */
+extension ReleaseHostsResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ReleaseHostsResult
+    public typealias HeadersType = ReleaseHostsResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ReleaseHostsResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ReplaceIamInstanceProfileAssociation operation in a HTTP client.
+ */
+extension ReplaceIamInstanceProfileAssociationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ReplaceIamInstanceProfileAssociationResult
+    public typealias HeadersType = ReplaceIamInstanceProfileAssociationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ReplaceIamInstanceProfileAssociationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ReplaceNetworkAclAssociation operation in a HTTP client.
+ */
+extension ReplaceNetworkAclAssociationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ReplaceNetworkAclAssociationResult
+    public typealias HeadersType = ReplaceNetworkAclAssociationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ReplaceNetworkAclAssociationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ReplaceRouteTableAssociation operation in a HTTP client.
+ */
+extension ReplaceRouteTableAssociationResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ReplaceRouteTableAssociationResult
+    public typealias HeadersType = ReplaceRouteTableAssociationResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ReplaceRouteTableAssociationResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RequestSpotFleet operation in a HTTP client.
+ */
+extension RequestSpotFleetResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = RequestSpotFleetResponse
+    public typealias HeadersType = RequestSpotFleetResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RequestSpotFleetResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RequestSpotInstances operation in a HTTP client.
+ */
+extension RequestSpotInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = RequestSpotInstancesResult
+    public typealias HeadersType = RequestSpotInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RequestSpotInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ResetFpgaImageAttribute operation in a HTTP client.
+ */
+extension ResetFpgaImageAttributeResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = ResetFpgaImageAttributeResult
+    public typealias HeadersType = ResetFpgaImageAttributeResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ResetFpgaImageAttributeResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RestoreAddressToClassic operation in a HTTP client.
+ */
+extension RestoreAddressToClassicResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = RestoreAddressToClassicResult
+    public typealias HeadersType = RestoreAddressToClassicResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RestoreAddressToClassicResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RunInstances operation in a HTTP client.
+ */
+extension Reservation: HTTPResponseOutputProtocol {
+    public typealias BodyType = Reservation
+    public typealias HeadersType = Reservation
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> Reservation {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RunScheduledInstances operation in a HTTP client.
+ */
+extension RunScheduledInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = RunScheduledInstancesResult
+    public typealias HeadersType = RunScheduledInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RunScheduledInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the StartInstances operation in a HTTP client.
+ */
+extension StartInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = StartInstancesResult
+    public typealias HeadersType = StartInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> StartInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the StopInstances operation in a HTTP client.
+ */
+extension StopInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = StopInstancesResult
+    public typealias HeadersType = StopInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> StopInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the TerminateInstances operation in a HTTP client.
+ */
+extension TerminateInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = TerminateInstancesResult
+    public typealias HeadersType = TerminateInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> TerminateInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UnassignIpv6Addresses operation in a HTTP client.
+ */
+extension UnassignIpv6AddressesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = UnassignIpv6AddressesResult
+    public typealias HeadersType = UnassignIpv6AddressesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UnassignIpv6AddressesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UnmonitorInstances operation in a HTTP client.
+ */
+extension UnmonitorInstancesResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = UnmonitorInstancesResult
+    public typealias HeadersType = UnmonitorInstancesResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UnmonitorInstancesResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateSecurityGroupRuleDescriptionsEgress operation in a HTTP client.
+ */
+extension UpdateSecurityGroupRuleDescriptionsEgressResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateSecurityGroupRuleDescriptionsEgressResult
+    public typealias HeadersType = UpdateSecurityGroupRuleDescriptionsEgressResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateSecurityGroupRuleDescriptionsEgressResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateSecurityGroupRuleDescriptionsIngress operation in a HTTP client.
+ */
+extension UpdateSecurityGroupRuleDescriptionsIngressResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateSecurityGroupRuleDescriptionsIngressResult
+    public typealias HeadersType = UpdateSecurityGroupRuleDescriptionsIngressResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateSecurityGroupRuleDescriptionsIngressResult {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the WithdrawByoipCidr operation in a HTTP client.
+ */
+extension WithdrawByoipCidrResult: HTTPResponseOutputProtocol {
+    public typealias BodyType = WithdrawByoipCidrResult
+    public typealias HeadersType = WithdrawByoipCidrResult
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> WithdrawByoipCidrResult {
+        return try bodyDecodableProvider()
+    }
+}
+

--- a/Sources/ElasticComputeCloudClient/MockElasticComputeCloudClient.swift
+++ b/Sources/ElasticComputeCloudClient/MockElasticComputeCloudClient.swift
@@ -1998,7 +1998,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func assignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func assignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let assignPrivateIpAddressesAsyncOverride = assignPrivateIpAddressesAsyncOverride {
             return try assignPrivateIpAddressesAsyncOverride(input, completion)
         }
@@ -2062,7 +2062,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func associateDhcpOptionsAsync(input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func associateDhcpOptionsAsync(input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let associateDhcpOptionsAsyncOverride = associateDhcpOptionsAsyncOverride {
             return try associateDhcpOptionsAsyncOverride(input, completion)
         }
@@ -2266,7 +2266,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func attachInternetGatewayAsync(input: ElasticComputeCloudModel.AttachInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func attachInternetGatewayAsync(input: ElasticComputeCloudModel.AttachInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let attachInternetGatewayAsyncOverride = attachInternetGatewayAsyncOverride {
             return try attachInternetGatewayAsyncOverride(input, completion)
         }
@@ -2400,7 +2400,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func authorizeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func authorizeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let authorizeSecurityGroupEgressAsyncOverride = authorizeSecurityGroupEgressAsyncOverride {
             return try authorizeSecurityGroupEgressAsyncOverride(input, completion)
         }
@@ -2429,7 +2429,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func authorizeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func authorizeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let authorizeSecurityGroupIngressAsyncOverride = authorizeSecurityGroupIngressAsyncOverride {
             return try authorizeSecurityGroupIngressAsyncOverride(input, completion)
         }
@@ -2563,7 +2563,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func cancelConversionTaskAsync(input: ElasticComputeCloudModel.CancelConversionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func cancelConversionTaskAsync(input: ElasticComputeCloudModel.CancelConversionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let cancelConversionTaskAsyncOverride = cancelConversionTaskAsyncOverride {
             return try cancelConversionTaskAsyncOverride(input, completion)
         }
@@ -2592,7 +2592,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func cancelExportTaskAsync(input: ElasticComputeCloudModel.CancelExportTaskRequest, completion: @escaping (Error?) -> ()) throws {
+    public func cancelExportTaskAsync(input: ElasticComputeCloudModel.CancelExportTaskRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let cancelExportTaskAsyncOverride = cancelExportTaskAsyncOverride {
             return try cancelExportTaskAsyncOverride(input, completion)
         }
@@ -3496,7 +3496,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createNetworkAclEntryAsync(input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createNetworkAclEntryAsync(input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let createNetworkAclEntryAsyncOverride = createNetworkAclEntryAsyncOverride {
             return try createNetworkAclEntryAsyncOverride(input, completion)
         }
@@ -3595,7 +3595,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createPlacementGroupAsync(input: ElasticComputeCloudModel.CreatePlacementGroupRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createPlacementGroupAsync(input: ElasticComputeCloudModel.CreatePlacementGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let createPlacementGroupAsyncOverride = createPlacementGroupAsyncOverride {
             return try createPlacementGroupAsyncOverride(input, completion)
         }
@@ -3869,7 +3869,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createTagsAsync(input: ElasticComputeCloudModel.CreateTagsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createTagsAsync(input: ElasticComputeCloudModel.CreateTagsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let createTagsAsyncOverride = createTagsAsyncOverride {
             return try createTagsAsyncOverride(input, completion)
         }
@@ -4143,7 +4143,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createVpnConnectionRouteAsync(input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createVpnConnectionRouteAsync(input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let createVpnConnectionRouteAsyncOverride = createVpnConnectionRouteAsyncOverride {
             return try createVpnConnectionRouteAsyncOverride(input, completion)
         }
@@ -4207,7 +4207,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteCustomerGatewayAsync(input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteCustomerGatewayAsync(input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteCustomerGatewayAsyncOverride = deleteCustomerGatewayAsyncOverride {
             return try deleteCustomerGatewayAsyncOverride(input, completion)
         }
@@ -4236,7 +4236,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteDhcpOptionsAsync(input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteDhcpOptionsAsync(input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteDhcpOptionsAsyncOverride = deleteDhcpOptionsAsyncOverride {
             return try deleteDhcpOptionsAsyncOverride(input, completion)
         }
@@ -4405,7 +4405,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteInternetGatewayAsync(input: ElasticComputeCloudModel.DeleteInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteInternetGatewayAsync(input: ElasticComputeCloudModel.DeleteInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteInternetGatewayAsyncOverride = deleteInternetGatewayAsyncOverride {
             return try deleteInternetGatewayAsyncOverride(input, completion)
         }
@@ -4434,7 +4434,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteKeyPairAsync(input: ElasticComputeCloudModel.DeleteKeyPairRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteKeyPairAsync(input: ElasticComputeCloudModel.DeleteKeyPairRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteKeyPairAsyncOverride = deleteKeyPairAsyncOverride {
             return try deleteKeyPairAsyncOverride(input, completion)
         }
@@ -4568,7 +4568,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteNetworkAclAsync(input: ElasticComputeCloudModel.DeleteNetworkAclRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteNetworkAclAsync(input: ElasticComputeCloudModel.DeleteNetworkAclRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteNetworkAclAsyncOverride = deleteNetworkAclAsyncOverride {
             return try deleteNetworkAclAsyncOverride(input, completion)
         }
@@ -4597,7 +4597,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteNetworkAclEntryAsync(input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteNetworkAclEntryAsync(input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteNetworkAclEntryAsyncOverride = deleteNetworkAclEntryAsyncOverride {
             return try deleteNetworkAclEntryAsyncOverride(input, completion)
         }
@@ -4626,7 +4626,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteNetworkInterfaceAsync(input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteNetworkInterfaceAsync(input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteNetworkInterfaceAsyncOverride = deleteNetworkInterfaceAsyncOverride {
             return try deleteNetworkInterfaceAsyncOverride(input, completion)
         }
@@ -4690,7 +4690,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deletePlacementGroupAsync(input: ElasticComputeCloudModel.DeletePlacementGroupRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deletePlacementGroupAsync(input: ElasticComputeCloudModel.DeletePlacementGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deletePlacementGroupAsyncOverride = deletePlacementGroupAsyncOverride {
             return try deletePlacementGroupAsyncOverride(input, completion)
         }
@@ -4719,7 +4719,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteRouteAsync(input: ElasticComputeCloudModel.DeleteRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteRouteAsync(input: ElasticComputeCloudModel.DeleteRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteRouteAsyncOverride = deleteRouteAsyncOverride {
             return try deleteRouteAsyncOverride(input, completion)
         }
@@ -4748,7 +4748,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteRouteTableAsync(input: ElasticComputeCloudModel.DeleteRouteTableRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteRouteTableAsync(input: ElasticComputeCloudModel.DeleteRouteTableRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteRouteTableAsyncOverride = deleteRouteTableAsyncOverride {
             return try deleteRouteTableAsyncOverride(input, completion)
         }
@@ -4777,7 +4777,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSecurityGroupAsync(input: ElasticComputeCloudModel.DeleteSecurityGroupRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSecurityGroupAsync(input: ElasticComputeCloudModel.DeleteSecurityGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteSecurityGroupAsyncOverride = deleteSecurityGroupAsyncOverride {
             return try deleteSecurityGroupAsyncOverride(input, completion)
         }
@@ -4806,7 +4806,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSnapshotAsync(input: ElasticComputeCloudModel.DeleteSnapshotRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSnapshotAsync(input: ElasticComputeCloudModel.DeleteSnapshotRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteSnapshotAsyncOverride = deleteSnapshotAsyncOverride {
             return try deleteSnapshotAsyncOverride(input, completion)
         }
@@ -4835,7 +4835,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSpotDatafeedSubscriptionAsync(input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSpotDatafeedSubscriptionAsync(input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteSpotDatafeedSubscriptionAsyncOverride = deleteSpotDatafeedSubscriptionAsyncOverride {
             return try deleteSpotDatafeedSubscriptionAsyncOverride(input, completion)
         }
@@ -4864,7 +4864,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSubnetAsync(input: ElasticComputeCloudModel.DeleteSubnetRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSubnetAsync(input: ElasticComputeCloudModel.DeleteSubnetRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteSubnetAsyncOverride = deleteSubnetAsyncOverride {
             return try deleteSubnetAsyncOverride(input, completion)
         }
@@ -4893,7 +4893,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteTagsAsync(input: ElasticComputeCloudModel.DeleteTagsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteTagsAsync(input: ElasticComputeCloudModel.DeleteTagsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteTagsAsyncOverride = deleteTagsAsyncOverride {
             return try deleteTagsAsyncOverride(input, completion)
         }
@@ -4922,7 +4922,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVolumeAsync(input: ElasticComputeCloudModel.DeleteVolumeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVolumeAsync(input: ElasticComputeCloudModel.DeleteVolumeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteVolumeAsyncOverride = deleteVolumeAsyncOverride {
             return try deleteVolumeAsyncOverride(input, completion)
         }
@@ -4951,7 +4951,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpcAsync(input: ElasticComputeCloudModel.DeleteVpcRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpcAsync(input: ElasticComputeCloudModel.DeleteVpcRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteVpcAsyncOverride = deleteVpcAsyncOverride {
             return try deleteVpcAsyncOverride(input, completion)
         }
@@ -5120,7 +5120,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpnConnectionAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpnConnectionAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteVpnConnectionAsyncOverride = deleteVpnConnectionAsyncOverride {
             return try deleteVpnConnectionAsyncOverride(input, completion)
         }
@@ -5149,7 +5149,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpnConnectionRouteAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpnConnectionRouteAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteVpnConnectionRouteAsyncOverride = deleteVpnConnectionRouteAsyncOverride {
             return try deleteVpnConnectionRouteAsyncOverride(input, completion)
         }
@@ -5178,7 +5178,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpnGatewayAsync(input: ElasticComputeCloudModel.DeleteVpnGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpnGatewayAsync(input: ElasticComputeCloudModel.DeleteVpnGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteVpnGatewayAsyncOverride = deleteVpnGatewayAsyncOverride {
             return try deleteVpnGatewayAsyncOverride(input, completion)
         }
@@ -5242,7 +5242,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deregisterImageAsync(input: ElasticComputeCloudModel.DeregisterImageRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deregisterImageAsync(input: ElasticComputeCloudModel.DeregisterImageRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deregisterImageAsyncOverride = deregisterImageAsyncOverride {
             return try deregisterImageAsyncOverride(input, completion)
         }
@@ -8316,7 +8316,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func detachInternetGatewayAsync(input: ElasticComputeCloudModel.DetachInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func detachInternetGatewayAsync(input: ElasticComputeCloudModel.DetachInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let detachInternetGatewayAsyncOverride = detachInternetGatewayAsyncOverride {
             return try detachInternetGatewayAsyncOverride(input, completion)
         }
@@ -8345,7 +8345,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func detachNetworkInterfaceAsync(input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest, completion: @escaping (Error?) -> ()) throws {
+    public func detachNetworkInterfaceAsync(input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let detachNetworkInterfaceAsyncOverride = detachNetworkInterfaceAsyncOverride {
             return try detachNetworkInterfaceAsyncOverride(input, completion)
         }
@@ -8409,7 +8409,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func detachVpnGatewayAsync(input: ElasticComputeCloudModel.DetachVpnGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func detachVpnGatewayAsync(input: ElasticComputeCloudModel.DetachVpnGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let detachVpnGatewayAsyncOverride = detachVpnGatewayAsyncOverride {
             return try detachVpnGatewayAsyncOverride(input, completion)
         }
@@ -8438,7 +8438,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest, completion: @escaping (Error?) -> ()) throws {
+    public func disableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let disableVgwRoutePropagationAsyncOverride = disableVgwRoutePropagationAsyncOverride {
             return try disableVgwRoutePropagationAsyncOverride(input, completion)
         }
@@ -8537,7 +8537,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disassociateAddressAsync(input: ElasticComputeCloudModel.DisassociateAddressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func disassociateAddressAsync(input: ElasticComputeCloudModel.DisassociateAddressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let disassociateAddressAsyncOverride = disassociateAddressAsyncOverride {
             return try disassociateAddressAsyncOverride(input, completion)
         }
@@ -8601,7 +8601,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disassociateRouteTableAsync(input: ElasticComputeCloudModel.DisassociateRouteTableRequest, completion: @escaping (Error?) -> ()) throws {
+    public func disassociateRouteTableAsync(input: ElasticComputeCloudModel.DisassociateRouteTableRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let disassociateRouteTableAsyncOverride = disassociateRouteTableAsyncOverride {
             return try disassociateRouteTableAsyncOverride(input, completion)
         }
@@ -8700,7 +8700,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func enableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest, completion: @escaping (Error?) -> ()) throws {
+    public func enableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let enableVgwRoutePropagationAsyncOverride = enableVgwRoutePropagationAsyncOverride {
             return try enableVgwRoutePropagationAsyncOverride(input, completion)
         }
@@ -8729,7 +8729,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func enableVolumeIOAsync(input: ElasticComputeCloudModel.EnableVolumeIORequest, completion: @escaping (Error?) -> ()) throws {
+    public func enableVolumeIOAsync(input: ElasticComputeCloudModel.EnableVolumeIORequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let enableVolumeIOAsyncOverride = enableVolumeIOAsyncOverride {
             return try enableVolumeIOAsyncOverride(input, completion)
         }
@@ -9353,7 +9353,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdFormatRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdFormatRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyIdFormatAsyncOverride = modifyIdFormatAsyncOverride {
             return try modifyIdFormatAsyncOverride(input, completion)
         }
@@ -9382,7 +9382,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyIdentityIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyIdentityIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyIdentityIdFormatAsyncOverride = modifyIdentityIdFormatAsyncOverride {
             return try modifyIdentityIdFormatAsyncOverride(input, completion)
         }
@@ -9411,7 +9411,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyImageAttributeAsync(input: ElasticComputeCloudModel.ModifyImageAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyImageAttributeAsync(input: ElasticComputeCloudModel.ModifyImageAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyImageAttributeAsyncOverride = modifyImageAttributeAsyncOverride {
             return try modifyImageAttributeAsyncOverride(input, completion)
         }
@@ -9440,7 +9440,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyInstanceAttributeAsync(input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyInstanceAttributeAsync(input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyInstanceAttributeAsyncOverride = modifyInstanceAttributeAsyncOverride {
             return try modifyInstanceAttributeAsyncOverride(input, completion)
         }
@@ -9609,7 +9609,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyNetworkInterfaceAttributeAsyncOverride = modifyNetworkInterfaceAttributeAsyncOverride {
             return try modifyNetworkInterfaceAttributeAsyncOverride(input, completion)
         }
@@ -9673,7 +9673,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifySnapshotAttributeAsync(input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifySnapshotAttributeAsync(input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifySnapshotAttributeAsyncOverride = modifySnapshotAttributeAsyncOverride {
             return try modifySnapshotAttributeAsyncOverride(input, completion)
         }
@@ -9737,7 +9737,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifySubnetAttributeAsync(input: ElasticComputeCloudModel.ModifySubnetAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifySubnetAttributeAsync(input: ElasticComputeCloudModel.ModifySubnetAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifySubnetAttributeAsyncOverride = modifySubnetAttributeAsyncOverride {
             return try modifySubnetAttributeAsyncOverride(input, completion)
         }
@@ -9801,7 +9801,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyVolumeAttributeAsync(input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyVolumeAttributeAsync(input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyVolumeAttributeAsyncOverride = modifyVolumeAttributeAsyncOverride {
             return try modifyVolumeAttributeAsyncOverride(input, completion)
         }
@@ -9830,7 +9830,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyVpcAttributeAsync(input: ElasticComputeCloudModel.ModifyVpcAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyVpcAttributeAsync(input: ElasticComputeCloudModel.ModifyVpcAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyVpcAttributeAsyncOverride = modifyVpcAttributeAsyncOverride {
             return try modifyVpcAttributeAsyncOverride(input, completion)
         }
@@ -10279,7 +10279,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func rebootInstancesAsync(input: ElasticComputeCloudModel.RebootInstancesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func rebootInstancesAsync(input: ElasticComputeCloudModel.RebootInstancesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let rebootInstancesAsyncOverride = rebootInstancesAsyncOverride {
             return try rebootInstancesAsyncOverride(input, completion)
         }
@@ -10413,7 +10413,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func releaseAddressAsync(input: ElasticComputeCloudModel.ReleaseAddressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func releaseAddressAsync(input: ElasticComputeCloudModel.ReleaseAddressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let releaseAddressAsyncOverride = releaseAddressAsyncOverride {
             return try releaseAddressAsyncOverride(input, completion)
         }
@@ -10547,7 +10547,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func replaceNetworkAclEntryAsync(input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws {
+    public func replaceNetworkAclEntryAsync(input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let replaceNetworkAclEntryAsyncOverride = replaceNetworkAclEntryAsyncOverride {
             return try replaceNetworkAclEntryAsyncOverride(input, completion)
         }
@@ -10576,7 +10576,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func replaceRouteAsync(input: ElasticComputeCloudModel.ReplaceRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func replaceRouteAsync(input: ElasticComputeCloudModel.ReplaceRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let replaceRouteAsyncOverride = replaceRouteAsyncOverride {
             return try replaceRouteAsyncOverride(input, completion)
         }
@@ -10640,7 +10640,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func reportInstanceStatusAsync(input: ElasticComputeCloudModel.ReportInstanceStatusRequest, completion: @escaping (Error?) -> ()) throws {
+    public func reportInstanceStatusAsync(input: ElasticComputeCloudModel.ReportInstanceStatusRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let reportInstanceStatusAsyncOverride = reportInstanceStatusAsyncOverride {
             return try reportInstanceStatusAsyncOverride(input, completion)
         }
@@ -10774,7 +10774,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetImageAttributeAsync(input: ElasticComputeCloudModel.ResetImageAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetImageAttributeAsync(input: ElasticComputeCloudModel.ResetImageAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let resetImageAttributeAsyncOverride = resetImageAttributeAsyncOverride {
             return try resetImageAttributeAsyncOverride(input, completion)
         }
@@ -10803,7 +10803,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetInstanceAttributeAsync(input: ElasticComputeCloudModel.ResetInstanceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetInstanceAttributeAsync(input: ElasticComputeCloudModel.ResetInstanceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let resetInstanceAttributeAsyncOverride = resetInstanceAttributeAsyncOverride {
             return try resetInstanceAttributeAsyncOverride(input, completion)
         }
@@ -10832,7 +10832,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let resetNetworkInterfaceAttributeAsyncOverride = resetNetworkInterfaceAttributeAsyncOverride {
             return try resetNetworkInterfaceAttributeAsyncOverride(input, completion)
         }
@@ -10861,7 +10861,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetSnapshotAttributeAsync(input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetSnapshotAttributeAsync(input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let resetSnapshotAttributeAsyncOverride = resetSnapshotAttributeAsyncOverride {
             return try resetSnapshotAttributeAsyncOverride(input, completion)
         }
@@ -10925,7 +10925,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func revokeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func revokeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let revokeSecurityGroupEgressAsyncOverride = revokeSecurityGroupEgressAsyncOverride {
             return try revokeSecurityGroupEgressAsyncOverride(input, completion)
         }
@@ -10954,7 +10954,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func revokeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func revokeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let revokeSecurityGroupIngressAsyncOverride = revokeSecurityGroupIngressAsyncOverride {
             return try revokeSecurityGroupIngressAsyncOverride(input, completion)
         }
@@ -11193,7 +11193,7 @@ public struct MockElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func unassignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func unassignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let unassignPrivateIpAddressesAsyncOverride = unassignPrivateIpAddressesAsyncOverride {
             return try unassignPrivateIpAddressesAsyncOverride(input, completion)
         }

--- a/Sources/ElasticComputeCloudClient/ThrowingElasticComputeCloudClient.swift
+++ b/Sources/ElasticComputeCloudClient/ThrowingElasticComputeCloudClient.swift
@@ -1986,7 +1986,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func assignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func assignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let assignPrivateIpAddressesAsyncOverride = assignPrivateIpAddressesAsyncOverride {
             return try assignPrivateIpAddressesAsyncOverride(input, completion)
         }
@@ -2049,7 +2049,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func associateDhcpOptionsAsync(input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func associateDhcpOptionsAsync(input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let associateDhcpOptionsAsyncOverride = associateDhcpOptionsAsyncOverride {
             return try associateDhcpOptionsAsyncOverride(input, completion)
         }
@@ -2244,7 +2244,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func attachInternetGatewayAsync(input: ElasticComputeCloudModel.AttachInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func attachInternetGatewayAsync(input: ElasticComputeCloudModel.AttachInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let attachInternetGatewayAsyncOverride = attachInternetGatewayAsyncOverride {
             return try attachInternetGatewayAsyncOverride(input, completion)
         }
@@ -2373,7 +2373,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func authorizeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func authorizeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let authorizeSecurityGroupEgressAsyncOverride = authorizeSecurityGroupEgressAsyncOverride {
             return try authorizeSecurityGroupEgressAsyncOverride(input, completion)
         }
@@ -2403,7 +2403,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func authorizeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func authorizeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let authorizeSecurityGroupIngressAsyncOverride = authorizeSecurityGroupIngressAsyncOverride {
             return try authorizeSecurityGroupIngressAsyncOverride(input, completion)
         }
@@ -2532,7 +2532,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func cancelConversionTaskAsync(input: ElasticComputeCloudModel.CancelConversionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func cancelConversionTaskAsync(input: ElasticComputeCloudModel.CancelConversionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let cancelConversionTaskAsyncOverride = cancelConversionTaskAsyncOverride {
             return try cancelConversionTaskAsyncOverride(input, completion)
         }
@@ -2562,7 +2562,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func cancelExportTaskAsync(input: ElasticComputeCloudModel.CancelExportTaskRequest, completion: @escaping (Error?) -> ()) throws {
+    public func cancelExportTaskAsync(input: ElasticComputeCloudModel.CancelExportTaskRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let cancelExportTaskAsyncOverride = cancelExportTaskAsyncOverride {
             return try cancelExportTaskAsyncOverride(input, completion)
         }
@@ -3417,7 +3417,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createNetworkAclEntryAsync(input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createNetworkAclEntryAsync(input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let createNetworkAclEntryAsyncOverride = createNetworkAclEntryAsyncOverride {
             return try createNetworkAclEntryAsyncOverride(input, completion)
         }
@@ -3513,7 +3513,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createPlacementGroupAsync(input: ElasticComputeCloudModel.CreatePlacementGroupRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createPlacementGroupAsync(input: ElasticComputeCloudModel.CreatePlacementGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let createPlacementGroupAsyncOverride = createPlacementGroupAsyncOverride {
             return try createPlacementGroupAsyncOverride(input, completion)
         }
@@ -3774,7 +3774,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createTagsAsync(input: ElasticComputeCloudModel.CreateTagsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createTagsAsync(input: ElasticComputeCloudModel.CreateTagsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let createTagsAsyncOverride = createTagsAsyncOverride {
             return try createTagsAsyncOverride(input, completion)
         }
@@ -4035,7 +4035,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func createVpnConnectionRouteAsync(input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func createVpnConnectionRouteAsync(input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let createVpnConnectionRouteAsyncOverride = createVpnConnectionRouteAsyncOverride {
             return try createVpnConnectionRouteAsyncOverride(input, completion)
         }
@@ -4098,7 +4098,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteCustomerGatewayAsync(input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteCustomerGatewayAsync(input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteCustomerGatewayAsyncOverride = deleteCustomerGatewayAsyncOverride {
             return try deleteCustomerGatewayAsyncOverride(input, completion)
         }
@@ -4128,7 +4128,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteDhcpOptionsAsync(input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteDhcpOptionsAsync(input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteDhcpOptionsAsyncOverride = deleteDhcpOptionsAsyncOverride {
             return try deleteDhcpOptionsAsyncOverride(input, completion)
         }
@@ -4290,7 +4290,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteInternetGatewayAsync(input: ElasticComputeCloudModel.DeleteInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteInternetGatewayAsync(input: ElasticComputeCloudModel.DeleteInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteInternetGatewayAsyncOverride = deleteInternetGatewayAsyncOverride {
             return try deleteInternetGatewayAsyncOverride(input, completion)
         }
@@ -4320,7 +4320,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteKeyPairAsync(input: ElasticComputeCloudModel.DeleteKeyPairRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteKeyPairAsync(input: ElasticComputeCloudModel.DeleteKeyPairRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteKeyPairAsyncOverride = deleteKeyPairAsyncOverride {
             return try deleteKeyPairAsyncOverride(input, completion)
         }
@@ -4449,7 +4449,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteNetworkAclAsync(input: ElasticComputeCloudModel.DeleteNetworkAclRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteNetworkAclAsync(input: ElasticComputeCloudModel.DeleteNetworkAclRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteNetworkAclAsyncOverride = deleteNetworkAclAsyncOverride {
             return try deleteNetworkAclAsyncOverride(input, completion)
         }
@@ -4479,7 +4479,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteNetworkAclEntryAsync(input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteNetworkAclEntryAsync(input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteNetworkAclEntryAsyncOverride = deleteNetworkAclEntryAsyncOverride {
             return try deleteNetworkAclEntryAsyncOverride(input, completion)
         }
@@ -4509,7 +4509,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteNetworkInterfaceAsync(input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteNetworkInterfaceAsync(input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteNetworkInterfaceAsyncOverride = deleteNetworkInterfaceAsyncOverride {
             return try deleteNetworkInterfaceAsyncOverride(input, completion)
         }
@@ -4572,7 +4572,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deletePlacementGroupAsync(input: ElasticComputeCloudModel.DeletePlacementGroupRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deletePlacementGroupAsync(input: ElasticComputeCloudModel.DeletePlacementGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deletePlacementGroupAsyncOverride = deletePlacementGroupAsyncOverride {
             return try deletePlacementGroupAsyncOverride(input, completion)
         }
@@ -4602,7 +4602,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteRouteAsync(input: ElasticComputeCloudModel.DeleteRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteRouteAsync(input: ElasticComputeCloudModel.DeleteRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteRouteAsyncOverride = deleteRouteAsyncOverride {
             return try deleteRouteAsyncOverride(input, completion)
         }
@@ -4632,7 +4632,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteRouteTableAsync(input: ElasticComputeCloudModel.DeleteRouteTableRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteRouteTableAsync(input: ElasticComputeCloudModel.DeleteRouteTableRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteRouteTableAsyncOverride = deleteRouteTableAsyncOverride {
             return try deleteRouteTableAsyncOverride(input, completion)
         }
@@ -4662,7 +4662,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSecurityGroupAsync(input: ElasticComputeCloudModel.DeleteSecurityGroupRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSecurityGroupAsync(input: ElasticComputeCloudModel.DeleteSecurityGroupRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteSecurityGroupAsyncOverride = deleteSecurityGroupAsyncOverride {
             return try deleteSecurityGroupAsyncOverride(input, completion)
         }
@@ -4692,7 +4692,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSnapshotAsync(input: ElasticComputeCloudModel.DeleteSnapshotRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSnapshotAsync(input: ElasticComputeCloudModel.DeleteSnapshotRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteSnapshotAsyncOverride = deleteSnapshotAsyncOverride {
             return try deleteSnapshotAsyncOverride(input, completion)
         }
@@ -4722,7 +4722,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSpotDatafeedSubscriptionAsync(input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSpotDatafeedSubscriptionAsync(input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteSpotDatafeedSubscriptionAsyncOverride = deleteSpotDatafeedSubscriptionAsyncOverride {
             return try deleteSpotDatafeedSubscriptionAsyncOverride(input, completion)
         }
@@ -4752,7 +4752,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteSubnetAsync(input: ElasticComputeCloudModel.DeleteSubnetRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteSubnetAsync(input: ElasticComputeCloudModel.DeleteSubnetRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteSubnetAsyncOverride = deleteSubnetAsyncOverride {
             return try deleteSubnetAsyncOverride(input, completion)
         }
@@ -4782,7 +4782,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteTagsAsync(input: ElasticComputeCloudModel.DeleteTagsRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteTagsAsync(input: ElasticComputeCloudModel.DeleteTagsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteTagsAsyncOverride = deleteTagsAsyncOverride {
             return try deleteTagsAsyncOverride(input, completion)
         }
@@ -4812,7 +4812,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVolumeAsync(input: ElasticComputeCloudModel.DeleteVolumeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVolumeAsync(input: ElasticComputeCloudModel.DeleteVolumeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteVolumeAsyncOverride = deleteVolumeAsyncOverride {
             return try deleteVolumeAsyncOverride(input, completion)
         }
@@ -4842,7 +4842,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpcAsync(input: ElasticComputeCloudModel.DeleteVpcRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpcAsync(input: ElasticComputeCloudModel.DeleteVpcRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteVpcAsyncOverride = deleteVpcAsyncOverride {
             return try deleteVpcAsyncOverride(input, completion)
         }
@@ -5004,7 +5004,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpnConnectionAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpnConnectionAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteVpnConnectionAsyncOverride = deleteVpnConnectionAsyncOverride {
             return try deleteVpnConnectionAsyncOverride(input, completion)
         }
@@ -5034,7 +5034,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpnConnectionRouteAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpnConnectionRouteAsync(input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteVpnConnectionRouteAsyncOverride = deleteVpnConnectionRouteAsyncOverride {
             return try deleteVpnConnectionRouteAsyncOverride(input, completion)
         }
@@ -5064,7 +5064,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteVpnGatewayAsync(input: ElasticComputeCloudModel.DeleteVpnGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteVpnGatewayAsync(input: ElasticComputeCloudModel.DeleteVpnGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteVpnGatewayAsyncOverride = deleteVpnGatewayAsyncOverride {
             return try deleteVpnGatewayAsyncOverride(input, completion)
         }
@@ -5127,7 +5127,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deregisterImageAsync(input: ElasticComputeCloudModel.DeregisterImageRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deregisterImageAsync(input: ElasticComputeCloudModel.DeregisterImageRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deregisterImageAsyncOverride = deregisterImageAsyncOverride {
             return try deregisterImageAsyncOverride(input, completion)
         }
@@ -8028,7 +8028,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func detachInternetGatewayAsync(input: ElasticComputeCloudModel.DetachInternetGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func detachInternetGatewayAsync(input: ElasticComputeCloudModel.DetachInternetGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let detachInternetGatewayAsyncOverride = detachInternetGatewayAsyncOverride {
             return try detachInternetGatewayAsyncOverride(input, completion)
         }
@@ -8058,7 +8058,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func detachNetworkInterfaceAsync(input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest, completion: @escaping (Error?) -> ()) throws {
+    public func detachNetworkInterfaceAsync(input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let detachNetworkInterfaceAsyncOverride = detachNetworkInterfaceAsyncOverride {
             return try detachNetworkInterfaceAsyncOverride(input, completion)
         }
@@ -8121,7 +8121,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func detachVpnGatewayAsync(input: ElasticComputeCloudModel.DetachVpnGatewayRequest, completion: @escaping (Error?) -> ()) throws {
+    public func detachVpnGatewayAsync(input: ElasticComputeCloudModel.DetachVpnGatewayRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let detachVpnGatewayAsyncOverride = detachVpnGatewayAsyncOverride {
             return try detachVpnGatewayAsyncOverride(input, completion)
         }
@@ -8151,7 +8151,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest, completion: @escaping (Error?) -> ()) throws {
+    public func disableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let disableVgwRoutePropagationAsyncOverride = disableVgwRoutePropagationAsyncOverride {
             return try disableVgwRoutePropagationAsyncOverride(input, completion)
         }
@@ -8247,7 +8247,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disassociateAddressAsync(input: ElasticComputeCloudModel.DisassociateAddressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func disassociateAddressAsync(input: ElasticComputeCloudModel.DisassociateAddressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let disassociateAddressAsyncOverride = disassociateAddressAsyncOverride {
             return try disassociateAddressAsyncOverride(input, completion)
         }
@@ -8310,7 +8310,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func disassociateRouteTableAsync(input: ElasticComputeCloudModel.DisassociateRouteTableRequest, completion: @escaping (Error?) -> ()) throws {
+    public func disassociateRouteTableAsync(input: ElasticComputeCloudModel.DisassociateRouteTableRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let disassociateRouteTableAsyncOverride = disassociateRouteTableAsyncOverride {
             return try disassociateRouteTableAsyncOverride(input, completion)
         }
@@ -8406,7 +8406,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func enableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest, completion: @escaping (Error?) -> ()) throws {
+    public func enableVgwRoutePropagationAsync(input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let enableVgwRoutePropagationAsyncOverride = enableVgwRoutePropagationAsyncOverride {
             return try enableVgwRoutePropagationAsyncOverride(input, completion)
         }
@@ -8436,7 +8436,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func enableVolumeIOAsync(input: ElasticComputeCloudModel.EnableVolumeIORequest, completion: @escaping (Error?) -> ()) throws {
+    public func enableVolumeIOAsync(input: ElasticComputeCloudModel.EnableVolumeIORequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let enableVolumeIOAsyncOverride = enableVolumeIOAsyncOverride {
             return try enableVolumeIOAsyncOverride(input, completion)
         }
@@ -9027,7 +9027,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdFormatRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdFormatRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyIdFormatAsyncOverride = modifyIdFormatAsyncOverride {
             return try modifyIdFormatAsyncOverride(input, completion)
         }
@@ -9057,7 +9057,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyIdentityIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyIdentityIdFormatAsync(input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyIdentityIdFormatAsyncOverride = modifyIdentityIdFormatAsyncOverride {
             return try modifyIdentityIdFormatAsyncOverride(input, completion)
         }
@@ -9087,7 +9087,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyImageAttributeAsync(input: ElasticComputeCloudModel.ModifyImageAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyImageAttributeAsync(input: ElasticComputeCloudModel.ModifyImageAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyImageAttributeAsyncOverride = modifyImageAttributeAsyncOverride {
             return try modifyImageAttributeAsyncOverride(input, completion)
         }
@@ -9117,7 +9117,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyInstanceAttributeAsync(input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyInstanceAttributeAsync(input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyInstanceAttributeAsyncOverride = modifyInstanceAttributeAsyncOverride {
             return try modifyInstanceAttributeAsyncOverride(input, completion)
         }
@@ -9279,7 +9279,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyNetworkInterfaceAttributeAsyncOverride = modifyNetworkInterfaceAttributeAsyncOverride {
             return try modifyNetworkInterfaceAttributeAsyncOverride(input, completion)
         }
@@ -9342,7 +9342,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifySnapshotAttributeAsync(input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifySnapshotAttributeAsync(input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifySnapshotAttributeAsyncOverride = modifySnapshotAttributeAsyncOverride {
             return try modifySnapshotAttributeAsyncOverride(input, completion)
         }
@@ -9405,7 +9405,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifySubnetAttributeAsync(input: ElasticComputeCloudModel.ModifySubnetAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifySubnetAttributeAsync(input: ElasticComputeCloudModel.ModifySubnetAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifySubnetAttributeAsyncOverride = modifySubnetAttributeAsyncOverride {
             return try modifySubnetAttributeAsyncOverride(input, completion)
         }
@@ -9468,7 +9468,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyVolumeAttributeAsync(input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyVolumeAttributeAsync(input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyVolumeAttributeAsyncOverride = modifyVolumeAttributeAsyncOverride {
             return try modifyVolumeAttributeAsyncOverride(input, completion)
         }
@@ -9498,7 +9498,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func modifyVpcAttributeAsync(input: ElasticComputeCloudModel.ModifyVpcAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func modifyVpcAttributeAsync(input: ElasticComputeCloudModel.ModifyVpcAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let modifyVpcAttributeAsyncOverride = modifyVpcAttributeAsyncOverride {
             return try modifyVpcAttributeAsyncOverride(input, completion)
         }
@@ -9924,7 +9924,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func rebootInstancesAsync(input: ElasticComputeCloudModel.RebootInstancesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func rebootInstancesAsync(input: ElasticComputeCloudModel.RebootInstancesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let rebootInstancesAsyncOverride = rebootInstancesAsyncOverride {
             return try rebootInstancesAsyncOverride(input, completion)
         }
@@ -10053,7 +10053,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func releaseAddressAsync(input: ElasticComputeCloudModel.ReleaseAddressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func releaseAddressAsync(input: ElasticComputeCloudModel.ReleaseAddressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let releaseAddressAsyncOverride = releaseAddressAsyncOverride {
             return try releaseAddressAsyncOverride(input, completion)
         }
@@ -10182,7 +10182,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func replaceNetworkAclEntryAsync(input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest, completion: @escaping (Error?) -> ()) throws {
+    public func replaceNetworkAclEntryAsync(input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let replaceNetworkAclEntryAsyncOverride = replaceNetworkAclEntryAsyncOverride {
             return try replaceNetworkAclEntryAsyncOverride(input, completion)
         }
@@ -10212,7 +10212,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func replaceRouteAsync(input: ElasticComputeCloudModel.ReplaceRouteRequest, completion: @escaping (Error?) -> ()) throws {
+    public func replaceRouteAsync(input: ElasticComputeCloudModel.ReplaceRouteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let replaceRouteAsyncOverride = replaceRouteAsyncOverride {
             return try replaceRouteAsyncOverride(input, completion)
         }
@@ -10275,7 +10275,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func reportInstanceStatusAsync(input: ElasticComputeCloudModel.ReportInstanceStatusRequest, completion: @escaping (Error?) -> ()) throws {
+    public func reportInstanceStatusAsync(input: ElasticComputeCloudModel.ReportInstanceStatusRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let reportInstanceStatusAsyncOverride = reportInstanceStatusAsyncOverride {
             return try reportInstanceStatusAsyncOverride(input, completion)
         }
@@ -10404,7 +10404,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetImageAttributeAsync(input: ElasticComputeCloudModel.ResetImageAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetImageAttributeAsync(input: ElasticComputeCloudModel.ResetImageAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let resetImageAttributeAsyncOverride = resetImageAttributeAsyncOverride {
             return try resetImageAttributeAsyncOverride(input, completion)
         }
@@ -10434,7 +10434,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetInstanceAttributeAsync(input: ElasticComputeCloudModel.ResetInstanceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetInstanceAttributeAsync(input: ElasticComputeCloudModel.ResetInstanceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let resetInstanceAttributeAsyncOverride = resetInstanceAttributeAsyncOverride {
             return try resetInstanceAttributeAsyncOverride(input, completion)
         }
@@ -10464,7 +10464,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetNetworkInterfaceAttributeAsync(input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let resetNetworkInterfaceAttributeAsyncOverride = resetNetworkInterfaceAttributeAsyncOverride {
             return try resetNetworkInterfaceAttributeAsyncOverride(input, completion)
         }
@@ -10494,7 +10494,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func resetSnapshotAttributeAsync(input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest, completion: @escaping (Error?) -> ()) throws {
+    public func resetSnapshotAttributeAsync(input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let resetSnapshotAttributeAsyncOverride = resetSnapshotAttributeAsyncOverride {
             return try resetSnapshotAttributeAsyncOverride(input, completion)
         }
@@ -10557,7 +10557,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func revokeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func revokeSecurityGroupEgressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let revokeSecurityGroupEgressAsyncOverride = revokeSecurityGroupEgressAsyncOverride {
             return try revokeSecurityGroupEgressAsyncOverride(input, completion)
         }
@@ -10587,7 +10587,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func revokeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest, completion: @escaping (Error?) -> ()) throws {
+    public func revokeSecurityGroupIngressAsync(input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let revokeSecurityGroupIngressAsyncOverride = revokeSecurityGroupIngressAsyncOverride {
             return try revokeSecurityGroupIngressAsyncOverride(input, completion)
         }
@@ -10815,7 +10815,7 @@ public struct ThrowingElasticComputeCloudClient: ElasticComputeCloudClientProtoc
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func unassignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func unassignPrivateIpAddressesAsync(input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let unassignPrivateIpAddressesAsyncOverride = unassignPrivateIpAddressesAsyncOverride {
             return try unassignPrivateIpAddressesAsyncOverride(input, completion)
         }

--- a/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
+++ b/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
@@ -64,6 +64,22 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
     }
 
     /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times.
+     */
+    public func close() {
+        httpClient.close()
+    }
+
+    /**
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
+     */
+    public func wait() {
+        httpClient.wait()
+    }
+
+    /**
      Invokes the CreateCluster operation returning immediately and passing the response to a callback.
 
      - Parameters:
@@ -80,7 +96,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.createCluster.rawValue,
                     target: target)
-        
+
         let requestInput = CreateClusterOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -107,7 +123,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.createCluster.rawValue,
                     target: target)
-        
+
         let requestInput = CreateClusterOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -134,7 +150,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.createService.rawValue,
                     target: target)
-        
+
         let requestInput = CreateServiceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -161,7 +177,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.createService.rawValue,
                     target: target)
-        
+
         let requestInput = CreateServiceOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -188,7 +204,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deleteAccountSetting.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteAccountSettingOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -215,7 +231,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deleteAccountSetting.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteAccountSettingOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -242,7 +258,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deleteAttributes.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteAttributesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -269,7 +285,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deleteAttributes.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteAttributesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -296,7 +312,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deleteCluster.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteClusterOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -323,7 +339,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deleteCluster.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteClusterOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -350,7 +366,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deleteService.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteServiceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -377,7 +393,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deleteService.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteServiceOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -404,7 +420,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deregisterContainerInstance.rawValue,
                     target: target)
-        
+
         let requestInput = DeregisterContainerInstanceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -431,7 +447,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deregisterContainerInstance.rawValue,
                     target: target)
-        
+
         let requestInput = DeregisterContainerInstanceOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -458,7 +474,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deregisterTaskDefinition.rawValue,
                     target: target)
-        
+
         let requestInput = DeregisterTaskDefinitionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -485,7 +501,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.deregisterTaskDefinition.rawValue,
                     target: target)
-        
+
         let requestInput = DeregisterTaskDefinitionOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -512,7 +528,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.describeClusters.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeClustersOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -539,7 +555,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.describeClusters.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeClustersOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -566,7 +582,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.describeContainerInstances.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeContainerInstancesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -593,7 +609,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.describeContainerInstances.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeContainerInstancesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -620,7 +636,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.describeServices.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeServicesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -647,7 +663,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.describeServices.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeServicesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -674,7 +690,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.describeTaskDefinition.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeTaskDefinitionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -701,7 +717,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.describeTaskDefinition.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeTaskDefinitionOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -728,7 +744,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.describeTasks.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeTasksOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -755,7 +771,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.describeTasks.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeTasksOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -782,7 +798,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.discoverPollEndpoint.rawValue,
                     target: target)
-        
+
         let requestInput = DiscoverPollEndpointOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -809,7 +825,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.discoverPollEndpoint.rawValue,
                     target: target)
-        
+
         let requestInput = DiscoverPollEndpointOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -836,7 +852,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listAccountSettings.rawValue,
                     target: target)
-        
+
         let requestInput = ListAccountSettingsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -863,7 +879,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listAccountSettings.rawValue,
                     target: target)
-        
+
         let requestInput = ListAccountSettingsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -890,7 +906,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listAttributes.rawValue,
                     target: target)
-        
+
         let requestInput = ListAttributesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -917,7 +933,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listAttributes.rawValue,
                     target: target)
-        
+
         let requestInput = ListAttributesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -944,7 +960,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listClusters.rawValue,
                     target: target)
-        
+
         let requestInput = ListClustersOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -971,7 +987,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listClusters.rawValue,
                     target: target)
-        
+
         let requestInput = ListClustersOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -998,7 +1014,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listContainerInstances.rawValue,
                     target: target)
-        
+
         let requestInput = ListContainerInstancesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1025,7 +1041,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listContainerInstances.rawValue,
                     target: target)
-        
+
         let requestInput = ListContainerInstancesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1052,7 +1068,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listServices.rawValue,
                     target: target)
-        
+
         let requestInput = ListServicesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1079,7 +1095,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listServices.rawValue,
                     target: target)
-        
+
         let requestInput = ListServicesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1106,7 +1122,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listTagsForResource.rawValue,
                     target: target)
-        
+
         let requestInput = ListTagsForResourceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1133,7 +1149,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listTagsForResource.rawValue,
                     target: target)
-        
+
         let requestInput = ListTagsForResourceOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1160,7 +1176,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listTaskDefinitionFamilies.rawValue,
                     target: target)
-        
+
         let requestInput = ListTaskDefinitionFamiliesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1187,7 +1203,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listTaskDefinitionFamilies.rawValue,
                     target: target)
-        
+
         let requestInput = ListTaskDefinitionFamiliesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1214,7 +1230,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listTaskDefinitions.rawValue,
                     target: target)
-        
+
         let requestInput = ListTaskDefinitionsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1241,7 +1257,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listTaskDefinitions.rawValue,
                     target: target)
-        
+
         let requestInput = ListTaskDefinitionsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1268,7 +1284,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listTasks.rawValue,
                     target: target)
-        
+
         let requestInput = ListTasksOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1295,7 +1311,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.listTasks.rawValue,
                     target: target)
-        
+
         let requestInput = ListTasksOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1322,7 +1338,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.putAccountSetting.rawValue,
                     target: target)
-        
+
         let requestInput = PutAccountSettingOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1349,7 +1365,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.putAccountSetting.rawValue,
                     target: target)
-        
+
         let requestInput = PutAccountSettingOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1376,7 +1392,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.putAttributes.rawValue,
                     target: target)
-        
+
         let requestInput = PutAttributesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1403,7 +1419,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.putAttributes.rawValue,
                     target: target)
-        
+
         let requestInput = PutAttributesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1430,7 +1446,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.registerContainerInstance.rawValue,
                     target: target)
-        
+
         let requestInput = RegisterContainerInstanceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1457,7 +1473,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.registerContainerInstance.rawValue,
                     target: target)
-        
+
         let requestInput = RegisterContainerInstanceOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1484,7 +1500,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.registerTaskDefinition.rawValue,
                     target: target)
-        
+
         let requestInput = RegisterTaskDefinitionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1511,7 +1527,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.registerTaskDefinition.rawValue,
                     target: target)
-        
+
         let requestInput = RegisterTaskDefinitionOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1538,7 +1554,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.runTask.rawValue,
                     target: target)
-        
+
         let requestInput = RunTaskOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1565,7 +1581,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.runTask.rawValue,
                     target: target)
-        
+
         let requestInput = RunTaskOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1592,7 +1608,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.startTask.rawValue,
                     target: target)
-        
+
         let requestInput = StartTaskOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1619,7 +1635,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.startTask.rawValue,
                     target: target)
-        
+
         let requestInput = StartTaskOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1646,7 +1662,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.stopTask.rawValue,
                     target: target)
-        
+
         let requestInput = StopTaskOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1673,7 +1689,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.stopTask.rawValue,
                     target: target)
-        
+
         let requestInput = StopTaskOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1700,7 +1716,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.submitContainerStateChange.rawValue,
                     target: target)
-        
+
         let requestInput = SubmitContainerStateChangeOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1727,7 +1743,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.submitContainerStateChange.rawValue,
                     target: target)
-        
+
         let requestInput = SubmitContainerStateChangeOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1754,7 +1770,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.submitTaskStateChange.rawValue,
                     target: target)
-        
+
         let requestInput = SubmitTaskStateChangeOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1781,7 +1797,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.submitTaskStateChange.rawValue,
                     target: target)
-        
+
         let requestInput = SubmitTaskStateChangeOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1808,7 +1824,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.tagResource.rawValue,
                     target: target)
-        
+
         let requestInput = TagResourceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1835,7 +1851,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.tagResource.rawValue,
                     target: target)
-        
+
         let requestInput = TagResourceOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1862,7 +1878,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.untagResource.rawValue,
                     target: target)
-        
+
         let requestInput = UntagResourceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1889,7 +1905,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.untagResource.rawValue,
                     target: target)
-        
+
         let requestInput = UntagResourceOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1916,7 +1932,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.updateContainerAgent.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateContainerAgentOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1943,7 +1959,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.updateContainerAgent.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateContainerAgentOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1970,7 +1986,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.updateContainerInstancesState.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateContainerInstancesStateOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1997,7 +2013,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.updateContainerInstancesState.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateContainerInstancesStateOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -2024,7 +2040,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.updateService.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateServiceOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -2051,7 +2067,7 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                     service: service,
                     operation: ElasticContainerModelOperations.updateService.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateServiceOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(

--- a/Sources/ElasticContainerClient/ElasticContainerOperationsClientOutput.swift
+++ b/Sources/ElasticContainerClient/ElasticContainerOperationsClientOutput.swift
@@ -1,0 +1,506 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// ElasticContainerOperationsClientOutput.swift
+// ElasticContainerClient
+//
+
+import Foundation
+import SmokeHTTPClient
+import ElasticContainerModel
+
+/**
+ Type to handle the output from the CreateCluster operation in a HTTP client.
+ */
+extension CreateClusterResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateClusterResponse
+    public typealias HeadersType = CreateClusterResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateClusterResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateService operation in a HTTP client.
+ */
+extension CreateServiceResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateServiceResponse
+    public typealias HeadersType = CreateServiceResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateServiceResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteAccountSetting operation in a HTTP client.
+ */
+extension DeleteAccountSettingResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteAccountSettingResponse
+    public typealias HeadersType = DeleteAccountSettingResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteAccountSettingResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteAttributes operation in a HTTP client.
+ */
+extension DeleteAttributesResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteAttributesResponse
+    public typealias HeadersType = DeleteAttributesResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteAttributesResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteCluster operation in a HTTP client.
+ */
+extension DeleteClusterResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteClusterResponse
+    public typealias HeadersType = DeleteClusterResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteClusterResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteService operation in a HTTP client.
+ */
+extension DeleteServiceResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteServiceResponse
+    public typealias HeadersType = DeleteServiceResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteServiceResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeregisterContainerInstance operation in a HTTP client.
+ */
+extension DeregisterContainerInstanceResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeregisterContainerInstanceResponse
+    public typealias HeadersType = DeregisterContainerInstanceResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeregisterContainerInstanceResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeregisterTaskDefinition operation in a HTTP client.
+ */
+extension DeregisterTaskDefinitionResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeregisterTaskDefinitionResponse
+    public typealias HeadersType = DeregisterTaskDefinitionResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeregisterTaskDefinitionResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeClusters operation in a HTTP client.
+ */
+extension DescribeClustersResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeClustersResponse
+    public typealias HeadersType = DescribeClustersResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeClustersResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeContainerInstances operation in a HTTP client.
+ */
+extension DescribeContainerInstancesResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeContainerInstancesResponse
+    public typealias HeadersType = DescribeContainerInstancesResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeContainerInstancesResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeServices operation in a HTTP client.
+ */
+extension DescribeServicesResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeServicesResponse
+    public typealias HeadersType = DescribeServicesResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeServicesResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeTaskDefinition operation in a HTTP client.
+ */
+extension DescribeTaskDefinitionResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeTaskDefinitionResponse
+    public typealias HeadersType = DescribeTaskDefinitionResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeTaskDefinitionResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeTasks operation in a HTTP client.
+ */
+extension DescribeTasksResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeTasksResponse
+    public typealias HeadersType = DescribeTasksResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeTasksResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DiscoverPollEndpoint operation in a HTTP client.
+ */
+extension DiscoverPollEndpointResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = DiscoverPollEndpointResponse
+    public typealias HeadersType = DiscoverPollEndpointResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DiscoverPollEndpointResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListAccountSettings operation in a HTTP client.
+ */
+extension ListAccountSettingsResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListAccountSettingsResponse
+    public typealias HeadersType = ListAccountSettingsResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListAccountSettingsResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListAttributes operation in a HTTP client.
+ */
+extension ListAttributesResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListAttributesResponse
+    public typealias HeadersType = ListAttributesResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListAttributesResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListClusters operation in a HTTP client.
+ */
+extension ListClustersResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListClustersResponse
+    public typealias HeadersType = ListClustersResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListClustersResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListContainerInstances operation in a HTTP client.
+ */
+extension ListContainerInstancesResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListContainerInstancesResponse
+    public typealias HeadersType = ListContainerInstancesResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListContainerInstancesResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListServices operation in a HTTP client.
+ */
+extension ListServicesResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListServicesResponse
+    public typealias HeadersType = ListServicesResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListServicesResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListTagsForResource operation in a HTTP client.
+ */
+extension ListTagsForResourceResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListTagsForResourceResponse
+    public typealias HeadersType = ListTagsForResourceResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListTagsForResourceResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListTaskDefinitionFamilies operation in a HTTP client.
+ */
+extension ListTaskDefinitionFamiliesResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListTaskDefinitionFamiliesResponse
+    public typealias HeadersType = ListTaskDefinitionFamiliesResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListTaskDefinitionFamiliesResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListTaskDefinitions operation in a HTTP client.
+ */
+extension ListTaskDefinitionsResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListTaskDefinitionsResponse
+    public typealias HeadersType = ListTaskDefinitionsResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListTaskDefinitionsResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListTasks operation in a HTTP client.
+ */
+extension ListTasksResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListTasksResponse
+    public typealias HeadersType = ListTasksResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListTasksResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PutAccountSetting operation in a HTTP client.
+ */
+extension PutAccountSettingResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = PutAccountSettingResponse
+    public typealias HeadersType = PutAccountSettingResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PutAccountSettingResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PutAttributes operation in a HTTP client.
+ */
+extension PutAttributesResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = PutAttributesResponse
+    public typealias HeadersType = PutAttributesResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PutAttributesResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RegisterContainerInstance operation in a HTTP client.
+ */
+extension RegisterContainerInstanceResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = RegisterContainerInstanceResponse
+    public typealias HeadersType = RegisterContainerInstanceResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RegisterContainerInstanceResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RegisterTaskDefinition operation in a HTTP client.
+ */
+extension RegisterTaskDefinitionResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = RegisterTaskDefinitionResponse
+    public typealias HeadersType = RegisterTaskDefinitionResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RegisterTaskDefinitionResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RunTask operation in a HTTP client.
+ */
+extension RunTaskResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = RunTaskResponse
+    public typealias HeadersType = RunTaskResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RunTaskResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the StartTask operation in a HTTP client.
+ */
+extension StartTaskResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = StartTaskResponse
+    public typealias HeadersType = StartTaskResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> StartTaskResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the StopTask operation in a HTTP client.
+ */
+extension StopTaskResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = StopTaskResponse
+    public typealias HeadersType = StopTaskResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> StopTaskResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the SubmitContainerStateChange operation in a HTTP client.
+ */
+extension SubmitContainerStateChangeResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = SubmitContainerStateChangeResponse
+    public typealias HeadersType = SubmitContainerStateChangeResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> SubmitContainerStateChangeResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the SubmitTaskStateChange operation in a HTTP client.
+ */
+extension SubmitTaskStateChangeResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = SubmitTaskStateChangeResponse
+    public typealias HeadersType = SubmitTaskStateChangeResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> SubmitTaskStateChangeResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the TagResource operation in a HTTP client.
+ */
+extension TagResourceResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = TagResourceResponse
+    public typealias HeadersType = TagResourceResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> TagResourceResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UntagResource operation in a HTTP client.
+ */
+extension UntagResourceResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = UntagResourceResponse
+    public typealias HeadersType = UntagResourceResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UntagResourceResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateContainerAgent operation in a HTTP client.
+ */
+extension UpdateContainerAgentResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateContainerAgentResponse
+    public typealias HeadersType = UpdateContainerAgentResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateContainerAgentResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateContainerInstancesState operation in a HTTP client.
+ */
+extension UpdateContainerInstancesStateResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateContainerInstancesStateResponse
+    public typealias HeadersType = UpdateContainerInstancesStateResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateContainerInstancesStateResponse {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateService operation in a HTTP client.
+ */
+extension UpdateServiceResponse: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateServiceResponse
+    public typealias HeadersType = UpdateServiceResponse
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateServiceResponse {
+        return try bodyDecodableProvider()
+    }
+}
+

--- a/Sources/S3Client/AWSS3Client.swift
+++ b/Sources/S3Client/AWSS3Client.swift
@@ -1,0 +1,4439 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment type_body_length
+// -- Generated Code; do not edit --
+//
+// AWSS3Client.swift
+// S3Client
+//
+
+import Foundation
+import S3Model
+import SmokeHTTPClient
+import SmokeAWSCore
+import SmokeAWSHttp
+import NIO
+import NIOHTTP1
+
+public enum S3ClientError: Swift.Error {
+    case invalidEndpoint(String)
+    case unsupportedPayload
+    case unknownError(String?)
+}
+
+/**
+ AWS Client for the S3 service.
+ */
+public struct AWSS3Client: S3ClientProtocol {
+    let httpClient: HTTPClient
+    let dataHttpClient: HTTPClient
+    let awsRegion: AWSRegion
+    let service: String
+    let target: String?
+    let credentialsProvider: CredentialsProvider
+    
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
+                endpointHostName: String = "s3.amazonaws.com",
+                endpointPort: Int = 443,
+                service: String = "s3",
+                contentType: String = "application/x-amz-rest-xml",
+                target: String? = nil,
+                connectionTimeoutSeconds: Int = 10) {
+        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>()
+
+        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>()
+
+        self.httpClient = HTTPClient(endpointHostName: endpointHostName,
+                                     endpointPort: endpointPort,
+                                     contentType: contentType,
+                                     clientDelegate: clientDelegate,
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+        self.dataHttpClient = HTTPClient(endpointHostName: endpointHostName,
+                                     endpointPort: endpointPort,
+                                     contentType: contentType,
+                                     clientDelegate: clientDelegateForDataHttpClient,
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+        self.awsRegion = awsRegion ?? .us_east_1
+        self.service = service
+        self.target = target
+        self.credentialsProvider = credentialsProvider
+    }
+
+    /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times.
+     */
+    public func close() {
+        httpClient.close()
+        dataHttpClient.close()
+    }
+
+    /**
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
+     */
+    public func wait() {
+        httpClient.wait()
+        dataHttpClient.wait()
+    }
+
+    /**
+     Invokes the AbortMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated AbortMultipartUploadRequest object being passed to this operation.
+         - completion: The AbortMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The AbortMultipartUploadOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchUpload.
+     */
+    public func abortMultipartUploadAsync(input: S3Model.AbortMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.AbortMultipartUploadOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.abortMultipartUpload.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = AbortMultipartUploadOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the AbortMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated AbortMultipartUploadRequest object being passed to this operation.
+     - Returns: The AbortMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchUpload.
+     */
+    public func abortMultipartUploadSync(input: S3Model.AbortMultipartUploadRequest) throws -> S3Model.AbortMultipartUploadOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.abortMultipartUpload.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = AbortMultipartUploadOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the CompleteMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CompleteMultipartUploadRequest object being passed to this operation.
+         - completion: The CompleteMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The CompleteMultipartUploadOutput
+           object will be validated before being returned to caller.
+     */
+    public func completeMultipartUploadAsync(input: S3Model.CompleteMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.CompleteMultipartUploadOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.completeMultipartUpload.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = CompleteMultipartUploadOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .POST,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the CompleteMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CompleteMultipartUploadRequest object being passed to this operation.
+     - Returns: The CompleteMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func completeMultipartUploadSync(input: S3Model.CompleteMultipartUploadRequest) throws -> S3Model.CompleteMultipartUploadOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.completeMultipartUpload.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = CompleteMultipartUploadOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .POST,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the CopyObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CopyObjectRequest object being passed to this operation.
+         - completion: The CopyObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The CopyObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: objectNotInActiveTier.
+     */
+    public func copyObjectAsync(input: S3Model.CopyObjectRequest, completion: @escaping (HTTPResult<S3Model.CopyObjectOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.copyObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = CopyObjectOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the CopyObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CopyObjectRequest object being passed to this operation.
+     - Returns: The CopyObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: objectNotInActiveTier.
+     */
+    public func copyObjectSync(input: S3Model.CopyObjectRequest) throws -> S3Model.CopyObjectOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.copyObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = CopyObjectOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the CreateBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CreateBucketRequest object being passed to this operation.
+         - completion: The CreateBucketOutput object or an error will be passed to this 
+           callback when the operation is complete. The CreateBucketOutput
+           object will be validated before being returned to caller.
+           The possible errors are: bucketAlreadyExists, bucketAlreadyOwnedByYou.
+     */
+    public func createBucketAsync(input: S3Model.CreateBucketRequest, completion: @escaping (HTTPResult<S3Model.CreateBucketOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.createBucket.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = CreateBucketOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the CreateBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CreateBucketRequest object being passed to this operation.
+     - Returns: The CreateBucketOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: bucketAlreadyExists, bucketAlreadyOwnedByYou.
+     */
+    public func createBucketSync(input: S3Model.CreateBucketRequest) throws -> S3Model.CreateBucketOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.createBucket.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = CreateBucketOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the CreateMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CreateMultipartUploadRequest object being passed to this operation.
+         - completion: The CreateMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The CreateMultipartUploadOutput
+           object will be validated before being returned to caller.
+     */
+    public func createMultipartUploadAsync(input: S3Model.CreateMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.CreateMultipartUploadOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.createMultipartUpload.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = CreateMultipartUploadOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?uploads",
+            httpMethod: .POST,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the CreateMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CreateMultipartUploadRequest object being passed to this operation.
+     - Returns: The CreateMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func createMultipartUploadSync(input: S3Model.CreateMultipartUploadRequest) throws -> S3Model.CreateMultipartUploadOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.createMultipartUpload.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = CreateMultipartUploadOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?uploads",
+            httpMethod: .POST,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketAsync(input: S3Model.DeleteBucketRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucket.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketRequest object being passed to this operation.
+     */
+    public func deleteBucketSync(input: S3Model.DeleteBucketRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucket.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketAnalyticsConfigurationAsync(input: S3Model.DeleteBucketAnalyticsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketAnalyticsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketAnalyticsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?analytics",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketAnalyticsConfigurationRequest object being passed to this operation.
+     */
+    public func deleteBucketAnalyticsConfigurationSync(input: S3Model.DeleteBucketAnalyticsConfigurationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketAnalyticsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketAnalyticsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?analytics",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketCorsRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketCorsAsync(input: S3Model.DeleteBucketCorsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketCors.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketCorsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?cors",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketCorsRequest object being passed to this operation.
+     */
+    public func deleteBucketCorsSync(input: S3Model.DeleteBucketCorsRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketCors.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketCorsOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?cors",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketEncryptionRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketEncryptionAsync(input: S3Model.DeleteBucketEncryptionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketEncryption.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketEncryptionOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?encryption",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketEncryptionRequest object being passed to this operation.
+     */
+    public func deleteBucketEncryptionSync(input: S3Model.DeleteBucketEncryptionRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketEncryption.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketEncryptionOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?encryption",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketInventoryConfigurationAsync(input: S3Model.DeleteBucketInventoryConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketInventoryConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketInventoryConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?inventory",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketInventoryConfigurationRequest object being passed to this operation.
+     */
+    public func deleteBucketInventoryConfigurationSync(input: S3Model.DeleteBucketInventoryConfigurationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketInventoryConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketInventoryConfigurationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?inventory",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketLifecycleRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketLifecycleAsync(input: S3Model.DeleteBucketLifecycleRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketLifecycle.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketLifecycleOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?lifecycle",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketLifecycleRequest object being passed to this operation.
+     */
+    public func deleteBucketLifecycleSync(input: S3Model.DeleteBucketLifecycleRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketLifecycle.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketLifecycleOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?lifecycle",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketMetricsConfigurationAsync(input: S3Model.DeleteBucketMetricsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketMetricsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketMetricsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?metrics",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketMetricsConfigurationRequest object being passed to this operation.
+     */
+    public func deleteBucketMetricsConfigurationSync(input: S3Model.DeleteBucketMetricsConfigurationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketMetricsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketMetricsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?metrics",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketPolicyRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketPolicyAsync(input: S3Model.DeleteBucketPolicyRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketPolicy.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketPolicyOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?policy",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketPolicyRequest object being passed to this operation.
+     */
+    public func deleteBucketPolicySync(input: S3Model.DeleteBucketPolicyRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketPolicy.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketPolicyOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?policy",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketReplicationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketReplicationAsync(input: S3Model.DeleteBucketReplicationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketReplication.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketReplicationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?replication",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketReplicationRequest object being passed to this operation.
+     */
+    public func deleteBucketReplicationSync(input: S3Model.DeleteBucketReplicationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketReplication.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketReplicationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?replication",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketTaggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketTaggingAsync(input: S3Model.DeleteBucketTaggingRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketTaggingOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?tagging",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketTaggingRequest object being passed to this operation.
+     */
+    public func deleteBucketTaggingSync(input: S3Model.DeleteBucketTaggingRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketTaggingOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?tagging",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketWebsiteRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketWebsiteAsync(input: S3Model.DeleteBucketWebsiteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketWebsite.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketWebsiteOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?website",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketWebsiteRequest object being passed to this operation.
+     */
+    public func deleteBucketWebsiteSync(input: S3Model.DeleteBucketWebsiteRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteBucketWebsite.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteBucketWebsiteOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?website",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectRequest object being passed to this operation.
+         - completion: The DeleteObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectOutput
+           object will be validated before being returned to caller.
+     */
+    public func deleteObjectAsync(input: S3Model.DeleteObjectRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteObjectOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectRequest object being passed to this operation.
+     - Returns: The DeleteObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func deleteObjectSync(input: S3Model.DeleteObjectRequest) throws -> S3Model.DeleteObjectOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteObjectOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectTaggingRequest object being passed to this operation.
+         - completion: The DeleteObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func deleteObjectTaggingAsync(input: S3Model.DeleteObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectTaggingOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteObjectTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteObjectTaggingOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?tagging",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectTaggingRequest object being passed to this operation.
+     - Returns: The DeleteObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func deleteObjectTaggingSync(input: S3Model.DeleteObjectTaggingRequest) throws -> S3Model.DeleteObjectTaggingOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteObjectTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteObjectTaggingOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?tagging",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteObjects operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectsRequest object being passed to this operation.
+         - completion: The DeleteObjectsOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectsOutput
+           object will be validated before being returned to caller.
+     */
+    public func deleteObjectsAsync(input: S3Model.DeleteObjectsRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectsOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteObjects.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteObjectsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?delete",
+            httpMethod: .POST,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeleteObjects operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectsRequest object being passed to this operation.
+     - Returns: The DeleteObjectsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func deleteObjectsSync(input: S3Model.DeleteObjectsRequest) throws -> S3Model.DeleteObjectsOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deleteObjects.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeleteObjectsOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?delete",
+            httpMethod: .POST,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeletePublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeletePublicAccessBlockRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deletePublicAccessBlockAsync(input: S3Model.DeletePublicAccessBlockRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deletePublicAccessBlock.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeletePublicAccessBlockOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?publicAccessBlock",
+            httpMethod: .DELETE,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the DeletePublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeletePublicAccessBlockRequest object being passed to this operation.
+     */
+    public func deletePublicAccessBlockSync(input: S3Model.DeletePublicAccessBlockRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.deletePublicAccessBlock.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = DeletePublicAccessBlockOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?publicAccessBlock",
+            httpMethod: .DELETE,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketAccelerateConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAccelerateConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketAccelerateConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAccelerateConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketAccelerateConfigurationAsync(input: S3Model.GetBucketAccelerateConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAccelerateConfigurationOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketAccelerateConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketAccelerateConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?accelerate",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketAccelerateConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAccelerateConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketAccelerateConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketAccelerateConfigurationSync(input: S3Model.GetBucketAccelerateConfigurationRequest) throws -> S3Model.GetBucketAccelerateConfigurationOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketAccelerateConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketAccelerateConfigurationOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?accelerate",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAclRequest object being passed to this operation.
+         - completion: The GetBucketAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAclOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketAclAsync(input: S3Model.GetBucketAclRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAclOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketAcl.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketAclOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?acl",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAclRequest object being passed to this operation.
+     - Returns: The GetBucketAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketAclSync(input: S3Model.GetBucketAclRequest) throws -> S3Model.GetBucketAclOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketAcl.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketAclOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?acl",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketAnalyticsConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAnalyticsConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketAnalyticsConfigurationAsync(input: S3Model.GetBucketAnalyticsConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAnalyticsConfigurationOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketAnalyticsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketAnalyticsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?analytics",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAnalyticsConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketAnalyticsConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketAnalyticsConfigurationSync(input: S3Model.GetBucketAnalyticsConfigurationRequest) throws -> S3Model.GetBucketAnalyticsConfigurationOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketAnalyticsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketAnalyticsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?analytics",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketCorsRequest object being passed to this operation.
+         - completion: The GetBucketCorsOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketCorsOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketCorsAsync(input: S3Model.GetBucketCorsRequest, completion: @escaping (HTTPResult<S3Model.GetBucketCorsOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketCors.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketCorsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?cors",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketCorsRequest object being passed to this operation.
+     - Returns: The GetBucketCorsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketCorsSync(input: S3Model.GetBucketCorsRequest) throws -> S3Model.GetBucketCorsOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketCors.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketCorsOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?cors",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketEncryptionRequest object being passed to this operation.
+         - completion: The GetBucketEncryptionOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketEncryptionOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketEncryptionAsync(input: S3Model.GetBucketEncryptionRequest, completion: @escaping (HTTPResult<S3Model.GetBucketEncryptionOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketEncryption.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketEncryptionOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?encryption",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketEncryptionRequest object being passed to this operation.
+     - Returns: The GetBucketEncryptionOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketEncryptionSync(input: S3Model.GetBucketEncryptionRequest) throws -> S3Model.GetBucketEncryptionOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketEncryption.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketEncryptionOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?encryption",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketInventoryConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketInventoryConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketInventoryConfigurationAsync(input: S3Model.GetBucketInventoryConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketInventoryConfigurationOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketInventoryConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketInventoryConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?inventory",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketInventoryConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketInventoryConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketInventoryConfigurationSync(input: S3Model.GetBucketInventoryConfigurationRequest) throws -> S3Model.GetBucketInventoryConfigurationOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketInventoryConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketInventoryConfigurationOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?inventory",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleRequest object being passed to this operation.
+         - completion: The GetBucketLifecycleOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLifecycleOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleAsync(input: S3Model.GetBucketLifecycleRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLifecycleOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketLifecycle.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketLifecycleOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?lifecycle",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleRequest object being passed to this operation.
+     - Returns: The GetBucketLifecycleOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleSync(input: S3Model.GetBucketLifecycleRequest) throws -> S3Model.GetBucketLifecycleOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketLifecycle.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketLifecycleOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?lifecycle",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketLifecycleConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketLifecycleConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLifecycleConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleConfigurationAsync(input: S3Model.GetBucketLifecycleConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLifecycleConfigurationOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketLifecycleConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketLifecycleConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?lifecycle",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketLifecycleConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketLifecycleConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleConfigurationSync(input: S3Model.GetBucketLifecycleConfigurationRequest) throws -> S3Model.GetBucketLifecycleConfigurationOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketLifecycleConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketLifecycleConfigurationOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?lifecycle",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketLocation operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLocationRequest object being passed to this operation.
+         - completion: The GetBucketLocationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLocationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLocationAsync(input: S3Model.GetBucketLocationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLocationOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketLocation.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketLocationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?location",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketLocation operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLocationRequest object being passed to this operation.
+     - Returns: The GetBucketLocationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLocationSync(input: S3Model.GetBucketLocationRequest) throws -> S3Model.GetBucketLocationOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketLocation.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketLocationOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?location",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketLogging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLoggingRequest object being passed to this operation.
+         - completion: The GetBucketLoggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLoggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLoggingAsync(input: S3Model.GetBucketLoggingRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLoggingOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketLogging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketLoggingOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?logging",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketLogging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLoggingRequest object being passed to this operation.
+     - Returns: The GetBucketLoggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLoggingSync(input: S3Model.GetBucketLoggingRequest) throws -> S3Model.GetBucketLoggingOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketLogging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketLoggingOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?logging",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketMetricsConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketMetricsConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketMetricsConfigurationAsync(input: S3Model.GetBucketMetricsConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketMetricsConfigurationOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketMetricsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketMetricsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?metrics",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketMetricsConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketMetricsConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketMetricsConfigurationSync(input: S3Model.GetBucketMetricsConfigurationRequest) throws -> S3Model.GetBucketMetricsConfigurationOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketMetricsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketMetricsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?metrics",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketNotification operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: The NotificationConfigurationDeprecated object or an error will be passed to this 
+           callback when the operation is complete. The NotificationConfigurationDeprecated
+           object will be validated before being returned to caller.
+     */
+    public func getBucketNotificationAsync(input: S3Model.GetBucketNotificationConfigurationRequest, completion: @escaping (HTTPResult<S3Model.NotificationConfigurationDeprecated>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketNotification.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketNotificationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?notification",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketNotification operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+     - Returns: The NotificationConfigurationDeprecated object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketNotificationSync(input: S3Model.GetBucketNotificationConfigurationRequest) throws -> S3Model.NotificationConfigurationDeprecated {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketNotification.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketNotificationOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?notification",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketNotificationConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: The NotificationConfiguration object or an error will be passed to this 
+           callback when the operation is complete. The NotificationConfiguration
+           object will be validated before being returned to caller.
+     */
+    public func getBucketNotificationConfigurationAsync(input: S3Model.GetBucketNotificationConfigurationRequest, completion: @escaping (HTTPResult<S3Model.NotificationConfiguration>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketNotificationConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketNotificationConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?notification",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketNotificationConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+     - Returns: The NotificationConfiguration object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketNotificationConfigurationSync(input: S3Model.GetBucketNotificationConfigurationRequest) throws -> S3Model.NotificationConfiguration {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketNotificationConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketNotificationConfigurationOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?notification",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyRequest object being passed to this operation.
+         - completion: The GetBucketPolicyOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketPolicyOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketPolicyAsync(input: S3Model.GetBucketPolicyRequest, completion: @escaping (HTTPResult<S3Model.GetBucketPolicyOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketPolicy.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketPolicyOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?policy",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyRequest object being passed to this operation.
+     - Returns: The GetBucketPolicyOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketPolicySync(input: S3Model.GetBucketPolicyRequest) throws -> S3Model.GetBucketPolicyOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketPolicy.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketPolicyOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?policy",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketPolicyStatus operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyStatusRequest object being passed to this operation.
+         - completion: The GetBucketPolicyStatusOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketPolicyStatusOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketPolicyStatusAsync(input: S3Model.GetBucketPolicyStatusRequest, completion: @escaping (HTTPResult<S3Model.GetBucketPolicyStatusOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketPolicyStatus.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketPolicyStatusOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?policyStatus",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketPolicyStatus operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyStatusRequest object being passed to this operation.
+     - Returns: The GetBucketPolicyStatusOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketPolicyStatusSync(input: S3Model.GetBucketPolicyStatusRequest) throws -> S3Model.GetBucketPolicyStatusOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketPolicyStatus.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketPolicyStatusOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?policyStatus",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketReplicationRequest object being passed to this operation.
+         - completion: The GetBucketReplicationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketReplicationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketReplicationAsync(input: S3Model.GetBucketReplicationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketReplicationOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketReplication.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketReplicationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?replication",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketReplicationRequest object being passed to this operation.
+     - Returns: The GetBucketReplicationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketReplicationSync(input: S3Model.GetBucketReplicationRequest) throws -> S3Model.GetBucketReplicationOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketReplication.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketReplicationOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?replication",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketRequestPayment operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketRequestPaymentRequest object being passed to this operation.
+         - completion: The GetBucketRequestPaymentOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketRequestPaymentOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketRequestPaymentAsync(input: S3Model.GetBucketRequestPaymentRequest, completion: @escaping (HTTPResult<S3Model.GetBucketRequestPaymentOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketRequestPayment.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketRequestPaymentOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?requestPayment",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketRequestPayment operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketRequestPaymentRequest object being passed to this operation.
+     - Returns: The GetBucketRequestPaymentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketRequestPaymentSync(input: S3Model.GetBucketRequestPaymentRequest) throws -> S3Model.GetBucketRequestPaymentOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketRequestPayment.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketRequestPaymentOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?requestPayment",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketTaggingRequest object being passed to this operation.
+         - completion: The GetBucketTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketTaggingAsync(input: S3Model.GetBucketTaggingRequest, completion: @escaping (HTTPResult<S3Model.GetBucketTaggingOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketTaggingOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?tagging",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketTaggingRequest object being passed to this operation.
+     - Returns: The GetBucketTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketTaggingSync(input: S3Model.GetBucketTaggingRequest) throws -> S3Model.GetBucketTaggingOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketTaggingOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?tagging",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketVersioning operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketVersioningRequest object being passed to this operation.
+         - completion: The GetBucketVersioningOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketVersioningOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketVersioningAsync(input: S3Model.GetBucketVersioningRequest, completion: @escaping (HTTPResult<S3Model.GetBucketVersioningOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketVersioning.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketVersioningOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?versioning",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketVersioning operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketVersioningRequest object being passed to this operation.
+     - Returns: The GetBucketVersioningOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketVersioningSync(input: S3Model.GetBucketVersioningRequest) throws -> S3Model.GetBucketVersioningOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketVersioning.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketVersioningOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?versioning",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketWebsiteRequest object being passed to this operation.
+         - completion: The GetBucketWebsiteOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketWebsiteOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketWebsiteAsync(input: S3Model.GetBucketWebsiteRequest, completion: @escaping (HTTPResult<S3Model.GetBucketWebsiteOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketWebsite.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketWebsiteOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?website",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketWebsiteRequest object being passed to this operation.
+     - Returns: The GetBucketWebsiteOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketWebsiteSync(input: S3Model.GetBucketWebsiteRequest) throws -> S3Model.GetBucketWebsiteOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getBucketWebsite.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetBucketWebsiteOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?website",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectRequest object being passed to this operation.
+         - completion: The GetObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func getObjectAsync(input: S3Model.GetObjectRequest, completion: @escaping (HTTPResult<S3Model.GetObjectOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetObjectOperationHTTPRequestInput(encodable: input)
+
+        _ = try dataHttpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectRequest object being passed to this operation.
+     - Returns: The GetObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func getObjectSync(input: S3Model.GetObjectRequest) throws -> S3Model.GetObjectOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetObjectOperationHTTPRequestInput(encodable: input)
+
+        return try dataHttpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetObjectAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectAclRequest object being passed to this operation.
+         - completion: The GetObjectAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectAclOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func getObjectAclAsync(input: S3Model.GetObjectAclRequest, completion: @escaping (HTTPResult<S3Model.GetObjectAclOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getObjectAcl.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetObjectAclOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?acl",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetObjectAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectAclRequest object being passed to this operation.
+     - Returns: The GetObjectAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func getObjectAclSync(input: S3Model.GetObjectAclRequest) throws -> S3Model.GetObjectAclOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getObjectAcl.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetObjectAclOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?acl",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectTaggingRequest object being passed to this operation.
+         - completion: The GetObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func getObjectTaggingAsync(input: S3Model.GetObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.GetObjectTaggingOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getObjectTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetObjectTaggingOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?tagging",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectTaggingRequest object being passed to this operation.
+     - Returns: The GetObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getObjectTaggingSync(input: S3Model.GetObjectTaggingRequest) throws -> S3Model.GetObjectTaggingOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getObjectTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetObjectTaggingOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?tagging",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetObjectTorrent operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectTorrentRequest object being passed to this operation.
+         - completion: The GetObjectTorrentOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectTorrentOutput
+           object will be validated before being returned to caller.
+     */
+    public func getObjectTorrentAsync(input: S3Model.GetObjectTorrentRequest, completion: @escaping (HTTPResult<S3Model.GetObjectTorrentOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getObjectTorrent.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetObjectTorrentOperationHTTPRequestInput(encodable: input)
+
+        _ = try dataHttpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?torrent",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetObjectTorrent operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectTorrentRequest object being passed to this operation.
+     - Returns: The GetObjectTorrentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getObjectTorrentSync(input: S3Model.GetObjectTorrentRequest) throws -> S3Model.GetObjectTorrentOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getObjectTorrent.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetObjectTorrentOperationHTTPRequestInput(encodable: input)
+
+        return try dataHttpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?torrent",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetPublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetPublicAccessBlockRequest object being passed to this operation.
+         - completion: The GetPublicAccessBlockOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetPublicAccessBlockOutput
+           object will be validated before being returned to caller.
+     */
+    public func getPublicAccessBlockAsync(input: S3Model.GetPublicAccessBlockRequest, completion: @escaping (HTTPResult<S3Model.GetPublicAccessBlockOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getPublicAccessBlock.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetPublicAccessBlockOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?publicAccessBlock",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the GetPublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetPublicAccessBlockRequest object being passed to this operation.
+     - Returns: The GetPublicAccessBlockOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getPublicAccessBlockSync(input: S3Model.GetPublicAccessBlockRequest) throws -> S3Model.GetPublicAccessBlockOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.getPublicAccessBlock.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = GetPublicAccessBlockOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?publicAccessBlock",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the HeadBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated HeadBucketRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+           The possible errors are: noSuchBucket.
+     */
+    public func headBucketAsync(input: S3Model.HeadBucketRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.headBucket.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = HeadBucketOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}",
+            httpMethod: .HEAD,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the HeadBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated HeadBucketRequest object being passed to this operation.
+     - Throws: noSuchBucket.
+     */
+    public func headBucketSync(input: S3Model.HeadBucketRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.headBucket.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = HeadBucketOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}",
+            httpMethod: .HEAD,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the HeadObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated HeadObjectRequest object being passed to this operation.
+         - completion: The HeadObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The HeadObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func headObjectAsync(input: S3Model.HeadObjectRequest, completion: @escaping (HTTPResult<S3Model.HeadObjectOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.headObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = HeadObjectOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .HEAD,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the HeadObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated HeadObjectRequest object being passed to this operation.
+     - Returns: The HeadObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func headObjectSync(input: S3Model.HeadObjectRequest) throws -> S3Model.HeadObjectOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.headObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = HeadObjectOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .HEAD,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListBucketAnalyticsConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketAnalyticsConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketAnalyticsConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketAnalyticsConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketAnalyticsConfigurationsAsync(input: S3Model.ListBucketAnalyticsConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketAnalyticsConfigurationsOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listBucketAnalyticsConfigurations.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListBucketAnalyticsConfigurationsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?analytics",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListBucketAnalyticsConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketAnalyticsConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketAnalyticsConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketAnalyticsConfigurationsSync(input: S3Model.ListBucketAnalyticsConfigurationsRequest) throws -> S3Model.ListBucketAnalyticsConfigurationsOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listBucketAnalyticsConfigurations.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListBucketAnalyticsConfigurationsOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?analytics",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListBucketInventoryConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketInventoryConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketInventoryConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketInventoryConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketInventoryConfigurationsAsync(input: S3Model.ListBucketInventoryConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketInventoryConfigurationsOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listBucketInventoryConfigurations.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListBucketInventoryConfigurationsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?inventory",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListBucketInventoryConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketInventoryConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketInventoryConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketInventoryConfigurationsSync(input: S3Model.ListBucketInventoryConfigurationsRequest) throws -> S3Model.ListBucketInventoryConfigurationsOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listBucketInventoryConfigurations.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListBucketInventoryConfigurationsOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?inventory",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListBucketMetricsConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketMetricsConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketMetricsConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketMetricsConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketMetricsConfigurationsAsync(input: S3Model.ListBucketMetricsConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketMetricsConfigurationsOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listBucketMetricsConfigurations.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListBucketMetricsConfigurationsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?metrics",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListBucketMetricsConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketMetricsConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketMetricsConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketMetricsConfigurationsSync(input: S3Model.ListBucketMetricsConfigurationsRequest) throws -> S3Model.ListBucketMetricsConfigurationsOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listBucketMetricsConfigurations.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListBucketMetricsConfigurationsOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?metrics",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListBuckets operation returning immediately and passing the response to a callback.
+         - completion: The ListBucketsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketsAsync(completion: @escaping (HTTPResult<S3Model.ListBucketsOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listBuckets.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = NoHTTPRequestInput()
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListBuckets operation waiting for the response before returning.
+     - Returns: The ListBucketsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketsSync() throws -> S3Model.ListBucketsOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listBuckets.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = NoHTTPRequestInput()
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListMultipartUploads operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListMultipartUploadsRequest object being passed to this operation.
+         - completion: The ListMultipartUploadsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListMultipartUploadsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listMultipartUploadsAsync(input: S3Model.ListMultipartUploadsRequest, completion: @escaping (HTTPResult<S3Model.ListMultipartUploadsOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listMultipartUploads.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListMultipartUploadsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?uploads",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListMultipartUploads operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListMultipartUploadsRequest object being passed to this operation.
+     - Returns: The ListMultipartUploadsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listMultipartUploadsSync(input: S3Model.ListMultipartUploadsRequest) throws -> S3Model.ListMultipartUploadsOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listMultipartUploads.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListMultipartUploadsOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?uploads",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListObjectVersions operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectVersionsRequest object being passed to this operation.
+         - completion: The ListObjectVersionsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectVersionsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listObjectVersionsAsync(input: S3Model.ListObjectVersionsRequest, completion: @escaping (HTTPResult<S3Model.ListObjectVersionsOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listObjectVersions.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListObjectVersionsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?versions",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListObjectVersions operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectVersionsRequest object being passed to this operation.
+     - Returns: The ListObjectVersionsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listObjectVersionsSync(input: S3Model.ListObjectVersionsRequest) throws -> S3Model.ListObjectVersionsOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listObjectVersions.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListObjectVersionsOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?versions",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListObjects operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectsRequest object being passed to this operation.
+         - completion: The ListObjectsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectsOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchBucket.
+     */
+    public func listObjectsAsync(input: S3Model.ListObjectsRequest, completion: @escaping (HTTPResult<S3Model.ListObjectsOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listObjects.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListObjectsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListObjects operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectsRequest object being passed to this operation.
+     - Returns: The ListObjectsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchBucket.
+     */
+    public func listObjectsSync(input: S3Model.ListObjectsRequest) throws -> S3Model.ListObjectsOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listObjects.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListObjectsOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListObjectsV2 operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectsV2Request object being passed to this operation.
+         - completion: The ListObjectsV2Output object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectsV2Output
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchBucket.
+     */
+    public func listObjectsV2Async(input: S3Model.ListObjectsV2Request, completion: @escaping (HTTPResult<S3Model.ListObjectsV2Output>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listObjectsV2.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListObjectsV2OperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}?list-type=2",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListObjectsV2 operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectsV2Request object being passed to this operation.
+     - Returns: The ListObjectsV2Output object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchBucket.
+     */
+    public func listObjectsV2Sync(input: S3Model.ListObjectsV2Request) throws -> S3Model.ListObjectsV2Output {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listObjectsV2.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListObjectsV2OperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}?list-type=2",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListParts operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListPartsRequest object being passed to this operation.
+         - completion: The ListPartsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListPartsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listPartsAsync(input: S3Model.ListPartsRequest, completion: @escaping (HTTPResult<S3Model.ListPartsOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listParts.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListPartsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .GET,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the ListParts operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListPartsRequest object being passed to this operation.
+     - Returns: The ListPartsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listPartsSync(input: S3Model.ListPartsRequest) throws -> S3Model.ListPartsOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.listParts.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = ListPartsOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .GET,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketAccelerateConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAccelerateConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketAccelerateConfigurationAsync(input: S3Model.PutBucketAccelerateConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketAccelerateConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketAccelerateConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?accelerate",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketAccelerateConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAccelerateConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketAccelerateConfigurationSync(input: S3Model.PutBucketAccelerateConfigurationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketAccelerateConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketAccelerateConfigurationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?accelerate",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAclRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketAclAsync(input: S3Model.PutBucketAclRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketAcl.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketAclOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?acl",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAclRequest object being passed to this operation.
+     */
+    public func putBucketAclSync(input: S3Model.PutBucketAclRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketAcl.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketAclOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?acl",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketAnalyticsConfigurationAsync(input: S3Model.PutBucketAnalyticsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketAnalyticsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketAnalyticsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?analytics",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAnalyticsConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketAnalyticsConfigurationSync(input: S3Model.PutBucketAnalyticsConfigurationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketAnalyticsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketAnalyticsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?analytics",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketCorsRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketCorsAsync(input: S3Model.PutBucketCorsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketCors.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketCorsOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?cors",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketCorsRequest object being passed to this operation.
+     */
+    public func putBucketCorsSync(input: S3Model.PutBucketCorsRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketCors.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketCorsOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?cors",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketEncryptionRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketEncryptionAsync(input: S3Model.PutBucketEncryptionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketEncryption.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketEncryptionOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?encryption",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketEncryptionRequest object being passed to this operation.
+     */
+    public func putBucketEncryptionSync(input: S3Model.PutBucketEncryptionRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketEncryption.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketEncryptionOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?encryption",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketInventoryConfigurationAsync(input: S3Model.PutBucketInventoryConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketInventoryConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketInventoryConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?inventory",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketInventoryConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketInventoryConfigurationSync(input: S3Model.PutBucketInventoryConfigurationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketInventoryConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketInventoryConfigurationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?inventory",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketLifecycleAsync(input: S3Model.PutBucketLifecycleRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketLifecycle.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketLifecycleOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?lifecycle",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleRequest object being passed to this operation.
+     */
+    public func putBucketLifecycleSync(input: S3Model.PutBucketLifecycleRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketLifecycle.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketLifecycleOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?lifecycle",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketLifecycleConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketLifecycleConfigurationAsync(input: S3Model.PutBucketLifecycleConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketLifecycleConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketLifecycleConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?lifecycle",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketLifecycleConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketLifecycleConfigurationSync(input: S3Model.PutBucketLifecycleConfigurationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketLifecycleConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketLifecycleConfigurationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?lifecycle",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketLogging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLoggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketLoggingAsync(input: S3Model.PutBucketLoggingRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketLogging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketLoggingOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?logging",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketLogging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLoggingRequest object being passed to this operation.
+     */
+    public func putBucketLoggingSync(input: S3Model.PutBucketLoggingRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketLogging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketLoggingOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?logging",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketMetricsConfigurationAsync(input: S3Model.PutBucketMetricsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketMetricsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketMetricsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?metrics",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketMetricsConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketMetricsConfigurationSync(input: S3Model.PutBucketMetricsConfigurationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketMetricsConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketMetricsConfigurationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?metrics",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketNotification operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketNotificationAsync(input: S3Model.PutBucketNotificationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketNotification.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketNotificationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?notification",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketNotification operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationRequest object being passed to this operation.
+     */
+    public func putBucketNotificationSync(input: S3Model.PutBucketNotificationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketNotification.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketNotificationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?notification",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketNotificationConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketNotificationConfigurationAsync(input: S3Model.PutBucketNotificationConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketNotificationConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketNotificationConfigurationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?notification",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketNotificationConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketNotificationConfigurationSync(input: S3Model.PutBucketNotificationConfigurationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketNotificationConfiguration.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketNotificationConfigurationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?notification",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketPolicyRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketPolicyAsync(input: S3Model.PutBucketPolicyRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketPolicy.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketPolicyOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?policy",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketPolicyRequest object being passed to this operation.
+     */
+    public func putBucketPolicySync(input: S3Model.PutBucketPolicyRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketPolicy.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketPolicyOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?policy",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketReplicationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketReplicationAsync(input: S3Model.PutBucketReplicationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketReplication.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketReplicationOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?replication",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketReplicationRequest object being passed to this operation.
+     */
+    public func putBucketReplicationSync(input: S3Model.PutBucketReplicationRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketReplication.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketReplicationOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?replication",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketRequestPayment operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketRequestPaymentRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketRequestPaymentAsync(input: S3Model.PutBucketRequestPaymentRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketRequestPayment.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketRequestPaymentOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?requestPayment",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketRequestPayment operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketRequestPaymentRequest object being passed to this operation.
+     */
+    public func putBucketRequestPaymentSync(input: S3Model.PutBucketRequestPaymentRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketRequestPayment.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketRequestPaymentOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?requestPayment",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketTaggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketTaggingAsync(input: S3Model.PutBucketTaggingRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketTaggingOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?tagging",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketTaggingRequest object being passed to this operation.
+     */
+    public func putBucketTaggingSync(input: S3Model.PutBucketTaggingRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketTaggingOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?tagging",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketVersioning operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketVersioningRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketVersioningAsync(input: S3Model.PutBucketVersioningRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketVersioning.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketVersioningOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?versioning",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketVersioning operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketVersioningRequest object being passed to this operation.
+     */
+    public func putBucketVersioningSync(input: S3Model.PutBucketVersioningRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketVersioning.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketVersioningOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?versioning",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketWebsiteRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketWebsiteAsync(input: S3Model.PutBucketWebsiteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketWebsite.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketWebsiteOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?website",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketWebsiteRequest object being passed to this operation.
+     */
+    public func putBucketWebsiteSync(input: S3Model.PutBucketWebsiteRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putBucketWebsite.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutBucketWebsiteOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?website",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectRequest object being passed to this operation.
+         - completion: The PutObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectOutput
+           object will be validated before being returned to caller.
+     */
+    public func putObjectAsync(input: S3Model.PutObjectRequest, completion: @escaping (HTTPResult<S3Model.PutObjectOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutObjectOperationHTTPRequestInput(encodable: input)
+
+        _ = try dataHttpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectRequest object being passed to this operation.
+     - Returns: The PutObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func putObjectSync(input: S3Model.PutObjectRequest) throws -> S3Model.PutObjectOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutObjectOperationHTTPRequestInput(encodable: input)
+
+        return try dataHttpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutObjectAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectAclRequest object being passed to this operation.
+         - completion: The PutObjectAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectAclOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func putObjectAclAsync(input: S3Model.PutObjectAclRequest, completion: @escaping (HTTPResult<S3Model.PutObjectAclOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putObjectAcl.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutObjectAclOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?acl",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutObjectAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectAclRequest object being passed to this operation.
+     - Returns: The PutObjectAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func putObjectAclSync(input: S3Model.PutObjectAclRequest) throws -> S3Model.PutObjectAclOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putObjectAcl.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutObjectAclOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?acl",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectTaggingRequest object being passed to this operation.
+         - completion: The PutObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func putObjectTaggingAsync(input: S3Model.PutObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.PutObjectTaggingOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putObjectTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutObjectTaggingOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?tagging",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectTaggingRequest object being passed to this operation.
+     - Returns: The PutObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func putObjectTaggingSync(input: S3Model.PutObjectTaggingRequest) throws -> S3Model.PutObjectTaggingOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putObjectTagging.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutObjectTaggingOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?tagging",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutPublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutPublicAccessBlockRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putPublicAccessBlockAsync(input: S3Model.PutPublicAccessBlockRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putPublicAccessBlock.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutPublicAccessBlockOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithoutOutput(
+            endpointPath: "/{Bucket}?publicAccessBlock",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the PutPublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutPublicAccessBlockRequest object being passed to this operation.
+     */
+    public func putPublicAccessBlockSync(input: S3Model.PutPublicAccessBlockRequest) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.putPublicAccessBlock.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = PutPublicAccessBlockOperationHTTPRequestInput(encodable: input)
+
+        try httpClient.executeSyncWithoutOutput(
+            endpointPath: "/{Bucket}?publicAccessBlock",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the RestoreObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated RestoreObjectRequest object being passed to this operation.
+         - completion: The RestoreObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The RestoreObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: objectAlreadyInActiveTier.
+     */
+    public func restoreObjectAsync(input: S3Model.RestoreObjectRequest, completion: @escaping (HTTPResult<S3Model.RestoreObjectOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.restoreObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = RestoreObjectOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?restore",
+            httpMethod: .POST,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the RestoreObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated RestoreObjectRequest object being passed to this operation.
+     - Returns: The RestoreObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: objectAlreadyInActiveTier.
+     */
+    public func restoreObjectSync(input: S3Model.RestoreObjectRequest) throws -> S3Model.RestoreObjectOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.restoreObject.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = RestoreObjectOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?restore",
+            httpMethod: .POST,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the SelectObjectContent operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated SelectObjectContentRequest object being passed to this operation.
+         - completion: The SelectObjectContentOutput object or an error will be passed to this 
+           callback when the operation is complete. The SelectObjectContentOutput
+           object will be validated before being returned to caller.
+     */
+    public func selectObjectContentAsync(input: S3Model.SelectObjectContentRequest, completion: @escaping (HTTPResult<S3Model.SelectObjectContentOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.selectObjectContent.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = SelectObjectContentOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?select&select-type=2",
+            httpMethod: .POST,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the SelectObjectContent operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated SelectObjectContentRequest object being passed to this operation.
+     - Returns: The SelectObjectContentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func selectObjectContentSync(input: S3Model.SelectObjectContentRequest) throws -> S3Model.SelectObjectContentOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.selectObjectContent.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = SelectObjectContentOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}?select&select-type=2",
+            httpMethod: .POST,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the UploadPart operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated UploadPartRequest object being passed to this operation.
+         - completion: The UploadPartOutput object or an error will be passed to this 
+           callback when the operation is complete. The UploadPartOutput
+           object will be validated before being returned to caller.
+     */
+    public func uploadPartAsync(input: S3Model.UploadPartRequest, completion: @escaping (HTTPResult<S3Model.UploadPartOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.uploadPart.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = UploadPartOperationHTTPRequestInput(encodable: input)
+
+        _ = try dataHttpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the UploadPart operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated UploadPartRequest object being passed to this operation.
+     - Returns: The UploadPartOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func uploadPartSync(input: S3Model.UploadPartRequest) throws -> S3Model.UploadPartOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.uploadPart.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = UploadPartOperationHTTPRequestInput(encodable: input)
+
+        return try dataHttpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the UploadPartCopy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated UploadPartCopyRequest object being passed to this operation.
+         - completion: The UploadPartCopyOutput object or an error will be passed to this 
+           callback when the operation is complete. The UploadPartCopyOutput
+           object will be validated before being returned to caller.
+     */
+    public func uploadPartCopyAsync(input: S3Model.UploadPartCopyRequest, completion: @escaping (HTTPResult<S3Model.UploadPartCopyOutput>) -> ()) throws {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.uploadPartCopy.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = UploadPartCopyOperationHTTPRequestInput(encodable: input)
+
+        _ = try httpClient.executeAsyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .PUT,
+            input: requestInput,
+            completion: completion,
+            handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Invokes the UploadPartCopy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated UploadPartCopyRequest object being passed to this operation.
+     - Returns: The UploadPartCopyOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func uploadPartCopySync(input: S3Model.UploadPartCopyRequest) throws -> S3Model.UploadPartCopyOutput {
+        let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: S3ModelOperations.uploadPartCopy.rawValue,
+                    target: target,
+                    signAllHeaders: true)
+
+        let requestInput = UploadPartCopyOperationHTTPRequestInput(encodable: input)
+
+        return try httpClient.executeSyncWithOutput(
+            endpointPath: "/{Bucket}/{Key+}",
+            httpMethod: .PUT,
+            input: requestInput,
+            handlerDelegate: handlerDelegate)
+    }
+}

--- a/Sources/S3Client/MockS3Client.swift
+++ b/Sources/S3Client/MockS3Client.swift
@@ -1,0 +1,3223 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment type_body_length
+// -- Generated Code; do not edit --
+//
+// MockS3Client.swift
+// S3Client
+//
+
+import Foundation
+import S3Model
+import SmokeHTTPClient
+
+/**
+ Mock Client for the S3 service by default returns the `__default` property of its return type.
+ */
+public struct MockS3Client: S3ClientProtocol {
+    let abortMultipartUploadAsyncOverride: S3ClientProtocol.AbortMultipartUploadAsyncType?
+    let abortMultipartUploadSyncOverride: S3ClientProtocol.AbortMultipartUploadSyncType?
+    let completeMultipartUploadAsyncOverride: S3ClientProtocol.CompleteMultipartUploadAsyncType?
+    let completeMultipartUploadSyncOverride: S3ClientProtocol.CompleteMultipartUploadSyncType?
+    let copyObjectAsyncOverride: S3ClientProtocol.CopyObjectAsyncType?
+    let copyObjectSyncOverride: S3ClientProtocol.CopyObjectSyncType?
+    let createBucketAsyncOverride: S3ClientProtocol.CreateBucketAsyncType?
+    let createBucketSyncOverride: S3ClientProtocol.CreateBucketSyncType?
+    let createMultipartUploadAsyncOverride: S3ClientProtocol.CreateMultipartUploadAsyncType?
+    let createMultipartUploadSyncOverride: S3ClientProtocol.CreateMultipartUploadSyncType?
+    let deleteBucketAsyncOverride: S3ClientProtocol.DeleteBucketAsyncType?
+    let deleteBucketSyncOverride: S3ClientProtocol.DeleteBucketSyncType?
+    let deleteBucketAnalyticsConfigurationAsyncOverride: S3ClientProtocol.DeleteBucketAnalyticsConfigurationAsyncType?
+    let deleteBucketAnalyticsConfigurationSyncOverride: S3ClientProtocol.DeleteBucketAnalyticsConfigurationSyncType?
+    let deleteBucketCorsAsyncOverride: S3ClientProtocol.DeleteBucketCorsAsyncType?
+    let deleteBucketCorsSyncOverride: S3ClientProtocol.DeleteBucketCorsSyncType?
+    let deleteBucketEncryptionAsyncOverride: S3ClientProtocol.DeleteBucketEncryptionAsyncType?
+    let deleteBucketEncryptionSyncOverride: S3ClientProtocol.DeleteBucketEncryptionSyncType?
+    let deleteBucketInventoryConfigurationAsyncOverride: S3ClientProtocol.DeleteBucketInventoryConfigurationAsyncType?
+    let deleteBucketInventoryConfigurationSyncOverride: S3ClientProtocol.DeleteBucketInventoryConfigurationSyncType?
+    let deleteBucketLifecycleAsyncOverride: S3ClientProtocol.DeleteBucketLifecycleAsyncType?
+    let deleteBucketLifecycleSyncOverride: S3ClientProtocol.DeleteBucketLifecycleSyncType?
+    let deleteBucketMetricsConfigurationAsyncOverride: S3ClientProtocol.DeleteBucketMetricsConfigurationAsyncType?
+    let deleteBucketMetricsConfigurationSyncOverride: S3ClientProtocol.DeleteBucketMetricsConfigurationSyncType?
+    let deleteBucketPolicyAsyncOverride: S3ClientProtocol.DeleteBucketPolicyAsyncType?
+    let deleteBucketPolicySyncOverride: S3ClientProtocol.DeleteBucketPolicySyncType?
+    let deleteBucketReplicationAsyncOverride: S3ClientProtocol.DeleteBucketReplicationAsyncType?
+    let deleteBucketReplicationSyncOverride: S3ClientProtocol.DeleteBucketReplicationSyncType?
+    let deleteBucketTaggingAsyncOverride: S3ClientProtocol.DeleteBucketTaggingAsyncType?
+    let deleteBucketTaggingSyncOverride: S3ClientProtocol.DeleteBucketTaggingSyncType?
+    let deleteBucketWebsiteAsyncOverride: S3ClientProtocol.DeleteBucketWebsiteAsyncType?
+    let deleteBucketWebsiteSyncOverride: S3ClientProtocol.DeleteBucketWebsiteSyncType?
+    let deleteObjectAsyncOverride: S3ClientProtocol.DeleteObjectAsyncType?
+    let deleteObjectSyncOverride: S3ClientProtocol.DeleteObjectSyncType?
+    let deleteObjectTaggingAsyncOverride: S3ClientProtocol.DeleteObjectTaggingAsyncType?
+    let deleteObjectTaggingSyncOverride: S3ClientProtocol.DeleteObjectTaggingSyncType?
+    let deleteObjectsAsyncOverride: S3ClientProtocol.DeleteObjectsAsyncType?
+    let deleteObjectsSyncOverride: S3ClientProtocol.DeleteObjectsSyncType?
+    let deletePublicAccessBlockAsyncOverride: S3ClientProtocol.DeletePublicAccessBlockAsyncType?
+    let deletePublicAccessBlockSyncOverride: S3ClientProtocol.DeletePublicAccessBlockSyncType?
+    let getBucketAccelerateConfigurationAsyncOverride: S3ClientProtocol.GetBucketAccelerateConfigurationAsyncType?
+    let getBucketAccelerateConfigurationSyncOverride: S3ClientProtocol.GetBucketAccelerateConfigurationSyncType?
+    let getBucketAclAsyncOverride: S3ClientProtocol.GetBucketAclAsyncType?
+    let getBucketAclSyncOverride: S3ClientProtocol.GetBucketAclSyncType?
+    let getBucketAnalyticsConfigurationAsyncOverride: S3ClientProtocol.GetBucketAnalyticsConfigurationAsyncType?
+    let getBucketAnalyticsConfigurationSyncOverride: S3ClientProtocol.GetBucketAnalyticsConfigurationSyncType?
+    let getBucketCorsAsyncOverride: S3ClientProtocol.GetBucketCorsAsyncType?
+    let getBucketCorsSyncOverride: S3ClientProtocol.GetBucketCorsSyncType?
+    let getBucketEncryptionAsyncOverride: S3ClientProtocol.GetBucketEncryptionAsyncType?
+    let getBucketEncryptionSyncOverride: S3ClientProtocol.GetBucketEncryptionSyncType?
+    let getBucketInventoryConfigurationAsyncOverride: S3ClientProtocol.GetBucketInventoryConfigurationAsyncType?
+    let getBucketInventoryConfigurationSyncOverride: S3ClientProtocol.GetBucketInventoryConfigurationSyncType?
+    let getBucketLifecycleAsyncOverride: S3ClientProtocol.GetBucketLifecycleAsyncType?
+    let getBucketLifecycleSyncOverride: S3ClientProtocol.GetBucketLifecycleSyncType?
+    let getBucketLifecycleConfigurationAsyncOverride: S3ClientProtocol.GetBucketLifecycleConfigurationAsyncType?
+    let getBucketLifecycleConfigurationSyncOverride: S3ClientProtocol.GetBucketLifecycleConfigurationSyncType?
+    let getBucketLocationAsyncOverride: S3ClientProtocol.GetBucketLocationAsyncType?
+    let getBucketLocationSyncOverride: S3ClientProtocol.GetBucketLocationSyncType?
+    let getBucketLoggingAsyncOverride: S3ClientProtocol.GetBucketLoggingAsyncType?
+    let getBucketLoggingSyncOverride: S3ClientProtocol.GetBucketLoggingSyncType?
+    let getBucketMetricsConfigurationAsyncOverride: S3ClientProtocol.GetBucketMetricsConfigurationAsyncType?
+    let getBucketMetricsConfigurationSyncOverride: S3ClientProtocol.GetBucketMetricsConfigurationSyncType?
+    let getBucketNotificationAsyncOverride: S3ClientProtocol.GetBucketNotificationAsyncType?
+    let getBucketNotificationSyncOverride: S3ClientProtocol.GetBucketNotificationSyncType?
+    let getBucketNotificationConfigurationAsyncOverride: S3ClientProtocol.GetBucketNotificationConfigurationAsyncType?
+    let getBucketNotificationConfigurationSyncOverride: S3ClientProtocol.GetBucketNotificationConfigurationSyncType?
+    let getBucketPolicyAsyncOverride: S3ClientProtocol.GetBucketPolicyAsyncType?
+    let getBucketPolicySyncOverride: S3ClientProtocol.GetBucketPolicySyncType?
+    let getBucketPolicyStatusAsyncOverride: S3ClientProtocol.GetBucketPolicyStatusAsyncType?
+    let getBucketPolicyStatusSyncOverride: S3ClientProtocol.GetBucketPolicyStatusSyncType?
+    let getBucketReplicationAsyncOverride: S3ClientProtocol.GetBucketReplicationAsyncType?
+    let getBucketReplicationSyncOverride: S3ClientProtocol.GetBucketReplicationSyncType?
+    let getBucketRequestPaymentAsyncOverride: S3ClientProtocol.GetBucketRequestPaymentAsyncType?
+    let getBucketRequestPaymentSyncOverride: S3ClientProtocol.GetBucketRequestPaymentSyncType?
+    let getBucketTaggingAsyncOverride: S3ClientProtocol.GetBucketTaggingAsyncType?
+    let getBucketTaggingSyncOverride: S3ClientProtocol.GetBucketTaggingSyncType?
+    let getBucketVersioningAsyncOverride: S3ClientProtocol.GetBucketVersioningAsyncType?
+    let getBucketVersioningSyncOverride: S3ClientProtocol.GetBucketVersioningSyncType?
+    let getBucketWebsiteAsyncOverride: S3ClientProtocol.GetBucketWebsiteAsyncType?
+    let getBucketWebsiteSyncOverride: S3ClientProtocol.GetBucketWebsiteSyncType?
+    let getObjectAsyncOverride: S3ClientProtocol.GetObjectAsyncType?
+    let getObjectSyncOverride: S3ClientProtocol.GetObjectSyncType?
+    let getObjectAclAsyncOverride: S3ClientProtocol.GetObjectAclAsyncType?
+    let getObjectAclSyncOverride: S3ClientProtocol.GetObjectAclSyncType?
+    let getObjectTaggingAsyncOverride: S3ClientProtocol.GetObjectTaggingAsyncType?
+    let getObjectTaggingSyncOverride: S3ClientProtocol.GetObjectTaggingSyncType?
+    let getObjectTorrentAsyncOverride: S3ClientProtocol.GetObjectTorrentAsyncType?
+    let getObjectTorrentSyncOverride: S3ClientProtocol.GetObjectTorrentSyncType?
+    let getPublicAccessBlockAsyncOverride: S3ClientProtocol.GetPublicAccessBlockAsyncType?
+    let getPublicAccessBlockSyncOverride: S3ClientProtocol.GetPublicAccessBlockSyncType?
+    let headBucketAsyncOverride: S3ClientProtocol.HeadBucketAsyncType?
+    let headBucketSyncOverride: S3ClientProtocol.HeadBucketSyncType?
+    let headObjectAsyncOverride: S3ClientProtocol.HeadObjectAsyncType?
+    let headObjectSyncOverride: S3ClientProtocol.HeadObjectSyncType?
+    let listBucketAnalyticsConfigurationsAsyncOverride: S3ClientProtocol.ListBucketAnalyticsConfigurationsAsyncType?
+    let listBucketAnalyticsConfigurationsSyncOverride: S3ClientProtocol.ListBucketAnalyticsConfigurationsSyncType?
+    let listBucketInventoryConfigurationsAsyncOverride: S3ClientProtocol.ListBucketInventoryConfigurationsAsyncType?
+    let listBucketInventoryConfigurationsSyncOverride: S3ClientProtocol.ListBucketInventoryConfigurationsSyncType?
+    let listBucketMetricsConfigurationsAsyncOverride: S3ClientProtocol.ListBucketMetricsConfigurationsAsyncType?
+    let listBucketMetricsConfigurationsSyncOverride: S3ClientProtocol.ListBucketMetricsConfigurationsSyncType?
+    let listBucketsAsyncOverride: S3ClientProtocol.ListBucketsAsyncType?
+    let listBucketsSyncOverride: S3ClientProtocol.ListBucketsSyncType?
+    let listMultipartUploadsAsyncOverride: S3ClientProtocol.ListMultipartUploadsAsyncType?
+    let listMultipartUploadsSyncOverride: S3ClientProtocol.ListMultipartUploadsSyncType?
+    let listObjectVersionsAsyncOverride: S3ClientProtocol.ListObjectVersionsAsyncType?
+    let listObjectVersionsSyncOverride: S3ClientProtocol.ListObjectVersionsSyncType?
+    let listObjectsAsyncOverride: S3ClientProtocol.ListObjectsAsyncType?
+    let listObjectsSyncOverride: S3ClientProtocol.ListObjectsSyncType?
+    let listObjectsV2AsyncOverride: S3ClientProtocol.ListObjectsV2AsyncType?
+    let listObjectsV2SyncOverride: S3ClientProtocol.ListObjectsV2SyncType?
+    let listPartsAsyncOverride: S3ClientProtocol.ListPartsAsyncType?
+    let listPartsSyncOverride: S3ClientProtocol.ListPartsSyncType?
+    let putBucketAccelerateConfigurationAsyncOverride: S3ClientProtocol.PutBucketAccelerateConfigurationAsyncType?
+    let putBucketAccelerateConfigurationSyncOverride: S3ClientProtocol.PutBucketAccelerateConfigurationSyncType?
+    let putBucketAclAsyncOverride: S3ClientProtocol.PutBucketAclAsyncType?
+    let putBucketAclSyncOverride: S3ClientProtocol.PutBucketAclSyncType?
+    let putBucketAnalyticsConfigurationAsyncOverride: S3ClientProtocol.PutBucketAnalyticsConfigurationAsyncType?
+    let putBucketAnalyticsConfigurationSyncOverride: S3ClientProtocol.PutBucketAnalyticsConfigurationSyncType?
+    let putBucketCorsAsyncOverride: S3ClientProtocol.PutBucketCorsAsyncType?
+    let putBucketCorsSyncOverride: S3ClientProtocol.PutBucketCorsSyncType?
+    let putBucketEncryptionAsyncOverride: S3ClientProtocol.PutBucketEncryptionAsyncType?
+    let putBucketEncryptionSyncOverride: S3ClientProtocol.PutBucketEncryptionSyncType?
+    let putBucketInventoryConfigurationAsyncOverride: S3ClientProtocol.PutBucketInventoryConfigurationAsyncType?
+    let putBucketInventoryConfigurationSyncOverride: S3ClientProtocol.PutBucketInventoryConfigurationSyncType?
+    let putBucketLifecycleAsyncOverride: S3ClientProtocol.PutBucketLifecycleAsyncType?
+    let putBucketLifecycleSyncOverride: S3ClientProtocol.PutBucketLifecycleSyncType?
+    let putBucketLifecycleConfigurationAsyncOverride: S3ClientProtocol.PutBucketLifecycleConfigurationAsyncType?
+    let putBucketLifecycleConfigurationSyncOverride: S3ClientProtocol.PutBucketLifecycleConfigurationSyncType?
+    let putBucketLoggingAsyncOverride: S3ClientProtocol.PutBucketLoggingAsyncType?
+    let putBucketLoggingSyncOverride: S3ClientProtocol.PutBucketLoggingSyncType?
+    let putBucketMetricsConfigurationAsyncOverride: S3ClientProtocol.PutBucketMetricsConfigurationAsyncType?
+    let putBucketMetricsConfigurationSyncOverride: S3ClientProtocol.PutBucketMetricsConfigurationSyncType?
+    let putBucketNotificationAsyncOverride: S3ClientProtocol.PutBucketNotificationAsyncType?
+    let putBucketNotificationSyncOverride: S3ClientProtocol.PutBucketNotificationSyncType?
+    let putBucketNotificationConfigurationAsyncOverride: S3ClientProtocol.PutBucketNotificationConfigurationAsyncType?
+    let putBucketNotificationConfigurationSyncOverride: S3ClientProtocol.PutBucketNotificationConfigurationSyncType?
+    let putBucketPolicyAsyncOverride: S3ClientProtocol.PutBucketPolicyAsyncType?
+    let putBucketPolicySyncOverride: S3ClientProtocol.PutBucketPolicySyncType?
+    let putBucketReplicationAsyncOverride: S3ClientProtocol.PutBucketReplicationAsyncType?
+    let putBucketReplicationSyncOverride: S3ClientProtocol.PutBucketReplicationSyncType?
+    let putBucketRequestPaymentAsyncOverride: S3ClientProtocol.PutBucketRequestPaymentAsyncType?
+    let putBucketRequestPaymentSyncOverride: S3ClientProtocol.PutBucketRequestPaymentSyncType?
+    let putBucketTaggingAsyncOverride: S3ClientProtocol.PutBucketTaggingAsyncType?
+    let putBucketTaggingSyncOverride: S3ClientProtocol.PutBucketTaggingSyncType?
+    let putBucketVersioningAsyncOverride: S3ClientProtocol.PutBucketVersioningAsyncType?
+    let putBucketVersioningSyncOverride: S3ClientProtocol.PutBucketVersioningSyncType?
+    let putBucketWebsiteAsyncOverride: S3ClientProtocol.PutBucketWebsiteAsyncType?
+    let putBucketWebsiteSyncOverride: S3ClientProtocol.PutBucketWebsiteSyncType?
+    let putObjectAsyncOverride: S3ClientProtocol.PutObjectAsyncType?
+    let putObjectSyncOverride: S3ClientProtocol.PutObjectSyncType?
+    let putObjectAclAsyncOverride: S3ClientProtocol.PutObjectAclAsyncType?
+    let putObjectAclSyncOverride: S3ClientProtocol.PutObjectAclSyncType?
+    let putObjectTaggingAsyncOverride: S3ClientProtocol.PutObjectTaggingAsyncType?
+    let putObjectTaggingSyncOverride: S3ClientProtocol.PutObjectTaggingSyncType?
+    let putPublicAccessBlockAsyncOverride: S3ClientProtocol.PutPublicAccessBlockAsyncType?
+    let putPublicAccessBlockSyncOverride: S3ClientProtocol.PutPublicAccessBlockSyncType?
+    let restoreObjectAsyncOverride: S3ClientProtocol.RestoreObjectAsyncType?
+    let restoreObjectSyncOverride: S3ClientProtocol.RestoreObjectSyncType?
+    let selectObjectContentAsyncOverride: S3ClientProtocol.SelectObjectContentAsyncType?
+    let selectObjectContentSyncOverride: S3ClientProtocol.SelectObjectContentSyncType?
+    let uploadPartAsyncOverride: S3ClientProtocol.UploadPartAsyncType?
+    let uploadPartSyncOverride: S3ClientProtocol.UploadPartSyncType?
+    let uploadPartCopyAsyncOverride: S3ClientProtocol.UploadPartCopyAsyncType?
+    let uploadPartCopySyncOverride: S3ClientProtocol.UploadPartCopySyncType?
+
+    /**
+     Initializer that creates an instance of this clients. The behavior of individual
+     functions can be overridden by passing them to this initializer.
+     */
+    public init(
+            abortMultipartUploadAsync: S3ClientProtocol.AbortMultipartUploadAsyncType? = nil,
+            abortMultipartUploadSync: S3ClientProtocol.AbortMultipartUploadSyncType? = nil,
+            completeMultipartUploadAsync: S3ClientProtocol.CompleteMultipartUploadAsyncType? = nil,
+            completeMultipartUploadSync: S3ClientProtocol.CompleteMultipartUploadSyncType? = nil,
+            copyObjectAsync: S3ClientProtocol.CopyObjectAsyncType? = nil,
+            copyObjectSync: S3ClientProtocol.CopyObjectSyncType? = nil,
+            createBucketAsync: S3ClientProtocol.CreateBucketAsyncType? = nil,
+            createBucketSync: S3ClientProtocol.CreateBucketSyncType? = nil,
+            createMultipartUploadAsync: S3ClientProtocol.CreateMultipartUploadAsyncType? = nil,
+            createMultipartUploadSync: S3ClientProtocol.CreateMultipartUploadSyncType? = nil,
+            deleteBucketAsync: S3ClientProtocol.DeleteBucketAsyncType? = nil,
+            deleteBucketSync: S3ClientProtocol.DeleteBucketSyncType? = nil,
+            deleteBucketAnalyticsConfigurationAsync: S3ClientProtocol.DeleteBucketAnalyticsConfigurationAsyncType? = nil,
+            deleteBucketAnalyticsConfigurationSync: S3ClientProtocol.DeleteBucketAnalyticsConfigurationSyncType? = nil,
+            deleteBucketCorsAsync: S3ClientProtocol.DeleteBucketCorsAsyncType? = nil,
+            deleteBucketCorsSync: S3ClientProtocol.DeleteBucketCorsSyncType? = nil,
+            deleteBucketEncryptionAsync: S3ClientProtocol.DeleteBucketEncryptionAsyncType? = nil,
+            deleteBucketEncryptionSync: S3ClientProtocol.DeleteBucketEncryptionSyncType? = nil,
+            deleteBucketInventoryConfigurationAsync: S3ClientProtocol.DeleteBucketInventoryConfigurationAsyncType? = nil,
+            deleteBucketInventoryConfigurationSync: S3ClientProtocol.DeleteBucketInventoryConfigurationSyncType? = nil,
+            deleteBucketLifecycleAsync: S3ClientProtocol.DeleteBucketLifecycleAsyncType? = nil,
+            deleteBucketLifecycleSync: S3ClientProtocol.DeleteBucketLifecycleSyncType? = nil,
+            deleteBucketMetricsConfigurationAsync: S3ClientProtocol.DeleteBucketMetricsConfigurationAsyncType? = nil,
+            deleteBucketMetricsConfigurationSync: S3ClientProtocol.DeleteBucketMetricsConfigurationSyncType? = nil,
+            deleteBucketPolicyAsync: S3ClientProtocol.DeleteBucketPolicyAsyncType? = nil,
+            deleteBucketPolicySync: S3ClientProtocol.DeleteBucketPolicySyncType? = nil,
+            deleteBucketReplicationAsync: S3ClientProtocol.DeleteBucketReplicationAsyncType? = nil,
+            deleteBucketReplicationSync: S3ClientProtocol.DeleteBucketReplicationSyncType? = nil,
+            deleteBucketTaggingAsync: S3ClientProtocol.DeleteBucketTaggingAsyncType? = nil,
+            deleteBucketTaggingSync: S3ClientProtocol.DeleteBucketTaggingSyncType? = nil,
+            deleteBucketWebsiteAsync: S3ClientProtocol.DeleteBucketWebsiteAsyncType? = nil,
+            deleteBucketWebsiteSync: S3ClientProtocol.DeleteBucketWebsiteSyncType? = nil,
+            deleteObjectAsync: S3ClientProtocol.DeleteObjectAsyncType? = nil,
+            deleteObjectSync: S3ClientProtocol.DeleteObjectSyncType? = nil,
+            deleteObjectTaggingAsync: S3ClientProtocol.DeleteObjectTaggingAsyncType? = nil,
+            deleteObjectTaggingSync: S3ClientProtocol.DeleteObjectTaggingSyncType? = nil,
+            deleteObjectsAsync: S3ClientProtocol.DeleteObjectsAsyncType? = nil,
+            deleteObjectsSync: S3ClientProtocol.DeleteObjectsSyncType? = nil,
+            deletePublicAccessBlockAsync: S3ClientProtocol.DeletePublicAccessBlockAsyncType? = nil,
+            deletePublicAccessBlockSync: S3ClientProtocol.DeletePublicAccessBlockSyncType? = nil,
+            getBucketAccelerateConfigurationAsync: S3ClientProtocol.GetBucketAccelerateConfigurationAsyncType? = nil,
+            getBucketAccelerateConfigurationSync: S3ClientProtocol.GetBucketAccelerateConfigurationSyncType? = nil,
+            getBucketAclAsync: S3ClientProtocol.GetBucketAclAsyncType? = nil,
+            getBucketAclSync: S3ClientProtocol.GetBucketAclSyncType? = nil,
+            getBucketAnalyticsConfigurationAsync: S3ClientProtocol.GetBucketAnalyticsConfigurationAsyncType? = nil,
+            getBucketAnalyticsConfigurationSync: S3ClientProtocol.GetBucketAnalyticsConfigurationSyncType? = nil,
+            getBucketCorsAsync: S3ClientProtocol.GetBucketCorsAsyncType? = nil,
+            getBucketCorsSync: S3ClientProtocol.GetBucketCorsSyncType? = nil,
+            getBucketEncryptionAsync: S3ClientProtocol.GetBucketEncryptionAsyncType? = nil,
+            getBucketEncryptionSync: S3ClientProtocol.GetBucketEncryptionSyncType? = nil,
+            getBucketInventoryConfigurationAsync: S3ClientProtocol.GetBucketInventoryConfigurationAsyncType? = nil,
+            getBucketInventoryConfigurationSync: S3ClientProtocol.GetBucketInventoryConfigurationSyncType? = nil,
+            getBucketLifecycleAsync: S3ClientProtocol.GetBucketLifecycleAsyncType? = nil,
+            getBucketLifecycleSync: S3ClientProtocol.GetBucketLifecycleSyncType? = nil,
+            getBucketLifecycleConfigurationAsync: S3ClientProtocol.GetBucketLifecycleConfigurationAsyncType? = nil,
+            getBucketLifecycleConfigurationSync: S3ClientProtocol.GetBucketLifecycleConfigurationSyncType? = nil,
+            getBucketLocationAsync: S3ClientProtocol.GetBucketLocationAsyncType? = nil,
+            getBucketLocationSync: S3ClientProtocol.GetBucketLocationSyncType? = nil,
+            getBucketLoggingAsync: S3ClientProtocol.GetBucketLoggingAsyncType? = nil,
+            getBucketLoggingSync: S3ClientProtocol.GetBucketLoggingSyncType? = nil,
+            getBucketMetricsConfigurationAsync: S3ClientProtocol.GetBucketMetricsConfigurationAsyncType? = nil,
+            getBucketMetricsConfigurationSync: S3ClientProtocol.GetBucketMetricsConfigurationSyncType? = nil,
+            getBucketNotificationAsync: S3ClientProtocol.GetBucketNotificationAsyncType? = nil,
+            getBucketNotificationSync: S3ClientProtocol.GetBucketNotificationSyncType? = nil,
+            getBucketNotificationConfigurationAsync: S3ClientProtocol.GetBucketNotificationConfigurationAsyncType? = nil,
+            getBucketNotificationConfigurationSync: S3ClientProtocol.GetBucketNotificationConfigurationSyncType? = nil,
+            getBucketPolicyAsync: S3ClientProtocol.GetBucketPolicyAsyncType? = nil,
+            getBucketPolicySync: S3ClientProtocol.GetBucketPolicySyncType? = nil,
+            getBucketPolicyStatusAsync: S3ClientProtocol.GetBucketPolicyStatusAsyncType? = nil,
+            getBucketPolicyStatusSync: S3ClientProtocol.GetBucketPolicyStatusSyncType? = nil,
+            getBucketReplicationAsync: S3ClientProtocol.GetBucketReplicationAsyncType? = nil,
+            getBucketReplicationSync: S3ClientProtocol.GetBucketReplicationSyncType? = nil,
+            getBucketRequestPaymentAsync: S3ClientProtocol.GetBucketRequestPaymentAsyncType? = nil,
+            getBucketRequestPaymentSync: S3ClientProtocol.GetBucketRequestPaymentSyncType? = nil,
+            getBucketTaggingAsync: S3ClientProtocol.GetBucketTaggingAsyncType? = nil,
+            getBucketTaggingSync: S3ClientProtocol.GetBucketTaggingSyncType? = nil,
+            getBucketVersioningAsync: S3ClientProtocol.GetBucketVersioningAsyncType? = nil,
+            getBucketVersioningSync: S3ClientProtocol.GetBucketVersioningSyncType? = nil,
+            getBucketWebsiteAsync: S3ClientProtocol.GetBucketWebsiteAsyncType? = nil,
+            getBucketWebsiteSync: S3ClientProtocol.GetBucketWebsiteSyncType? = nil,
+            getObjectAsync: S3ClientProtocol.GetObjectAsyncType? = nil,
+            getObjectSync: S3ClientProtocol.GetObjectSyncType? = nil,
+            getObjectAclAsync: S3ClientProtocol.GetObjectAclAsyncType? = nil,
+            getObjectAclSync: S3ClientProtocol.GetObjectAclSyncType? = nil,
+            getObjectTaggingAsync: S3ClientProtocol.GetObjectTaggingAsyncType? = nil,
+            getObjectTaggingSync: S3ClientProtocol.GetObjectTaggingSyncType? = nil,
+            getObjectTorrentAsync: S3ClientProtocol.GetObjectTorrentAsyncType? = nil,
+            getObjectTorrentSync: S3ClientProtocol.GetObjectTorrentSyncType? = nil,
+            getPublicAccessBlockAsync: S3ClientProtocol.GetPublicAccessBlockAsyncType? = nil,
+            getPublicAccessBlockSync: S3ClientProtocol.GetPublicAccessBlockSyncType? = nil,
+            headBucketAsync: S3ClientProtocol.HeadBucketAsyncType? = nil,
+            headBucketSync: S3ClientProtocol.HeadBucketSyncType? = nil,
+            headObjectAsync: S3ClientProtocol.HeadObjectAsyncType? = nil,
+            headObjectSync: S3ClientProtocol.HeadObjectSyncType? = nil,
+            listBucketAnalyticsConfigurationsAsync: S3ClientProtocol.ListBucketAnalyticsConfigurationsAsyncType? = nil,
+            listBucketAnalyticsConfigurationsSync: S3ClientProtocol.ListBucketAnalyticsConfigurationsSyncType? = nil,
+            listBucketInventoryConfigurationsAsync: S3ClientProtocol.ListBucketInventoryConfigurationsAsyncType? = nil,
+            listBucketInventoryConfigurationsSync: S3ClientProtocol.ListBucketInventoryConfigurationsSyncType? = nil,
+            listBucketMetricsConfigurationsAsync: S3ClientProtocol.ListBucketMetricsConfigurationsAsyncType? = nil,
+            listBucketMetricsConfigurationsSync: S3ClientProtocol.ListBucketMetricsConfigurationsSyncType? = nil,
+            listBucketsAsync: S3ClientProtocol.ListBucketsAsyncType? = nil,
+            listBucketsSync: S3ClientProtocol.ListBucketsSyncType? = nil,
+            listMultipartUploadsAsync: S3ClientProtocol.ListMultipartUploadsAsyncType? = nil,
+            listMultipartUploadsSync: S3ClientProtocol.ListMultipartUploadsSyncType? = nil,
+            listObjectVersionsAsync: S3ClientProtocol.ListObjectVersionsAsyncType? = nil,
+            listObjectVersionsSync: S3ClientProtocol.ListObjectVersionsSyncType? = nil,
+            listObjectsAsync: S3ClientProtocol.ListObjectsAsyncType? = nil,
+            listObjectsSync: S3ClientProtocol.ListObjectsSyncType? = nil,
+            listObjectsV2Async: S3ClientProtocol.ListObjectsV2AsyncType? = nil,
+            listObjectsV2Sync: S3ClientProtocol.ListObjectsV2SyncType? = nil,
+            listPartsAsync: S3ClientProtocol.ListPartsAsyncType? = nil,
+            listPartsSync: S3ClientProtocol.ListPartsSyncType? = nil,
+            putBucketAccelerateConfigurationAsync: S3ClientProtocol.PutBucketAccelerateConfigurationAsyncType? = nil,
+            putBucketAccelerateConfigurationSync: S3ClientProtocol.PutBucketAccelerateConfigurationSyncType? = nil,
+            putBucketAclAsync: S3ClientProtocol.PutBucketAclAsyncType? = nil,
+            putBucketAclSync: S3ClientProtocol.PutBucketAclSyncType? = nil,
+            putBucketAnalyticsConfigurationAsync: S3ClientProtocol.PutBucketAnalyticsConfigurationAsyncType? = nil,
+            putBucketAnalyticsConfigurationSync: S3ClientProtocol.PutBucketAnalyticsConfigurationSyncType? = nil,
+            putBucketCorsAsync: S3ClientProtocol.PutBucketCorsAsyncType? = nil,
+            putBucketCorsSync: S3ClientProtocol.PutBucketCorsSyncType? = nil,
+            putBucketEncryptionAsync: S3ClientProtocol.PutBucketEncryptionAsyncType? = nil,
+            putBucketEncryptionSync: S3ClientProtocol.PutBucketEncryptionSyncType? = nil,
+            putBucketInventoryConfigurationAsync: S3ClientProtocol.PutBucketInventoryConfigurationAsyncType? = nil,
+            putBucketInventoryConfigurationSync: S3ClientProtocol.PutBucketInventoryConfigurationSyncType? = nil,
+            putBucketLifecycleAsync: S3ClientProtocol.PutBucketLifecycleAsyncType? = nil,
+            putBucketLifecycleSync: S3ClientProtocol.PutBucketLifecycleSyncType? = nil,
+            putBucketLifecycleConfigurationAsync: S3ClientProtocol.PutBucketLifecycleConfigurationAsyncType? = nil,
+            putBucketLifecycleConfigurationSync: S3ClientProtocol.PutBucketLifecycleConfigurationSyncType? = nil,
+            putBucketLoggingAsync: S3ClientProtocol.PutBucketLoggingAsyncType? = nil,
+            putBucketLoggingSync: S3ClientProtocol.PutBucketLoggingSyncType? = nil,
+            putBucketMetricsConfigurationAsync: S3ClientProtocol.PutBucketMetricsConfigurationAsyncType? = nil,
+            putBucketMetricsConfigurationSync: S3ClientProtocol.PutBucketMetricsConfigurationSyncType? = nil,
+            putBucketNotificationAsync: S3ClientProtocol.PutBucketNotificationAsyncType? = nil,
+            putBucketNotificationSync: S3ClientProtocol.PutBucketNotificationSyncType? = nil,
+            putBucketNotificationConfigurationAsync: S3ClientProtocol.PutBucketNotificationConfigurationAsyncType? = nil,
+            putBucketNotificationConfigurationSync: S3ClientProtocol.PutBucketNotificationConfigurationSyncType? = nil,
+            putBucketPolicyAsync: S3ClientProtocol.PutBucketPolicyAsyncType? = nil,
+            putBucketPolicySync: S3ClientProtocol.PutBucketPolicySyncType? = nil,
+            putBucketReplicationAsync: S3ClientProtocol.PutBucketReplicationAsyncType? = nil,
+            putBucketReplicationSync: S3ClientProtocol.PutBucketReplicationSyncType? = nil,
+            putBucketRequestPaymentAsync: S3ClientProtocol.PutBucketRequestPaymentAsyncType? = nil,
+            putBucketRequestPaymentSync: S3ClientProtocol.PutBucketRequestPaymentSyncType? = nil,
+            putBucketTaggingAsync: S3ClientProtocol.PutBucketTaggingAsyncType? = nil,
+            putBucketTaggingSync: S3ClientProtocol.PutBucketTaggingSyncType? = nil,
+            putBucketVersioningAsync: S3ClientProtocol.PutBucketVersioningAsyncType? = nil,
+            putBucketVersioningSync: S3ClientProtocol.PutBucketVersioningSyncType? = nil,
+            putBucketWebsiteAsync: S3ClientProtocol.PutBucketWebsiteAsyncType? = nil,
+            putBucketWebsiteSync: S3ClientProtocol.PutBucketWebsiteSyncType? = nil,
+            putObjectAsync: S3ClientProtocol.PutObjectAsyncType? = nil,
+            putObjectSync: S3ClientProtocol.PutObjectSyncType? = nil,
+            putObjectAclAsync: S3ClientProtocol.PutObjectAclAsyncType? = nil,
+            putObjectAclSync: S3ClientProtocol.PutObjectAclSyncType? = nil,
+            putObjectTaggingAsync: S3ClientProtocol.PutObjectTaggingAsyncType? = nil,
+            putObjectTaggingSync: S3ClientProtocol.PutObjectTaggingSyncType? = nil,
+            putPublicAccessBlockAsync: S3ClientProtocol.PutPublicAccessBlockAsyncType? = nil,
+            putPublicAccessBlockSync: S3ClientProtocol.PutPublicAccessBlockSyncType? = nil,
+            restoreObjectAsync: S3ClientProtocol.RestoreObjectAsyncType? = nil,
+            restoreObjectSync: S3ClientProtocol.RestoreObjectSyncType? = nil,
+            selectObjectContentAsync: S3ClientProtocol.SelectObjectContentAsyncType? = nil,
+            selectObjectContentSync: S3ClientProtocol.SelectObjectContentSyncType? = nil,
+            uploadPartAsync: S3ClientProtocol.UploadPartAsyncType? = nil,
+            uploadPartSync: S3ClientProtocol.UploadPartSyncType? = nil,
+            uploadPartCopyAsync: S3ClientProtocol.UploadPartCopyAsyncType? = nil,
+            uploadPartCopySync: S3ClientProtocol.UploadPartCopySyncType? = nil) {
+        self.abortMultipartUploadAsyncOverride = abortMultipartUploadAsync
+        self.abortMultipartUploadSyncOverride = abortMultipartUploadSync
+        self.completeMultipartUploadAsyncOverride = completeMultipartUploadAsync
+        self.completeMultipartUploadSyncOverride = completeMultipartUploadSync
+        self.copyObjectAsyncOverride = copyObjectAsync
+        self.copyObjectSyncOverride = copyObjectSync
+        self.createBucketAsyncOverride = createBucketAsync
+        self.createBucketSyncOverride = createBucketSync
+        self.createMultipartUploadAsyncOverride = createMultipartUploadAsync
+        self.createMultipartUploadSyncOverride = createMultipartUploadSync
+        self.deleteBucketAsyncOverride = deleteBucketAsync
+        self.deleteBucketSyncOverride = deleteBucketSync
+        self.deleteBucketAnalyticsConfigurationAsyncOverride = deleteBucketAnalyticsConfigurationAsync
+        self.deleteBucketAnalyticsConfigurationSyncOverride = deleteBucketAnalyticsConfigurationSync
+        self.deleteBucketCorsAsyncOverride = deleteBucketCorsAsync
+        self.deleteBucketCorsSyncOverride = deleteBucketCorsSync
+        self.deleteBucketEncryptionAsyncOverride = deleteBucketEncryptionAsync
+        self.deleteBucketEncryptionSyncOverride = deleteBucketEncryptionSync
+        self.deleteBucketInventoryConfigurationAsyncOverride = deleteBucketInventoryConfigurationAsync
+        self.deleteBucketInventoryConfigurationSyncOverride = deleteBucketInventoryConfigurationSync
+        self.deleteBucketLifecycleAsyncOverride = deleteBucketLifecycleAsync
+        self.deleteBucketLifecycleSyncOverride = deleteBucketLifecycleSync
+        self.deleteBucketMetricsConfigurationAsyncOverride = deleteBucketMetricsConfigurationAsync
+        self.deleteBucketMetricsConfigurationSyncOverride = deleteBucketMetricsConfigurationSync
+        self.deleteBucketPolicyAsyncOverride = deleteBucketPolicyAsync
+        self.deleteBucketPolicySyncOverride = deleteBucketPolicySync
+        self.deleteBucketReplicationAsyncOverride = deleteBucketReplicationAsync
+        self.deleteBucketReplicationSyncOverride = deleteBucketReplicationSync
+        self.deleteBucketTaggingAsyncOverride = deleteBucketTaggingAsync
+        self.deleteBucketTaggingSyncOverride = deleteBucketTaggingSync
+        self.deleteBucketWebsiteAsyncOverride = deleteBucketWebsiteAsync
+        self.deleteBucketWebsiteSyncOverride = deleteBucketWebsiteSync
+        self.deleteObjectAsyncOverride = deleteObjectAsync
+        self.deleteObjectSyncOverride = deleteObjectSync
+        self.deleteObjectTaggingAsyncOverride = deleteObjectTaggingAsync
+        self.deleteObjectTaggingSyncOverride = deleteObjectTaggingSync
+        self.deleteObjectsAsyncOverride = deleteObjectsAsync
+        self.deleteObjectsSyncOverride = deleteObjectsSync
+        self.deletePublicAccessBlockAsyncOverride = deletePublicAccessBlockAsync
+        self.deletePublicAccessBlockSyncOverride = deletePublicAccessBlockSync
+        self.getBucketAccelerateConfigurationAsyncOverride = getBucketAccelerateConfigurationAsync
+        self.getBucketAccelerateConfigurationSyncOverride = getBucketAccelerateConfigurationSync
+        self.getBucketAclAsyncOverride = getBucketAclAsync
+        self.getBucketAclSyncOverride = getBucketAclSync
+        self.getBucketAnalyticsConfigurationAsyncOverride = getBucketAnalyticsConfigurationAsync
+        self.getBucketAnalyticsConfigurationSyncOverride = getBucketAnalyticsConfigurationSync
+        self.getBucketCorsAsyncOverride = getBucketCorsAsync
+        self.getBucketCorsSyncOverride = getBucketCorsSync
+        self.getBucketEncryptionAsyncOverride = getBucketEncryptionAsync
+        self.getBucketEncryptionSyncOverride = getBucketEncryptionSync
+        self.getBucketInventoryConfigurationAsyncOverride = getBucketInventoryConfigurationAsync
+        self.getBucketInventoryConfigurationSyncOverride = getBucketInventoryConfigurationSync
+        self.getBucketLifecycleAsyncOverride = getBucketLifecycleAsync
+        self.getBucketLifecycleSyncOverride = getBucketLifecycleSync
+        self.getBucketLifecycleConfigurationAsyncOverride = getBucketLifecycleConfigurationAsync
+        self.getBucketLifecycleConfigurationSyncOverride = getBucketLifecycleConfigurationSync
+        self.getBucketLocationAsyncOverride = getBucketLocationAsync
+        self.getBucketLocationSyncOverride = getBucketLocationSync
+        self.getBucketLoggingAsyncOverride = getBucketLoggingAsync
+        self.getBucketLoggingSyncOverride = getBucketLoggingSync
+        self.getBucketMetricsConfigurationAsyncOverride = getBucketMetricsConfigurationAsync
+        self.getBucketMetricsConfigurationSyncOverride = getBucketMetricsConfigurationSync
+        self.getBucketNotificationAsyncOverride = getBucketNotificationAsync
+        self.getBucketNotificationSyncOverride = getBucketNotificationSync
+        self.getBucketNotificationConfigurationAsyncOverride = getBucketNotificationConfigurationAsync
+        self.getBucketNotificationConfigurationSyncOverride = getBucketNotificationConfigurationSync
+        self.getBucketPolicyAsyncOverride = getBucketPolicyAsync
+        self.getBucketPolicySyncOverride = getBucketPolicySync
+        self.getBucketPolicyStatusAsyncOverride = getBucketPolicyStatusAsync
+        self.getBucketPolicyStatusSyncOverride = getBucketPolicyStatusSync
+        self.getBucketReplicationAsyncOverride = getBucketReplicationAsync
+        self.getBucketReplicationSyncOverride = getBucketReplicationSync
+        self.getBucketRequestPaymentAsyncOverride = getBucketRequestPaymentAsync
+        self.getBucketRequestPaymentSyncOverride = getBucketRequestPaymentSync
+        self.getBucketTaggingAsyncOverride = getBucketTaggingAsync
+        self.getBucketTaggingSyncOverride = getBucketTaggingSync
+        self.getBucketVersioningAsyncOverride = getBucketVersioningAsync
+        self.getBucketVersioningSyncOverride = getBucketVersioningSync
+        self.getBucketWebsiteAsyncOverride = getBucketWebsiteAsync
+        self.getBucketWebsiteSyncOverride = getBucketWebsiteSync
+        self.getObjectAsyncOverride = getObjectAsync
+        self.getObjectSyncOverride = getObjectSync
+        self.getObjectAclAsyncOverride = getObjectAclAsync
+        self.getObjectAclSyncOverride = getObjectAclSync
+        self.getObjectTaggingAsyncOverride = getObjectTaggingAsync
+        self.getObjectTaggingSyncOverride = getObjectTaggingSync
+        self.getObjectTorrentAsyncOverride = getObjectTorrentAsync
+        self.getObjectTorrentSyncOverride = getObjectTorrentSync
+        self.getPublicAccessBlockAsyncOverride = getPublicAccessBlockAsync
+        self.getPublicAccessBlockSyncOverride = getPublicAccessBlockSync
+        self.headBucketAsyncOverride = headBucketAsync
+        self.headBucketSyncOverride = headBucketSync
+        self.headObjectAsyncOverride = headObjectAsync
+        self.headObjectSyncOverride = headObjectSync
+        self.listBucketAnalyticsConfigurationsAsyncOverride = listBucketAnalyticsConfigurationsAsync
+        self.listBucketAnalyticsConfigurationsSyncOverride = listBucketAnalyticsConfigurationsSync
+        self.listBucketInventoryConfigurationsAsyncOverride = listBucketInventoryConfigurationsAsync
+        self.listBucketInventoryConfigurationsSyncOverride = listBucketInventoryConfigurationsSync
+        self.listBucketMetricsConfigurationsAsyncOverride = listBucketMetricsConfigurationsAsync
+        self.listBucketMetricsConfigurationsSyncOverride = listBucketMetricsConfigurationsSync
+        self.listBucketsAsyncOverride = listBucketsAsync
+        self.listBucketsSyncOverride = listBucketsSync
+        self.listMultipartUploadsAsyncOverride = listMultipartUploadsAsync
+        self.listMultipartUploadsSyncOverride = listMultipartUploadsSync
+        self.listObjectVersionsAsyncOverride = listObjectVersionsAsync
+        self.listObjectVersionsSyncOverride = listObjectVersionsSync
+        self.listObjectsAsyncOverride = listObjectsAsync
+        self.listObjectsSyncOverride = listObjectsSync
+        self.listObjectsV2AsyncOverride = listObjectsV2Async
+        self.listObjectsV2SyncOverride = listObjectsV2Sync
+        self.listPartsAsyncOverride = listPartsAsync
+        self.listPartsSyncOverride = listPartsSync
+        self.putBucketAccelerateConfigurationAsyncOverride = putBucketAccelerateConfigurationAsync
+        self.putBucketAccelerateConfigurationSyncOverride = putBucketAccelerateConfigurationSync
+        self.putBucketAclAsyncOverride = putBucketAclAsync
+        self.putBucketAclSyncOverride = putBucketAclSync
+        self.putBucketAnalyticsConfigurationAsyncOverride = putBucketAnalyticsConfigurationAsync
+        self.putBucketAnalyticsConfigurationSyncOverride = putBucketAnalyticsConfigurationSync
+        self.putBucketCorsAsyncOverride = putBucketCorsAsync
+        self.putBucketCorsSyncOverride = putBucketCorsSync
+        self.putBucketEncryptionAsyncOverride = putBucketEncryptionAsync
+        self.putBucketEncryptionSyncOverride = putBucketEncryptionSync
+        self.putBucketInventoryConfigurationAsyncOverride = putBucketInventoryConfigurationAsync
+        self.putBucketInventoryConfigurationSyncOverride = putBucketInventoryConfigurationSync
+        self.putBucketLifecycleAsyncOverride = putBucketLifecycleAsync
+        self.putBucketLifecycleSyncOverride = putBucketLifecycleSync
+        self.putBucketLifecycleConfigurationAsyncOverride = putBucketLifecycleConfigurationAsync
+        self.putBucketLifecycleConfigurationSyncOverride = putBucketLifecycleConfigurationSync
+        self.putBucketLoggingAsyncOverride = putBucketLoggingAsync
+        self.putBucketLoggingSyncOverride = putBucketLoggingSync
+        self.putBucketMetricsConfigurationAsyncOverride = putBucketMetricsConfigurationAsync
+        self.putBucketMetricsConfigurationSyncOverride = putBucketMetricsConfigurationSync
+        self.putBucketNotificationAsyncOverride = putBucketNotificationAsync
+        self.putBucketNotificationSyncOverride = putBucketNotificationSync
+        self.putBucketNotificationConfigurationAsyncOverride = putBucketNotificationConfigurationAsync
+        self.putBucketNotificationConfigurationSyncOverride = putBucketNotificationConfigurationSync
+        self.putBucketPolicyAsyncOverride = putBucketPolicyAsync
+        self.putBucketPolicySyncOverride = putBucketPolicySync
+        self.putBucketReplicationAsyncOverride = putBucketReplicationAsync
+        self.putBucketReplicationSyncOverride = putBucketReplicationSync
+        self.putBucketRequestPaymentAsyncOverride = putBucketRequestPaymentAsync
+        self.putBucketRequestPaymentSyncOverride = putBucketRequestPaymentSync
+        self.putBucketTaggingAsyncOverride = putBucketTaggingAsync
+        self.putBucketTaggingSyncOverride = putBucketTaggingSync
+        self.putBucketVersioningAsyncOverride = putBucketVersioningAsync
+        self.putBucketVersioningSyncOverride = putBucketVersioningSync
+        self.putBucketWebsiteAsyncOverride = putBucketWebsiteAsync
+        self.putBucketWebsiteSyncOverride = putBucketWebsiteSync
+        self.putObjectAsyncOverride = putObjectAsync
+        self.putObjectSyncOverride = putObjectSync
+        self.putObjectAclAsyncOverride = putObjectAclAsync
+        self.putObjectAclSyncOverride = putObjectAclSync
+        self.putObjectTaggingAsyncOverride = putObjectTaggingAsync
+        self.putObjectTaggingSyncOverride = putObjectTaggingSync
+        self.putPublicAccessBlockAsyncOverride = putPublicAccessBlockAsync
+        self.putPublicAccessBlockSyncOverride = putPublicAccessBlockSync
+        self.restoreObjectAsyncOverride = restoreObjectAsync
+        self.restoreObjectSyncOverride = restoreObjectSync
+        self.selectObjectContentAsyncOverride = selectObjectContentAsync
+        self.selectObjectContentSyncOverride = selectObjectContentSync
+        self.uploadPartAsyncOverride = uploadPartAsync
+        self.uploadPartSyncOverride = uploadPartSync
+        self.uploadPartCopyAsyncOverride = uploadPartCopyAsync
+        self.uploadPartCopySyncOverride = uploadPartCopySync
+    }
+
+    /**
+     Invokes the AbortMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated AbortMultipartUploadRequest object being passed to this operation.
+         - completion: The AbortMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The AbortMultipartUploadOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchUpload.
+     */
+    public func abortMultipartUploadAsync(input: S3Model.AbortMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.AbortMultipartUploadOutput>) -> ()) throws {
+        if let abortMultipartUploadAsyncOverride = abortMultipartUploadAsyncOverride {
+            return try abortMultipartUploadAsyncOverride(input, completion)
+        }
+
+        let result = AbortMultipartUploadOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the AbortMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated AbortMultipartUploadRequest object being passed to this operation.
+     - Returns: The AbortMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchUpload.
+     */
+    public func abortMultipartUploadSync(input: S3Model.AbortMultipartUploadRequest) throws -> S3Model.AbortMultipartUploadOutput {
+        if let abortMultipartUploadSyncOverride = abortMultipartUploadSyncOverride {
+            return try abortMultipartUploadSyncOverride(input)
+        }
+
+        return AbortMultipartUploadOutput.__default
+    }
+
+    /**
+     Invokes the CompleteMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CompleteMultipartUploadRequest object being passed to this operation.
+         - completion: The CompleteMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The CompleteMultipartUploadOutput
+           object will be validated before being returned to caller.
+     */
+    public func completeMultipartUploadAsync(input: S3Model.CompleteMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.CompleteMultipartUploadOutput>) -> ()) throws {
+        if let completeMultipartUploadAsyncOverride = completeMultipartUploadAsyncOverride {
+            return try completeMultipartUploadAsyncOverride(input, completion)
+        }
+
+        let result = CompleteMultipartUploadOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the CompleteMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CompleteMultipartUploadRequest object being passed to this operation.
+     - Returns: The CompleteMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func completeMultipartUploadSync(input: S3Model.CompleteMultipartUploadRequest) throws -> S3Model.CompleteMultipartUploadOutput {
+        if let completeMultipartUploadSyncOverride = completeMultipartUploadSyncOverride {
+            return try completeMultipartUploadSyncOverride(input)
+        }
+
+        return CompleteMultipartUploadOutput.__default
+    }
+
+    /**
+     Invokes the CopyObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CopyObjectRequest object being passed to this operation.
+         - completion: The CopyObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The CopyObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: objectNotInActiveTier.
+     */
+    public func copyObjectAsync(input: S3Model.CopyObjectRequest, completion: @escaping (HTTPResult<S3Model.CopyObjectOutput>) -> ()) throws {
+        if let copyObjectAsyncOverride = copyObjectAsyncOverride {
+            return try copyObjectAsyncOverride(input, completion)
+        }
+
+        let result = CopyObjectOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the CopyObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CopyObjectRequest object being passed to this operation.
+     - Returns: The CopyObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: objectNotInActiveTier.
+     */
+    public func copyObjectSync(input: S3Model.CopyObjectRequest) throws -> S3Model.CopyObjectOutput {
+        if let copyObjectSyncOverride = copyObjectSyncOverride {
+            return try copyObjectSyncOverride(input)
+        }
+
+        return CopyObjectOutput.__default
+    }
+
+    /**
+     Invokes the CreateBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CreateBucketRequest object being passed to this operation.
+         - completion: The CreateBucketOutput object or an error will be passed to this 
+           callback when the operation is complete. The CreateBucketOutput
+           object will be validated before being returned to caller.
+           The possible errors are: bucketAlreadyExists, bucketAlreadyOwnedByYou.
+     */
+    public func createBucketAsync(input: S3Model.CreateBucketRequest, completion: @escaping (HTTPResult<S3Model.CreateBucketOutput>) -> ()) throws {
+        if let createBucketAsyncOverride = createBucketAsyncOverride {
+            return try createBucketAsyncOverride(input, completion)
+        }
+
+        let result = CreateBucketOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the CreateBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CreateBucketRequest object being passed to this operation.
+     - Returns: The CreateBucketOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: bucketAlreadyExists, bucketAlreadyOwnedByYou.
+     */
+    public func createBucketSync(input: S3Model.CreateBucketRequest) throws -> S3Model.CreateBucketOutput {
+        if let createBucketSyncOverride = createBucketSyncOverride {
+            return try createBucketSyncOverride(input)
+        }
+
+        return CreateBucketOutput.__default
+    }
+
+    /**
+     Invokes the CreateMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CreateMultipartUploadRequest object being passed to this operation.
+         - completion: The CreateMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The CreateMultipartUploadOutput
+           object will be validated before being returned to caller.
+     */
+    public func createMultipartUploadAsync(input: S3Model.CreateMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.CreateMultipartUploadOutput>) -> ()) throws {
+        if let createMultipartUploadAsyncOverride = createMultipartUploadAsyncOverride {
+            return try createMultipartUploadAsyncOverride(input, completion)
+        }
+
+        let result = CreateMultipartUploadOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the CreateMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CreateMultipartUploadRequest object being passed to this operation.
+     - Returns: The CreateMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func createMultipartUploadSync(input: S3Model.CreateMultipartUploadRequest) throws -> S3Model.CreateMultipartUploadOutput {
+        if let createMultipartUploadSyncOverride = createMultipartUploadSyncOverride {
+            return try createMultipartUploadSyncOverride(input)
+        }
+
+        return CreateMultipartUploadOutput.__default
+    }
+
+    /**
+     Invokes the DeleteBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketAsync(input: S3Model.DeleteBucketRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketAsyncOverride = deleteBucketAsyncOverride {
+            return try deleteBucketAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketRequest object being passed to this operation.
+     */
+    public func deleteBucketSync(input: S3Model.DeleteBucketRequest) throws {
+        if let deleteBucketSyncOverride = deleteBucketSyncOverride {
+            return try deleteBucketSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketAnalyticsConfigurationAsync(input: S3Model.DeleteBucketAnalyticsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketAnalyticsConfigurationAsyncOverride = deleteBucketAnalyticsConfigurationAsyncOverride {
+            return try deleteBucketAnalyticsConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketAnalyticsConfigurationRequest object being passed to this operation.
+     */
+    public func deleteBucketAnalyticsConfigurationSync(input: S3Model.DeleteBucketAnalyticsConfigurationRequest) throws {
+        if let deleteBucketAnalyticsConfigurationSyncOverride = deleteBucketAnalyticsConfigurationSyncOverride {
+            return try deleteBucketAnalyticsConfigurationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketCorsRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketCorsAsync(input: S3Model.DeleteBucketCorsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketCorsAsyncOverride = deleteBucketCorsAsyncOverride {
+            return try deleteBucketCorsAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketCorsRequest object being passed to this operation.
+     */
+    public func deleteBucketCorsSync(input: S3Model.DeleteBucketCorsRequest) throws {
+        if let deleteBucketCorsSyncOverride = deleteBucketCorsSyncOverride {
+            return try deleteBucketCorsSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketEncryptionRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketEncryptionAsync(input: S3Model.DeleteBucketEncryptionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketEncryptionAsyncOverride = deleteBucketEncryptionAsyncOverride {
+            return try deleteBucketEncryptionAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketEncryptionRequest object being passed to this operation.
+     */
+    public func deleteBucketEncryptionSync(input: S3Model.DeleteBucketEncryptionRequest) throws {
+        if let deleteBucketEncryptionSyncOverride = deleteBucketEncryptionSyncOverride {
+            return try deleteBucketEncryptionSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketInventoryConfigurationAsync(input: S3Model.DeleteBucketInventoryConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketInventoryConfigurationAsyncOverride = deleteBucketInventoryConfigurationAsyncOverride {
+            return try deleteBucketInventoryConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketInventoryConfigurationRequest object being passed to this operation.
+     */
+    public func deleteBucketInventoryConfigurationSync(input: S3Model.DeleteBucketInventoryConfigurationRequest) throws {
+        if let deleteBucketInventoryConfigurationSyncOverride = deleteBucketInventoryConfigurationSyncOverride {
+            return try deleteBucketInventoryConfigurationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketLifecycleRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketLifecycleAsync(input: S3Model.DeleteBucketLifecycleRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketLifecycleAsyncOverride = deleteBucketLifecycleAsyncOverride {
+            return try deleteBucketLifecycleAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketLifecycleRequest object being passed to this operation.
+     */
+    public func deleteBucketLifecycleSync(input: S3Model.DeleteBucketLifecycleRequest) throws {
+        if let deleteBucketLifecycleSyncOverride = deleteBucketLifecycleSyncOverride {
+            return try deleteBucketLifecycleSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketMetricsConfigurationAsync(input: S3Model.DeleteBucketMetricsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketMetricsConfigurationAsyncOverride = deleteBucketMetricsConfigurationAsyncOverride {
+            return try deleteBucketMetricsConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketMetricsConfigurationRequest object being passed to this operation.
+     */
+    public func deleteBucketMetricsConfigurationSync(input: S3Model.DeleteBucketMetricsConfigurationRequest) throws {
+        if let deleteBucketMetricsConfigurationSyncOverride = deleteBucketMetricsConfigurationSyncOverride {
+            return try deleteBucketMetricsConfigurationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketPolicyRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketPolicyAsync(input: S3Model.DeleteBucketPolicyRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketPolicyAsyncOverride = deleteBucketPolicyAsyncOverride {
+            return try deleteBucketPolicyAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketPolicyRequest object being passed to this operation.
+     */
+    public func deleteBucketPolicySync(input: S3Model.DeleteBucketPolicyRequest) throws {
+        if let deleteBucketPolicySyncOverride = deleteBucketPolicySyncOverride {
+            return try deleteBucketPolicySyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketReplicationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketReplicationAsync(input: S3Model.DeleteBucketReplicationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketReplicationAsyncOverride = deleteBucketReplicationAsyncOverride {
+            return try deleteBucketReplicationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketReplicationRequest object being passed to this operation.
+     */
+    public func deleteBucketReplicationSync(input: S3Model.DeleteBucketReplicationRequest) throws {
+        if let deleteBucketReplicationSyncOverride = deleteBucketReplicationSyncOverride {
+            return try deleteBucketReplicationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketTaggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketTaggingAsync(input: S3Model.DeleteBucketTaggingRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketTaggingAsyncOverride = deleteBucketTaggingAsyncOverride {
+            return try deleteBucketTaggingAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketTaggingRequest object being passed to this operation.
+     */
+    public func deleteBucketTaggingSync(input: S3Model.DeleteBucketTaggingRequest) throws {
+        if let deleteBucketTaggingSyncOverride = deleteBucketTaggingSyncOverride {
+            return try deleteBucketTaggingSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketWebsiteRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketWebsiteAsync(input: S3Model.DeleteBucketWebsiteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketWebsiteAsyncOverride = deleteBucketWebsiteAsyncOverride {
+            return try deleteBucketWebsiteAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeleteBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketWebsiteRequest object being passed to this operation.
+     */
+    public func deleteBucketWebsiteSync(input: S3Model.DeleteBucketWebsiteRequest) throws {
+        if let deleteBucketWebsiteSyncOverride = deleteBucketWebsiteSyncOverride {
+            return try deleteBucketWebsiteSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the DeleteObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectRequest object being passed to this operation.
+         - completion: The DeleteObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectOutput
+           object will be validated before being returned to caller.
+     */
+    public func deleteObjectAsync(input: S3Model.DeleteObjectRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectOutput>) -> ()) throws {
+        if let deleteObjectAsyncOverride = deleteObjectAsyncOverride {
+            return try deleteObjectAsyncOverride(input, completion)
+        }
+
+        let result = DeleteObjectOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the DeleteObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectRequest object being passed to this operation.
+     - Returns: The DeleteObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func deleteObjectSync(input: S3Model.DeleteObjectRequest) throws -> S3Model.DeleteObjectOutput {
+        if let deleteObjectSyncOverride = deleteObjectSyncOverride {
+            return try deleteObjectSyncOverride(input)
+        }
+
+        return DeleteObjectOutput.__default
+    }
+
+    /**
+     Invokes the DeleteObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectTaggingRequest object being passed to this operation.
+         - completion: The DeleteObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func deleteObjectTaggingAsync(input: S3Model.DeleteObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectTaggingOutput>) -> ()) throws {
+        if let deleteObjectTaggingAsyncOverride = deleteObjectTaggingAsyncOverride {
+            return try deleteObjectTaggingAsyncOverride(input, completion)
+        }
+
+        let result = DeleteObjectTaggingOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the DeleteObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectTaggingRequest object being passed to this operation.
+     - Returns: The DeleteObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func deleteObjectTaggingSync(input: S3Model.DeleteObjectTaggingRequest) throws -> S3Model.DeleteObjectTaggingOutput {
+        if let deleteObjectTaggingSyncOverride = deleteObjectTaggingSyncOverride {
+            return try deleteObjectTaggingSyncOverride(input)
+        }
+
+        return DeleteObjectTaggingOutput.__default
+    }
+
+    /**
+     Invokes the DeleteObjects operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectsRequest object being passed to this operation.
+         - completion: The DeleteObjectsOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectsOutput
+           object will be validated before being returned to caller.
+     */
+    public func deleteObjectsAsync(input: S3Model.DeleteObjectsRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectsOutput>) -> ()) throws {
+        if let deleteObjectsAsyncOverride = deleteObjectsAsyncOverride {
+            return try deleteObjectsAsyncOverride(input, completion)
+        }
+
+        let result = DeleteObjectsOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the DeleteObjects operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectsRequest object being passed to this operation.
+     - Returns: The DeleteObjectsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func deleteObjectsSync(input: S3Model.DeleteObjectsRequest) throws -> S3Model.DeleteObjectsOutput {
+        if let deleteObjectsSyncOverride = deleteObjectsSyncOverride {
+            return try deleteObjectsSyncOverride(input)
+        }
+
+        return DeleteObjectsOutput.__default
+    }
+
+    /**
+     Invokes the DeletePublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeletePublicAccessBlockRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deletePublicAccessBlockAsync(input: S3Model.DeletePublicAccessBlockRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deletePublicAccessBlockAsyncOverride = deletePublicAccessBlockAsyncOverride {
+            return try deletePublicAccessBlockAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the DeletePublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeletePublicAccessBlockRequest object being passed to this operation.
+     */
+    public func deletePublicAccessBlockSync(input: S3Model.DeletePublicAccessBlockRequest) throws {
+        if let deletePublicAccessBlockSyncOverride = deletePublicAccessBlockSyncOverride {
+            return try deletePublicAccessBlockSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the GetBucketAccelerateConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAccelerateConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketAccelerateConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAccelerateConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketAccelerateConfigurationAsync(input: S3Model.GetBucketAccelerateConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAccelerateConfigurationOutput>) -> ()) throws {
+        if let getBucketAccelerateConfigurationAsyncOverride = getBucketAccelerateConfigurationAsyncOverride {
+            return try getBucketAccelerateConfigurationAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketAccelerateConfigurationOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketAccelerateConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAccelerateConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketAccelerateConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketAccelerateConfigurationSync(input: S3Model.GetBucketAccelerateConfigurationRequest) throws -> S3Model.GetBucketAccelerateConfigurationOutput {
+        if let getBucketAccelerateConfigurationSyncOverride = getBucketAccelerateConfigurationSyncOverride {
+            return try getBucketAccelerateConfigurationSyncOverride(input)
+        }
+
+        return GetBucketAccelerateConfigurationOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAclRequest object being passed to this operation.
+         - completion: The GetBucketAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAclOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketAclAsync(input: S3Model.GetBucketAclRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAclOutput>) -> ()) throws {
+        if let getBucketAclAsyncOverride = getBucketAclAsyncOverride {
+            return try getBucketAclAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketAclOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAclRequest object being passed to this operation.
+     - Returns: The GetBucketAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketAclSync(input: S3Model.GetBucketAclRequest) throws -> S3Model.GetBucketAclOutput {
+        if let getBucketAclSyncOverride = getBucketAclSyncOverride {
+            return try getBucketAclSyncOverride(input)
+        }
+
+        return GetBucketAclOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketAnalyticsConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAnalyticsConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketAnalyticsConfigurationAsync(input: S3Model.GetBucketAnalyticsConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAnalyticsConfigurationOutput>) -> ()) throws {
+        if let getBucketAnalyticsConfigurationAsyncOverride = getBucketAnalyticsConfigurationAsyncOverride {
+            return try getBucketAnalyticsConfigurationAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketAnalyticsConfigurationOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAnalyticsConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketAnalyticsConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketAnalyticsConfigurationSync(input: S3Model.GetBucketAnalyticsConfigurationRequest) throws -> S3Model.GetBucketAnalyticsConfigurationOutput {
+        if let getBucketAnalyticsConfigurationSyncOverride = getBucketAnalyticsConfigurationSyncOverride {
+            return try getBucketAnalyticsConfigurationSyncOverride(input)
+        }
+
+        return GetBucketAnalyticsConfigurationOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketCorsRequest object being passed to this operation.
+         - completion: The GetBucketCorsOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketCorsOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketCorsAsync(input: S3Model.GetBucketCorsRequest, completion: @escaping (HTTPResult<S3Model.GetBucketCorsOutput>) -> ()) throws {
+        if let getBucketCorsAsyncOverride = getBucketCorsAsyncOverride {
+            return try getBucketCorsAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketCorsOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketCorsRequest object being passed to this operation.
+     - Returns: The GetBucketCorsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketCorsSync(input: S3Model.GetBucketCorsRequest) throws -> S3Model.GetBucketCorsOutput {
+        if let getBucketCorsSyncOverride = getBucketCorsSyncOverride {
+            return try getBucketCorsSyncOverride(input)
+        }
+
+        return GetBucketCorsOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketEncryptionRequest object being passed to this operation.
+         - completion: The GetBucketEncryptionOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketEncryptionOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketEncryptionAsync(input: S3Model.GetBucketEncryptionRequest, completion: @escaping (HTTPResult<S3Model.GetBucketEncryptionOutput>) -> ()) throws {
+        if let getBucketEncryptionAsyncOverride = getBucketEncryptionAsyncOverride {
+            return try getBucketEncryptionAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketEncryptionOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketEncryptionRequest object being passed to this operation.
+     - Returns: The GetBucketEncryptionOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketEncryptionSync(input: S3Model.GetBucketEncryptionRequest) throws -> S3Model.GetBucketEncryptionOutput {
+        if let getBucketEncryptionSyncOverride = getBucketEncryptionSyncOverride {
+            return try getBucketEncryptionSyncOverride(input)
+        }
+
+        return GetBucketEncryptionOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketInventoryConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketInventoryConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketInventoryConfigurationAsync(input: S3Model.GetBucketInventoryConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketInventoryConfigurationOutput>) -> ()) throws {
+        if let getBucketInventoryConfigurationAsyncOverride = getBucketInventoryConfigurationAsyncOverride {
+            return try getBucketInventoryConfigurationAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketInventoryConfigurationOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketInventoryConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketInventoryConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketInventoryConfigurationSync(input: S3Model.GetBucketInventoryConfigurationRequest) throws -> S3Model.GetBucketInventoryConfigurationOutput {
+        if let getBucketInventoryConfigurationSyncOverride = getBucketInventoryConfigurationSyncOverride {
+            return try getBucketInventoryConfigurationSyncOverride(input)
+        }
+
+        return GetBucketInventoryConfigurationOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleRequest object being passed to this operation.
+         - completion: The GetBucketLifecycleOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLifecycleOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleAsync(input: S3Model.GetBucketLifecycleRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLifecycleOutput>) -> ()) throws {
+        if let getBucketLifecycleAsyncOverride = getBucketLifecycleAsyncOverride {
+            return try getBucketLifecycleAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketLifecycleOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleRequest object being passed to this operation.
+     - Returns: The GetBucketLifecycleOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleSync(input: S3Model.GetBucketLifecycleRequest) throws -> S3Model.GetBucketLifecycleOutput {
+        if let getBucketLifecycleSyncOverride = getBucketLifecycleSyncOverride {
+            return try getBucketLifecycleSyncOverride(input)
+        }
+
+        return GetBucketLifecycleOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketLifecycleConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketLifecycleConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLifecycleConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleConfigurationAsync(input: S3Model.GetBucketLifecycleConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLifecycleConfigurationOutput>) -> ()) throws {
+        if let getBucketLifecycleConfigurationAsyncOverride = getBucketLifecycleConfigurationAsyncOverride {
+            return try getBucketLifecycleConfigurationAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketLifecycleConfigurationOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketLifecycleConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketLifecycleConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleConfigurationSync(input: S3Model.GetBucketLifecycleConfigurationRequest) throws -> S3Model.GetBucketLifecycleConfigurationOutput {
+        if let getBucketLifecycleConfigurationSyncOverride = getBucketLifecycleConfigurationSyncOverride {
+            return try getBucketLifecycleConfigurationSyncOverride(input)
+        }
+
+        return GetBucketLifecycleConfigurationOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketLocation operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLocationRequest object being passed to this operation.
+         - completion: The GetBucketLocationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLocationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLocationAsync(input: S3Model.GetBucketLocationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLocationOutput>) -> ()) throws {
+        if let getBucketLocationAsyncOverride = getBucketLocationAsyncOverride {
+            return try getBucketLocationAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketLocationOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketLocation operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLocationRequest object being passed to this operation.
+     - Returns: The GetBucketLocationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLocationSync(input: S3Model.GetBucketLocationRequest) throws -> S3Model.GetBucketLocationOutput {
+        if let getBucketLocationSyncOverride = getBucketLocationSyncOverride {
+            return try getBucketLocationSyncOverride(input)
+        }
+
+        return GetBucketLocationOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketLogging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLoggingRequest object being passed to this operation.
+         - completion: The GetBucketLoggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLoggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLoggingAsync(input: S3Model.GetBucketLoggingRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLoggingOutput>) -> ()) throws {
+        if let getBucketLoggingAsyncOverride = getBucketLoggingAsyncOverride {
+            return try getBucketLoggingAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketLoggingOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketLogging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLoggingRequest object being passed to this operation.
+     - Returns: The GetBucketLoggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLoggingSync(input: S3Model.GetBucketLoggingRequest) throws -> S3Model.GetBucketLoggingOutput {
+        if let getBucketLoggingSyncOverride = getBucketLoggingSyncOverride {
+            return try getBucketLoggingSyncOverride(input)
+        }
+
+        return GetBucketLoggingOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketMetricsConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketMetricsConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketMetricsConfigurationAsync(input: S3Model.GetBucketMetricsConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketMetricsConfigurationOutput>) -> ()) throws {
+        if let getBucketMetricsConfigurationAsyncOverride = getBucketMetricsConfigurationAsyncOverride {
+            return try getBucketMetricsConfigurationAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketMetricsConfigurationOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketMetricsConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketMetricsConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketMetricsConfigurationSync(input: S3Model.GetBucketMetricsConfigurationRequest) throws -> S3Model.GetBucketMetricsConfigurationOutput {
+        if let getBucketMetricsConfigurationSyncOverride = getBucketMetricsConfigurationSyncOverride {
+            return try getBucketMetricsConfigurationSyncOverride(input)
+        }
+
+        return GetBucketMetricsConfigurationOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketNotification operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: The NotificationConfigurationDeprecated object or an error will be passed to this 
+           callback when the operation is complete. The NotificationConfigurationDeprecated
+           object will be validated before being returned to caller.
+     */
+    public func getBucketNotificationAsync(input: S3Model.GetBucketNotificationConfigurationRequest, completion: @escaping (HTTPResult<S3Model.NotificationConfigurationDeprecated>) -> ()) throws {
+        if let getBucketNotificationAsyncOverride = getBucketNotificationAsyncOverride {
+            return try getBucketNotificationAsyncOverride(input, completion)
+        }
+
+        let result = NotificationConfigurationDeprecated.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketNotification operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+     - Returns: The NotificationConfigurationDeprecated object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketNotificationSync(input: S3Model.GetBucketNotificationConfigurationRequest) throws -> S3Model.NotificationConfigurationDeprecated {
+        if let getBucketNotificationSyncOverride = getBucketNotificationSyncOverride {
+            return try getBucketNotificationSyncOverride(input)
+        }
+
+        return NotificationConfigurationDeprecated.__default
+    }
+
+    /**
+     Invokes the GetBucketNotificationConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: The NotificationConfiguration object or an error will be passed to this 
+           callback when the operation is complete. The NotificationConfiguration
+           object will be validated before being returned to caller.
+     */
+    public func getBucketNotificationConfigurationAsync(input: S3Model.GetBucketNotificationConfigurationRequest, completion: @escaping (HTTPResult<S3Model.NotificationConfiguration>) -> ()) throws {
+        if let getBucketNotificationConfigurationAsyncOverride = getBucketNotificationConfigurationAsyncOverride {
+            return try getBucketNotificationConfigurationAsyncOverride(input, completion)
+        }
+
+        let result = NotificationConfiguration.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketNotificationConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+     - Returns: The NotificationConfiguration object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketNotificationConfigurationSync(input: S3Model.GetBucketNotificationConfigurationRequest) throws -> S3Model.NotificationConfiguration {
+        if let getBucketNotificationConfigurationSyncOverride = getBucketNotificationConfigurationSyncOverride {
+            return try getBucketNotificationConfigurationSyncOverride(input)
+        }
+
+        return NotificationConfiguration.__default
+    }
+
+    /**
+     Invokes the GetBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyRequest object being passed to this operation.
+         - completion: The GetBucketPolicyOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketPolicyOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketPolicyAsync(input: S3Model.GetBucketPolicyRequest, completion: @escaping (HTTPResult<S3Model.GetBucketPolicyOutput>) -> ()) throws {
+        if let getBucketPolicyAsyncOverride = getBucketPolicyAsyncOverride {
+            return try getBucketPolicyAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketPolicyOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyRequest object being passed to this operation.
+     - Returns: The GetBucketPolicyOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketPolicySync(input: S3Model.GetBucketPolicyRequest) throws -> S3Model.GetBucketPolicyOutput {
+        if let getBucketPolicySyncOverride = getBucketPolicySyncOverride {
+            return try getBucketPolicySyncOverride(input)
+        }
+
+        return GetBucketPolicyOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketPolicyStatus operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyStatusRequest object being passed to this operation.
+         - completion: The GetBucketPolicyStatusOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketPolicyStatusOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketPolicyStatusAsync(input: S3Model.GetBucketPolicyStatusRequest, completion: @escaping (HTTPResult<S3Model.GetBucketPolicyStatusOutput>) -> ()) throws {
+        if let getBucketPolicyStatusAsyncOverride = getBucketPolicyStatusAsyncOverride {
+            return try getBucketPolicyStatusAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketPolicyStatusOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketPolicyStatus operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyStatusRequest object being passed to this operation.
+     - Returns: The GetBucketPolicyStatusOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketPolicyStatusSync(input: S3Model.GetBucketPolicyStatusRequest) throws -> S3Model.GetBucketPolicyStatusOutput {
+        if let getBucketPolicyStatusSyncOverride = getBucketPolicyStatusSyncOverride {
+            return try getBucketPolicyStatusSyncOverride(input)
+        }
+
+        return GetBucketPolicyStatusOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketReplicationRequest object being passed to this operation.
+         - completion: The GetBucketReplicationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketReplicationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketReplicationAsync(input: S3Model.GetBucketReplicationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketReplicationOutput>) -> ()) throws {
+        if let getBucketReplicationAsyncOverride = getBucketReplicationAsyncOverride {
+            return try getBucketReplicationAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketReplicationOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketReplicationRequest object being passed to this operation.
+     - Returns: The GetBucketReplicationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketReplicationSync(input: S3Model.GetBucketReplicationRequest) throws -> S3Model.GetBucketReplicationOutput {
+        if let getBucketReplicationSyncOverride = getBucketReplicationSyncOverride {
+            return try getBucketReplicationSyncOverride(input)
+        }
+
+        return GetBucketReplicationOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketRequestPayment operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketRequestPaymentRequest object being passed to this operation.
+         - completion: The GetBucketRequestPaymentOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketRequestPaymentOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketRequestPaymentAsync(input: S3Model.GetBucketRequestPaymentRequest, completion: @escaping (HTTPResult<S3Model.GetBucketRequestPaymentOutput>) -> ()) throws {
+        if let getBucketRequestPaymentAsyncOverride = getBucketRequestPaymentAsyncOverride {
+            return try getBucketRequestPaymentAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketRequestPaymentOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketRequestPayment operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketRequestPaymentRequest object being passed to this operation.
+     - Returns: The GetBucketRequestPaymentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketRequestPaymentSync(input: S3Model.GetBucketRequestPaymentRequest) throws -> S3Model.GetBucketRequestPaymentOutput {
+        if let getBucketRequestPaymentSyncOverride = getBucketRequestPaymentSyncOverride {
+            return try getBucketRequestPaymentSyncOverride(input)
+        }
+
+        return GetBucketRequestPaymentOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketTaggingRequest object being passed to this operation.
+         - completion: The GetBucketTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketTaggingAsync(input: S3Model.GetBucketTaggingRequest, completion: @escaping (HTTPResult<S3Model.GetBucketTaggingOutput>) -> ()) throws {
+        if let getBucketTaggingAsyncOverride = getBucketTaggingAsyncOverride {
+            return try getBucketTaggingAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketTaggingOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketTaggingRequest object being passed to this operation.
+     - Returns: The GetBucketTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketTaggingSync(input: S3Model.GetBucketTaggingRequest) throws -> S3Model.GetBucketTaggingOutput {
+        if let getBucketTaggingSyncOverride = getBucketTaggingSyncOverride {
+            return try getBucketTaggingSyncOverride(input)
+        }
+
+        return GetBucketTaggingOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketVersioning operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketVersioningRequest object being passed to this operation.
+         - completion: The GetBucketVersioningOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketVersioningOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketVersioningAsync(input: S3Model.GetBucketVersioningRequest, completion: @escaping (HTTPResult<S3Model.GetBucketVersioningOutput>) -> ()) throws {
+        if let getBucketVersioningAsyncOverride = getBucketVersioningAsyncOverride {
+            return try getBucketVersioningAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketVersioningOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketVersioning operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketVersioningRequest object being passed to this operation.
+     - Returns: The GetBucketVersioningOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketVersioningSync(input: S3Model.GetBucketVersioningRequest) throws -> S3Model.GetBucketVersioningOutput {
+        if let getBucketVersioningSyncOverride = getBucketVersioningSyncOverride {
+            return try getBucketVersioningSyncOverride(input)
+        }
+
+        return GetBucketVersioningOutput.__default
+    }
+
+    /**
+     Invokes the GetBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketWebsiteRequest object being passed to this operation.
+         - completion: The GetBucketWebsiteOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketWebsiteOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketWebsiteAsync(input: S3Model.GetBucketWebsiteRequest, completion: @escaping (HTTPResult<S3Model.GetBucketWebsiteOutput>) -> ()) throws {
+        if let getBucketWebsiteAsyncOverride = getBucketWebsiteAsyncOverride {
+            return try getBucketWebsiteAsyncOverride(input, completion)
+        }
+
+        let result = GetBucketWebsiteOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketWebsiteRequest object being passed to this operation.
+     - Returns: The GetBucketWebsiteOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketWebsiteSync(input: S3Model.GetBucketWebsiteRequest) throws -> S3Model.GetBucketWebsiteOutput {
+        if let getBucketWebsiteSyncOverride = getBucketWebsiteSyncOverride {
+            return try getBucketWebsiteSyncOverride(input)
+        }
+
+        return GetBucketWebsiteOutput.__default
+    }
+
+    /**
+     Invokes the GetObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectRequest object being passed to this operation.
+         - completion: The GetObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func getObjectAsync(input: S3Model.GetObjectRequest, completion: @escaping (HTTPResult<S3Model.GetObjectOutput>) -> ()) throws {
+        if let getObjectAsyncOverride = getObjectAsyncOverride {
+            return try getObjectAsyncOverride(input, completion)
+        }
+
+        let result = GetObjectOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectRequest object being passed to this operation.
+     - Returns: The GetObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func getObjectSync(input: S3Model.GetObjectRequest) throws -> S3Model.GetObjectOutput {
+        if let getObjectSyncOverride = getObjectSyncOverride {
+            return try getObjectSyncOverride(input)
+        }
+
+        return GetObjectOutput.__default
+    }
+
+    /**
+     Invokes the GetObjectAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectAclRequest object being passed to this operation.
+         - completion: The GetObjectAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectAclOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func getObjectAclAsync(input: S3Model.GetObjectAclRequest, completion: @escaping (HTTPResult<S3Model.GetObjectAclOutput>) -> ()) throws {
+        if let getObjectAclAsyncOverride = getObjectAclAsyncOverride {
+            return try getObjectAclAsyncOverride(input, completion)
+        }
+
+        let result = GetObjectAclOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetObjectAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectAclRequest object being passed to this operation.
+     - Returns: The GetObjectAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func getObjectAclSync(input: S3Model.GetObjectAclRequest) throws -> S3Model.GetObjectAclOutput {
+        if let getObjectAclSyncOverride = getObjectAclSyncOverride {
+            return try getObjectAclSyncOverride(input)
+        }
+
+        return GetObjectAclOutput.__default
+    }
+
+    /**
+     Invokes the GetObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectTaggingRequest object being passed to this operation.
+         - completion: The GetObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func getObjectTaggingAsync(input: S3Model.GetObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.GetObjectTaggingOutput>) -> ()) throws {
+        if let getObjectTaggingAsyncOverride = getObjectTaggingAsyncOverride {
+            return try getObjectTaggingAsyncOverride(input, completion)
+        }
+
+        let result = GetObjectTaggingOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectTaggingRequest object being passed to this operation.
+     - Returns: The GetObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getObjectTaggingSync(input: S3Model.GetObjectTaggingRequest) throws -> S3Model.GetObjectTaggingOutput {
+        if let getObjectTaggingSyncOverride = getObjectTaggingSyncOverride {
+            return try getObjectTaggingSyncOverride(input)
+        }
+
+        return GetObjectTaggingOutput.__default
+    }
+
+    /**
+     Invokes the GetObjectTorrent operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectTorrentRequest object being passed to this operation.
+         - completion: The GetObjectTorrentOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectTorrentOutput
+           object will be validated before being returned to caller.
+     */
+    public func getObjectTorrentAsync(input: S3Model.GetObjectTorrentRequest, completion: @escaping (HTTPResult<S3Model.GetObjectTorrentOutput>) -> ()) throws {
+        if let getObjectTorrentAsyncOverride = getObjectTorrentAsyncOverride {
+            return try getObjectTorrentAsyncOverride(input, completion)
+        }
+
+        let result = GetObjectTorrentOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetObjectTorrent operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectTorrentRequest object being passed to this operation.
+     - Returns: The GetObjectTorrentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getObjectTorrentSync(input: S3Model.GetObjectTorrentRequest) throws -> S3Model.GetObjectTorrentOutput {
+        if let getObjectTorrentSyncOverride = getObjectTorrentSyncOverride {
+            return try getObjectTorrentSyncOverride(input)
+        }
+
+        return GetObjectTorrentOutput.__default
+    }
+
+    /**
+     Invokes the GetPublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetPublicAccessBlockRequest object being passed to this operation.
+         - completion: The GetPublicAccessBlockOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetPublicAccessBlockOutput
+           object will be validated before being returned to caller.
+     */
+    public func getPublicAccessBlockAsync(input: S3Model.GetPublicAccessBlockRequest, completion: @escaping (HTTPResult<S3Model.GetPublicAccessBlockOutput>) -> ()) throws {
+        if let getPublicAccessBlockAsyncOverride = getPublicAccessBlockAsyncOverride {
+            return try getPublicAccessBlockAsyncOverride(input, completion)
+        }
+
+        let result = GetPublicAccessBlockOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the GetPublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetPublicAccessBlockRequest object being passed to this operation.
+     - Returns: The GetPublicAccessBlockOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getPublicAccessBlockSync(input: S3Model.GetPublicAccessBlockRequest) throws -> S3Model.GetPublicAccessBlockOutput {
+        if let getPublicAccessBlockSyncOverride = getPublicAccessBlockSyncOverride {
+            return try getPublicAccessBlockSyncOverride(input)
+        }
+
+        return GetPublicAccessBlockOutput.__default
+    }
+
+    /**
+     Invokes the HeadBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated HeadBucketRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+           The possible errors are: noSuchBucket.
+     */
+    public func headBucketAsync(input: S3Model.HeadBucketRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let headBucketAsyncOverride = headBucketAsyncOverride {
+            return try headBucketAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the HeadBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated HeadBucketRequest object being passed to this operation.
+     - Throws: noSuchBucket.
+     */
+    public func headBucketSync(input: S3Model.HeadBucketRequest) throws {
+        if let headBucketSyncOverride = headBucketSyncOverride {
+            return try headBucketSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the HeadObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated HeadObjectRequest object being passed to this operation.
+         - completion: The HeadObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The HeadObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func headObjectAsync(input: S3Model.HeadObjectRequest, completion: @escaping (HTTPResult<S3Model.HeadObjectOutput>) -> ()) throws {
+        if let headObjectAsyncOverride = headObjectAsyncOverride {
+            return try headObjectAsyncOverride(input, completion)
+        }
+
+        let result = HeadObjectOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the HeadObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated HeadObjectRequest object being passed to this operation.
+     - Returns: The HeadObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func headObjectSync(input: S3Model.HeadObjectRequest) throws -> S3Model.HeadObjectOutput {
+        if let headObjectSyncOverride = headObjectSyncOverride {
+            return try headObjectSyncOverride(input)
+        }
+
+        return HeadObjectOutput.__default
+    }
+
+    /**
+     Invokes the ListBucketAnalyticsConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketAnalyticsConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketAnalyticsConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketAnalyticsConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketAnalyticsConfigurationsAsync(input: S3Model.ListBucketAnalyticsConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketAnalyticsConfigurationsOutput>) -> ()) throws {
+        if let listBucketAnalyticsConfigurationsAsyncOverride = listBucketAnalyticsConfigurationsAsyncOverride {
+            return try listBucketAnalyticsConfigurationsAsyncOverride(input, completion)
+        }
+
+        let result = ListBucketAnalyticsConfigurationsOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the ListBucketAnalyticsConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketAnalyticsConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketAnalyticsConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketAnalyticsConfigurationsSync(input: S3Model.ListBucketAnalyticsConfigurationsRequest) throws -> S3Model.ListBucketAnalyticsConfigurationsOutput {
+        if let listBucketAnalyticsConfigurationsSyncOverride = listBucketAnalyticsConfigurationsSyncOverride {
+            return try listBucketAnalyticsConfigurationsSyncOverride(input)
+        }
+
+        return ListBucketAnalyticsConfigurationsOutput.__default
+    }
+
+    /**
+     Invokes the ListBucketInventoryConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketInventoryConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketInventoryConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketInventoryConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketInventoryConfigurationsAsync(input: S3Model.ListBucketInventoryConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketInventoryConfigurationsOutput>) -> ()) throws {
+        if let listBucketInventoryConfigurationsAsyncOverride = listBucketInventoryConfigurationsAsyncOverride {
+            return try listBucketInventoryConfigurationsAsyncOverride(input, completion)
+        }
+
+        let result = ListBucketInventoryConfigurationsOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the ListBucketInventoryConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketInventoryConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketInventoryConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketInventoryConfigurationsSync(input: S3Model.ListBucketInventoryConfigurationsRequest) throws -> S3Model.ListBucketInventoryConfigurationsOutput {
+        if let listBucketInventoryConfigurationsSyncOverride = listBucketInventoryConfigurationsSyncOverride {
+            return try listBucketInventoryConfigurationsSyncOverride(input)
+        }
+
+        return ListBucketInventoryConfigurationsOutput.__default
+    }
+
+    /**
+     Invokes the ListBucketMetricsConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketMetricsConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketMetricsConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketMetricsConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketMetricsConfigurationsAsync(input: S3Model.ListBucketMetricsConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketMetricsConfigurationsOutput>) -> ()) throws {
+        if let listBucketMetricsConfigurationsAsyncOverride = listBucketMetricsConfigurationsAsyncOverride {
+            return try listBucketMetricsConfigurationsAsyncOverride(input, completion)
+        }
+
+        let result = ListBucketMetricsConfigurationsOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the ListBucketMetricsConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketMetricsConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketMetricsConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketMetricsConfigurationsSync(input: S3Model.ListBucketMetricsConfigurationsRequest) throws -> S3Model.ListBucketMetricsConfigurationsOutput {
+        if let listBucketMetricsConfigurationsSyncOverride = listBucketMetricsConfigurationsSyncOverride {
+            return try listBucketMetricsConfigurationsSyncOverride(input)
+        }
+
+        return ListBucketMetricsConfigurationsOutput.__default
+    }
+
+    /**
+     Invokes the ListBuckets operation returning immediately and passing the response to a callback.
+         - completion: The ListBucketsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketsAsync(completion: @escaping (HTTPResult<S3Model.ListBucketsOutput>) -> ()) throws {
+        if let listBucketsAsyncOverride = listBucketsAsyncOverride {
+            return try listBucketsAsyncOverride(completion)
+        }
+
+        let result = ListBucketsOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the ListBuckets operation waiting for the response before returning.
+     - Returns: The ListBucketsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketsSync() throws -> S3Model.ListBucketsOutput {
+        if let listBucketsSyncOverride = listBucketsSyncOverride {
+            return try listBucketsSyncOverride()
+        }
+
+        return ListBucketsOutput.__default
+    }
+
+    /**
+     Invokes the ListMultipartUploads operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListMultipartUploadsRequest object being passed to this operation.
+         - completion: The ListMultipartUploadsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListMultipartUploadsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listMultipartUploadsAsync(input: S3Model.ListMultipartUploadsRequest, completion: @escaping (HTTPResult<S3Model.ListMultipartUploadsOutput>) -> ()) throws {
+        if let listMultipartUploadsAsyncOverride = listMultipartUploadsAsyncOverride {
+            return try listMultipartUploadsAsyncOverride(input, completion)
+        }
+
+        let result = ListMultipartUploadsOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the ListMultipartUploads operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListMultipartUploadsRequest object being passed to this operation.
+     - Returns: The ListMultipartUploadsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listMultipartUploadsSync(input: S3Model.ListMultipartUploadsRequest) throws -> S3Model.ListMultipartUploadsOutput {
+        if let listMultipartUploadsSyncOverride = listMultipartUploadsSyncOverride {
+            return try listMultipartUploadsSyncOverride(input)
+        }
+
+        return ListMultipartUploadsOutput.__default
+    }
+
+    /**
+     Invokes the ListObjectVersions operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectVersionsRequest object being passed to this operation.
+         - completion: The ListObjectVersionsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectVersionsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listObjectVersionsAsync(input: S3Model.ListObjectVersionsRequest, completion: @escaping (HTTPResult<S3Model.ListObjectVersionsOutput>) -> ()) throws {
+        if let listObjectVersionsAsyncOverride = listObjectVersionsAsyncOverride {
+            return try listObjectVersionsAsyncOverride(input, completion)
+        }
+
+        let result = ListObjectVersionsOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the ListObjectVersions operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectVersionsRequest object being passed to this operation.
+     - Returns: The ListObjectVersionsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listObjectVersionsSync(input: S3Model.ListObjectVersionsRequest) throws -> S3Model.ListObjectVersionsOutput {
+        if let listObjectVersionsSyncOverride = listObjectVersionsSyncOverride {
+            return try listObjectVersionsSyncOverride(input)
+        }
+
+        return ListObjectVersionsOutput.__default
+    }
+
+    /**
+     Invokes the ListObjects operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectsRequest object being passed to this operation.
+         - completion: The ListObjectsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectsOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchBucket.
+     */
+    public func listObjectsAsync(input: S3Model.ListObjectsRequest, completion: @escaping (HTTPResult<S3Model.ListObjectsOutput>) -> ()) throws {
+        if let listObjectsAsyncOverride = listObjectsAsyncOverride {
+            return try listObjectsAsyncOverride(input, completion)
+        }
+
+        let result = ListObjectsOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the ListObjects operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectsRequest object being passed to this operation.
+     - Returns: The ListObjectsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchBucket.
+     */
+    public func listObjectsSync(input: S3Model.ListObjectsRequest) throws -> S3Model.ListObjectsOutput {
+        if let listObjectsSyncOverride = listObjectsSyncOverride {
+            return try listObjectsSyncOverride(input)
+        }
+
+        return ListObjectsOutput.__default
+    }
+
+    /**
+     Invokes the ListObjectsV2 operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectsV2Request object being passed to this operation.
+         - completion: The ListObjectsV2Output object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectsV2Output
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchBucket.
+     */
+    public func listObjectsV2Async(input: S3Model.ListObjectsV2Request, completion: @escaping (HTTPResult<S3Model.ListObjectsV2Output>) -> ()) throws {
+        if let listObjectsV2AsyncOverride = listObjectsV2AsyncOverride {
+            return try listObjectsV2AsyncOverride(input, completion)
+        }
+
+        let result = ListObjectsV2Output.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the ListObjectsV2 operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectsV2Request object being passed to this operation.
+     - Returns: The ListObjectsV2Output object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchBucket.
+     */
+    public func listObjectsV2Sync(input: S3Model.ListObjectsV2Request) throws -> S3Model.ListObjectsV2Output {
+        if let listObjectsV2SyncOverride = listObjectsV2SyncOverride {
+            return try listObjectsV2SyncOverride(input)
+        }
+
+        return ListObjectsV2Output.__default
+    }
+
+    /**
+     Invokes the ListParts operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListPartsRequest object being passed to this operation.
+         - completion: The ListPartsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListPartsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listPartsAsync(input: S3Model.ListPartsRequest, completion: @escaping (HTTPResult<S3Model.ListPartsOutput>) -> ()) throws {
+        if let listPartsAsyncOverride = listPartsAsyncOverride {
+            return try listPartsAsyncOverride(input, completion)
+        }
+
+        let result = ListPartsOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the ListParts operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListPartsRequest object being passed to this operation.
+     - Returns: The ListPartsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listPartsSync(input: S3Model.ListPartsRequest) throws -> S3Model.ListPartsOutput {
+        if let listPartsSyncOverride = listPartsSyncOverride {
+            return try listPartsSyncOverride(input)
+        }
+
+        return ListPartsOutput.__default
+    }
+
+    /**
+     Invokes the PutBucketAccelerateConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAccelerateConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketAccelerateConfigurationAsync(input: S3Model.PutBucketAccelerateConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketAccelerateConfigurationAsyncOverride = putBucketAccelerateConfigurationAsyncOverride {
+            return try putBucketAccelerateConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketAccelerateConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAccelerateConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketAccelerateConfigurationSync(input: S3Model.PutBucketAccelerateConfigurationRequest) throws {
+        if let putBucketAccelerateConfigurationSyncOverride = putBucketAccelerateConfigurationSyncOverride {
+            return try putBucketAccelerateConfigurationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAclRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketAclAsync(input: S3Model.PutBucketAclRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketAclAsyncOverride = putBucketAclAsyncOverride {
+            return try putBucketAclAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAclRequest object being passed to this operation.
+     */
+    public func putBucketAclSync(input: S3Model.PutBucketAclRequest) throws {
+        if let putBucketAclSyncOverride = putBucketAclSyncOverride {
+            return try putBucketAclSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketAnalyticsConfigurationAsync(input: S3Model.PutBucketAnalyticsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketAnalyticsConfigurationAsyncOverride = putBucketAnalyticsConfigurationAsyncOverride {
+            return try putBucketAnalyticsConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAnalyticsConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketAnalyticsConfigurationSync(input: S3Model.PutBucketAnalyticsConfigurationRequest) throws {
+        if let putBucketAnalyticsConfigurationSyncOverride = putBucketAnalyticsConfigurationSyncOverride {
+            return try putBucketAnalyticsConfigurationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketCorsRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketCorsAsync(input: S3Model.PutBucketCorsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketCorsAsyncOverride = putBucketCorsAsyncOverride {
+            return try putBucketCorsAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketCorsRequest object being passed to this operation.
+     */
+    public func putBucketCorsSync(input: S3Model.PutBucketCorsRequest) throws {
+        if let putBucketCorsSyncOverride = putBucketCorsSyncOverride {
+            return try putBucketCorsSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketEncryptionRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketEncryptionAsync(input: S3Model.PutBucketEncryptionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketEncryptionAsyncOverride = putBucketEncryptionAsyncOverride {
+            return try putBucketEncryptionAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketEncryptionRequest object being passed to this operation.
+     */
+    public func putBucketEncryptionSync(input: S3Model.PutBucketEncryptionRequest) throws {
+        if let putBucketEncryptionSyncOverride = putBucketEncryptionSyncOverride {
+            return try putBucketEncryptionSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketInventoryConfigurationAsync(input: S3Model.PutBucketInventoryConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketInventoryConfigurationAsyncOverride = putBucketInventoryConfigurationAsyncOverride {
+            return try putBucketInventoryConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketInventoryConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketInventoryConfigurationSync(input: S3Model.PutBucketInventoryConfigurationRequest) throws {
+        if let putBucketInventoryConfigurationSyncOverride = putBucketInventoryConfigurationSyncOverride {
+            return try putBucketInventoryConfigurationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketLifecycleAsync(input: S3Model.PutBucketLifecycleRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketLifecycleAsyncOverride = putBucketLifecycleAsyncOverride {
+            return try putBucketLifecycleAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleRequest object being passed to this operation.
+     */
+    public func putBucketLifecycleSync(input: S3Model.PutBucketLifecycleRequest) throws {
+        if let putBucketLifecycleSyncOverride = putBucketLifecycleSyncOverride {
+            return try putBucketLifecycleSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketLifecycleConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketLifecycleConfigurationAsync(input: S3Model.PutBucketLifecycleConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketLifecycleConfigurationAsyncOverride = putBucketLifecycleConfigurationAsyncOverride {
+            return try putBucketLifecycleConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketLifecycleConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketLifecycleConfigurationSync(input: S3Model.PutBucketLifecycleConfigurationRequest) throws {
+        if let putBucketLifecycleConfigurationSyncOverride = putBucketLifecycleConfigurationSyncOverride {
+            return try putBucketLifecycleConfigurationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketLogging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLoggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketLoggingAsync(input: S3Model.PutBucketLoggingRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketLoggingAsyncOverride = putBucketLoggingAsyncOverride {
+            return try putBucketLoggingAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketLogging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLoggingRequest object being passed to this operation.
+     */
+    public func putBucketLoggingSync(input: S3Model.PutBucketLoggingRequest) throws {
+        if let putBucketLoggingSyncOverride = putBucketLoggingSyncOverride {
+            return try putBucketLoggingSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketMetricsConfigurationAsync(input: S3Model.PutBucketMetricsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketMetricsConfigurationAsyncOverride = putBucketMetricsConfigurationAsyncOverride {
+            return try putBucketMetricsConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketMetricsConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketMetricsConfigurationSync(input: S3Model.PutBucketMetricsConfigurationRequest) throws {
+        if let putBucketMetricsConfigurationSyncOverride = putBucketMetricsConfigurationSyncOverride {
+            return try putBucketMetricsConfigurationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketNotification operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketNotificationAsync(input: S3Model.PutBucketNotificationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketNotificationAsyncOverride = putBucketNotificationAsyncOverride {
+            return try putBucketNotificationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketNotification operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationRequest object being passed to this operation.
+     */
+    public func putBucketNotificationSync(input: S3Model.PutBucketNotificationRequest) throws {
+        if let putBucketNotificationSyncOverride = putBucketNotificationSyncOverride {
+            return try putBucketNotificationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketNotificationConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketNotificationConfigurationAsync(input: S3Model.PutBucketNotificationConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketNotificationConfigurationAsyncOverride = putBucketNotificationConfigurationAsyncOverride {
+            return try putBucketNotificationConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketNotificationConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketNotificationConfigurationSync(input: S3Model.PutBucketNotificationConfigurationRequest) throws {
+        if let putBucketNotificationConfigurationSyncOverride = putBucketNotificationConfigurationSyncOverride {
+            return try putBucketNotificationConfigurationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketPolicyRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketPolicyAsync(input: S3Model.PutBucketPolicyRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketPolicyAsyncOverride = putBucketPolicyAsyncOverride {
+            return try putBucketPolicyAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketPolicyRequest object being passed to this operation.
+     */
+    public func putBucketPolicySync(input: S3Model.PutBucketPolicyRequest) throws {
+        if let putBucketPolicySyncOverride = putBucketPolicySyncOverride {
+            return try putBucketPolicySyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketReplicationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketReplicationAsync(input: S3Model.PutBucketReplicationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketReplicationAsyncOverride = putBucketReplicationAsyncOverride {
+            return try putBucketReplicationAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketReplicationRequest object being passed to this operation.
+     */
+    public func putBucketReplicationSync(input: S3Model.PutBucketReplicationRequest) throws {
+        if let putBucketReplicationSyncOverride = putBucketReplicationSyncOverride {
+            return try putBucketReplicationSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketRequestPayment operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketRequestPaymentRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketRequestPaymentAsync(input: S3Model.PutBucketRequestPaymentRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketRequestPaymentAsyncOverride = putBucketRequestPaymentAsyncOverride {
+            return try putBucketRequestPaymentAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketRequestPayment operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketRequestPaymentRequest object being passed to this operation.
+     */
+    public func putBucketRequestPaymentSync(input: S3Model.PutBucketRequestPaymentRequest) throws {
+        if let putBucketRequestPaymentSyncOverride = putBucketRequestPaymentSyncOverride {
+            return try putBucketRequestPaymentSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketTaggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketTaggingAsync(input: S3Model.PutBucketTaggingRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketTaggingAsyncOverride = putBucketTaggingAsyncOverride {
+            return try putBucketTaggingAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketTaggingRequest object being passed to this operation.
+     */
+    public func putBucketTaggingSync(input: S3Model.PutBucketTaggingRequest) throws {
+        if let putBucketTaggingSyncOverride = putBucketTaggingSyncOverride {
+            return try putBucketTaggingSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketVersioning operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketVersioningRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketVersioningAsync(input: S3Model.PutBucketVersioningRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketVersioningAsyncOverride = putBucketVersioningAsyncOverride {
+            return try putBucketVersioningAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketVersioning operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketVersioningRequest object being passed to this operation.
+     */
+    public func putBucketVersioningSync(input: S3Model.PutBucketVersioningRequest) throws {
+        if let putBucketVersioningSyncOverride = putBucketVersioningSyncOverride {
+            return try putBucketVersioningSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketWebsiteRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketWebsiteAsync(input: S3Model.PutBucketWebsiteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketWebsiteAsyncOverride = putBucketWebsiteAsyncOverride {
+            return try putBucketWebsiteAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketWebsiteRequest object being passed to this operation.
+     */
+    public func putBucketWebsiteSync(input: S3Model.PutBucketWebsiteRequest) throws {
+        if let putBucketWebsiteSyncOverride = putBucketWebsiteSyncOverride {
+            return try putBucketWebsiteSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the PutObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectRequest object being passed to this operation.
+         - completion: The PutObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectOutput
+           object will be validated before being returned to caller.
+     */
+    public func putObjectAsync(input: S3Model.PutObjectRequest, completion: @escaping (HTTPResult<S3Model.PutObjectOutput>) -> ()) throws {
+        if let putObjectAsyncOverride = putObjectAsyncOverride {
+            return try putObjectAsyncOverride(input, completion)
+        }
+
+        let result = PutObjectOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the PutObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectRequest object being passed to this operation.
+     - Returns: The PutObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func putObjectSync(input: S3Model.PutObjectRequest) throws -> S3Model.PutObjectOutput {
+        if let putObjectSyncOverride = putObjectSyncOverride {
+            return try putObjectSyncOverride(input)
+        }
+
+        return PutObjectOutput.__default
+    }
+
+    /**
+     Invokes the PutObjectAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectAclRequest object being passed to this operation.
+         - completion: The PutObjectAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectAclOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func putObjectAclAsync(input: S3Model.PutObjectAclRequest, completion: @escaping (HTTPResult<S3Model.PutObjectAclOutput>) -> ()) throws {
+        if let putObjectAclAsyncOverride = putObjectAclAsyncOverride {
+            return try putObjectAclAsyncOverride(input, completion)
+        }
+
+        let result = PutObjectAclOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the PutObjectAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectAclRequest object being passed to this operation.
+     - Returns: The PutObjectAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func putObjectAclSync(input: S3Model.PutObjectAclRequest) throws -> S3Model.PutObjectAclOutput {
+        if let putObjectAclSyncOverride = putObjectAclSyncOverride {
+            return try putObjectAclSyncOverride(input)
+        }
+
+        return PutObjectAclOutput.__default
+    }
+
+    /**
+     Invokes the PutObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectTaggingRequest object being passed to this operation.
+         - completion: The PutObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func putObjectTaggingAsync(input: S3Model.PutObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.PutObjectTaggingOutput>) -> ()) throws {
+        if let putObjectTaggingAsyncOverride = putObjectTaggingAsyncOverride {
+            return try putObjectTaggingAsyncOverride(input, completion)
+        }
+
+        let result = PutObjectTaggingOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the PutObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectTaggingRequest object being passed to this operation.
+     - Returns: The PutObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func putObjectTaggingSync(input: S3Model.PutObjectTaggingRequest) throws -> S3Model.PutObjectTaggingOutput {
+        if let putObjectTaggingSyncOverride = putObjectTaggingSyncOverride {
+            return try putObjectTaggingSyncOverride(input)
+        }
+
+        return PutObjectTaggingOutput.__default
+    }
+
+    /**
+     Invokes the PutPublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutPublicAccessBlockRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putPublicAccessBlockAsync(input: S3Model.PutPublicAccessBlockRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putPublicAccessBlockAsyncOverride = putPublicAccessBlockAsyncOverride {
+            return try putPublicAccessBlockAsyncOverride(input, completion)
+        }
+
+        completion(nil)
+    }
+
+    /**
+     Invokes the PutPublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutPublicAccessBlockRequest object being passed to this operation.
+     */
+    public func putPublicAccessBlockSync(input: S3Model.PutPublicAccessBlockRequest) throws {
+        if let putPublicAccessBlockSyncOverride = putPublicAccessBlockSyncOverride {
+            return try putPublicAccessBlockSyncOverride(input)
+        }
+
+    }
+
+    /**
+     Invokes the RestoreObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated RestoreObjectRequest object being passed to this operation.
+         - completion: The RestoreObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The RestoreObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: objectAlreadyInActiveTier.
+     */
+    public func restoreObjectAsync(input: S3Model.RestoreObjectRequest, completion: @escaping (HTTPResult<S3Model.RestoreObjectOutput>) -> ()) throws {
+        if let restoreObjectAsyncOverride = restoreObjectAsyncOverride {
+            return try restoreObjectAsyncOverride(input, completion)
+        }
+
+        let result = RestoreObjectOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the RestoreObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated RestoreObjectRequest object being passed to this operation.
+     - Returns: The RestoreObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: objectAlreadyInActiveTier.
+     */
+    public func restoreObjectSync(input: S3Model.RestoreObjectRequest) throws -> S3Model.RestoreObjectOutput {
+        if let restoreObjectSyncOverride = restoreObjectSyncOverride {
+            return try restoreObjectSyncOverride(input)
+        }
+
+        return RestoreObjectOutput.__default
+    }
+
+    /**
+     Invokes the SelectObjectContent operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated SelectObjectContentRequest object being passed to this operation.
+         - completion: The SelectObjectContentOutput object or an error will be passed to this 
+           callback when the operation is complete. The SelectObjectContentOutput
+           object will be validated before being returned to caller.
+     */
+    public func selectObjectContentAsync(input: S3Model.SelectObjectContentRequest, completion: @escaping (HTTPResult<S3Model.SelectObjectContentOutput>) -> ()) throws {
+        if let selectObjectContentAsyncOverride = selectObjectContentAsyncOverride {
+            return try selectObjectContentAsyncOverride(input, completion)
+        }
+
+        let result = SelectObjectContentOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the SelectObjectContent operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated SelectObjectContentRequest object being passed to this operation.
+     - Returns: The SelectObjectContentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func selectObjectContentSync(input: S3Model.SelectObjectContentRequest) throws -> S3Model.SelectObjectContentOutput {
+        if let selectObjectContentSyncOverride = selectObjectContentSyncOverride {
+            return try selectObjectContentSyncOverride(input)
+        }
+
+        return SelectObjectContentOutput.__default
+    }
+
+    /**
+     Invokes the UploadPart operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated UploadPartRequest object being passed to this operation.
+         - completion: The UploadPartOutput object or an error will be passed to this 
+           callback when the operation is complete. The UploadPartOutput
+           object will be validated before being returned to caller.
+     */
+    public func uploadPartAsync(input: S3Model.UploadPartRequest, completion: @escaping (HTTPResult<S3Model.UploadPartOutput>) -> ()) throws {
+        if let uploadPartAsyncOverride = uploadPartAsyncOverride {
+            return try uploadPartAsyncOverride(input, completion)
+        }
+
+        let result = UploadPartOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the UploadPart operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated UploadPartRequest object being passed to this operation.
+     - Returns: The UploadPartOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func uploadPartSync(input: S3Model.UploadPartRequest) throws -> S3Model.UploadPartOutput {
+        if let uploadPartSyncOverride = uploadPartSyncOverride {
+            return try uploadPartSyncOverride(input)
+        }
+
+        return UploadPartOutput.__default
+    }
+
+    /**
+     Invokes the UploadPartCopy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated UploadPartCopyRequest object being passed to this operation.
+         - completion: The UploadPartCopyOutput object or an error will be passed to this 
+           callback when the operation is complete. The UploadPartCopyOutput
+           object will be validated before being returned to caller.
+     */
+    public func uploadPartCopyAsync(input: S3Model.UploadPartCopyRequest, completion: @escaping (HTTPResult<S3Model.UploadPartCopyOutput>) -> ()) throws {
+        if let uploadPartCopyAsyncOverride = uploadPartCopyAsyncOverride {
+            return try uploadPartCopyAsyncOverride(input, completion)
+        }
+
+        let result = UploadPartCopyOutput.__default
+        
+        completion(.response(result))
+    }
+
+    /**
+     Invokes the UploadPartCopy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated UploadPartCopyRequest object being passed to this operation.
+     - Returns: The UploadPartCopyOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func uploadPartCopySync(input: S3Model.UploadPartCopyRequest) throws -> S3Model.UploadPartCopyOutput {
+        if let uploadPartCopySyncOverride = uploadPartCopySyncOverride {
+            return try uploadPartCopySyncOverride(input)
+        }
+
+        return UploadPartCopyOutput.__default
+    }
+}

--- a/Sources/S3Client/S3ClientProtocol.swift
+++ b/Sources/S3Client/S3ClientProtocol.swift
@@ -1,0 +1,1836 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment type_body_length
+// -- Generated Code; do not edit --
+//
+// S3ClientProtocol.swift
+// S3Client
+//
+
+import Foundation
+import S3Model
+import SmokeHTTPClient
+
+/**
+ Client Protocol for the S3 service.
+ */
+public protocol S3ClientProtocol {
+    typealias AbortMultipartUploadSyncType = (_ input: S3Model.AbortMultipartUploadRequest) throws -> S3Model.AbortMultipartUploadOutput
+    typealias AbortMultipartUploadAsyncType = (_ input: S3Model.AbortMultipartUploadRequest, _ completion: @escaping (HTTPResult<S3Model.AbortMultipartUploadOutput>) -> ()) throws -> ()
+    typealias CompleteMultipartUploadSyncType = (_ input: S3Model.CompleteMultipartUploadRequest) throws -> S3Model.CompleteMultipartUploadOutput
+    typealias CompleteMultipartUploadAsyncType = (_ input: S3Model.CompleteMultipartUploadRequest, _ completion: @escaping (HTTPResult<S3Model.CompleteMultipartUploadOutput>) -> ()) throws -> ()
+    typealias CopyObjectSyncType = (_ input: S3Model.CopyObjectRequest) throws -> S3Model.CopyObjectOutput
+    typealias CopyObjectAsyncType = (_ input: S3Model.CopyObjectRequest, _ completion: @escaping (HTTPResult<S3Model.CopyObjectOutput>) -> ()) throws -> ()
+    typealias CreateBucketSyncType = (_ input: S3Model.CreateBucketRequest) throws -> S3Model.CreateBucketOutput
+    typealias CreateBucketAsyncType = (_ input: S3Model.CreateBucketRequest, _ completion: @escaping (HTTPResult<S3Model.CreateBucketOutput>) -> ()) throws -> ()
+    typealias CreateMultipartUploadSyncType = (_ input: S3Model.CreateMultipartUploadRequest) throws -> S3Model.CreateMultipartUploadOutput
+    typealias CreateMultipartUploadAsyncType = (_ input: S3Model.CreateMultipartUploadRequest, _ completion: @escaping (HTTPResult<S3Model.CreateMultipartUploadOutput>) -> ()) throws -> ()
+    typealias DeleteBucketSyncType = (_ input: S3Model.DeleteBucketRequest) throws -> ()
+    typealias DeleteBucketAsyncType = (_ input: S3Model.DeleteBucketRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteBucketAnalyticsConfigurationSyncType = (_ input: S3Model.DeleteBucketAnalyticsConfigurationRequest) throws -> ()
+    typealias DeleteBucketAnalyticsConfigurationAsyncType = (_ input: S3Model.DeleteBucketAnalyticsConfigurationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteBucketCorsSyncType = (_ input: S3Model.DeleteBucketCorsRequest) throws -> ()
+    typealias DeleteBucketCorsAsyncType = (_ input: S3Model.DeleteBucketCorsRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteBucketEncryptionSyncType = (_ input: S3Model.DeleteBucketEncryptionRequest) throws -> ()
+    typealias DeleteBucketEncryptionAsyncType = (_ input: S3Model.DeleteBucketEncryptionRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteBucketInventoryConfigurationSyncType = (_ input: S3Model.DeleteBucketInventoryConfigurationRequest) throws -> ()
+    typealias DeleteBucketInventoryConfigurationAsyncType = (_ input: S3Model.DeleteBucketInventoryConfigurationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteBucketLifecycleSyncType = (_ input: S3Model.DeleteBucketLifecycleRequest) throws -> ()
+    typealias DeleteBucketLifecycleAsyncType = (_ input: S3Model.DeleteBucketLifecycleRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteBucketMetricsConfigurationSyncType = (_ input: S3Model.DeleteBucketMetricsConfigurationRequest) throws -> ()
+    typealias DeleteBucketMetricsConfigurationAsyncType = (_ input: S3Model.DeleteBucketMetricsConfigurationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteBucketPolicySyncType = (_ input: S3Model.DeleteBucketPolicyRequest) throws -> ()
+    typealias DeleteBucketPolicyAsyncType = (_ input: S3Model.DeleteBucketPolicyRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteBucketReplicationSyncType = (_ input: S3Model.DeleteBucketReplicationRequest) throws -> ()
+    typealias DeleteBucketReplicationAsyncType = (_ input: S3Model.DeleteBucketReplicationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteBucketTaggingSyncType = (_ input: S3Model.DeleteBucketTaggingRequest) throws -> ()
+    typealias DeleteBucketTaggingAsyncType = (_ input: S3Model.DeleteBucketTaggingRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteBucketWebsiteSyncType = (_ input: S3Model.DeleteBucketWebsiteRequest) throws -> ()
+    typealias DeleteBucketWebsiteAsyncType = (_ input: S3Model.DeleteBucketWebsiteRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias DeleteObjectSyncType = (_ input: S3Model.DeleteObjectRequest) throws -> S3Model.DeleteObjectOutput
+    typealias DeleteObjectAsyncType = (_ input: S3Model.DeleteObjectRequest, _ completion: @escaping (HTTPResult<S3Model.DeleteObjectOutput>) -> ()) throws -> ()
+    typealias DeleteObjectTaggingSyncType = (_ input: S3Model.DeleteObjectTaggingRequest) throws -> S3Model.DeleteObjectTaggingOutput
+    typealias DeleteObjectTaggingAsyncType = (_ input: S3Model.DeleteObjectTaggingRequest, _ completion: @escaping (HTTPResult<S3Model.DeleteObjectTaggingOutput>) -> ()) throws -> ()
+    typealias DeleteObjectsSyncType = (_ input: S3Model.DeleteObjectsRequest) throws -> S3Model.DeleteObjectsOutput
+    typealias DeleteObjectsAsyncType = (_ input: S3Model.DeleteObjectsRequest, _ completion: @escaping (HTTPResult<S3Model.DeleteObjectsOutput>) -> ()) throws -> ()
+    typealias DeletePublicAccessBlockSyncType = (_ input: S3Model.DeletePublicAccessBlockRequest) throws -> ()
+    typealias DeletePublicAccessBlockAsyncType = (_ input: S3Model.DeletePublicAccessBlockRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias GetBucketAccelerateConfigurationSyncType = (_ input: S3Model.GetBucketAccelerateConfigurationRequest) throws -> S3Model.GetBucketAccelerateConfigurationOutput
+    typealias GetBucketAccelerateConfigurationAsyncType = (_ input: S3Model.GetBucketAccelerateConfigurationRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketAccelerateConfigurationOutput>) -> ()) throws -> ()
+    typealias GetBucketAclSyncType = (_ input: S3Model.GetBucketAclRequest) throws -> S3Model.GetBucketAclOutput
+    typealias GetBucketAclAsyncType = (_ input: S3Model.GetBucketAclRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketAclOutput>) -> ()) throws -> ()
+    typealias GetBucketAnalyticsConfigurationSyncType = (_ input: S3Model.GetBucketAnalyticsConfigurationRequest) throws -> S3Model.GetBucketAnalyticsConfigurationOutput
+    typealias GetBucketAnalyticsConfigurationAsyncType = (_ input: S3Model.GetBucketAnalyticsConfigurationRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketAnalyticsConfigurationOutput>) -> ()) throws -> ()
+    typealias GetBucketCorsSyncType = (_ input: S3Model.GetBucketCorsRequest) throws -> S3Model.GetBucketCorsOutput
+    typealias GetBucketCorsAsyncType = (_ input: S3Model.GetBucketCorsRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketCorsOutput>) -> ()) throws -> ()
+    typealias GetBucketEncryptionSyncType = (_ input: S3Model.GetBucketEncryptionRequest) throws -> S3Model.GetBucketEncryptionOutput
+    typealias GetBucketEncryptionAsyncType = (_ input: S3Model.GetBucketEncryptionRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketEncryptionOutput>) -> ()) throws -> ()
+    typealias GetBucketInventoryConfigurationSyncType = (_ input: S3Model.GetBucketInventoryConfigurationRequest) throws -> S3Model.GetBucketInventoryConfigurationOutput
+    typealias GetBucketInventoryConfigurationAsyncType = (_ input: S3Model.GetBucketInventoryConfigurationRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketInventoryConfigurationOutput>) -> ()) throws -> ()
+    typealias GetBucketLifecycleSyncType = (_ input: S3Model.GetBucketLifecycleRequest) throws -> S3Model.GetBucketLifecycleOutput
+    typealias GetBucketLifecycleAsyncType = (_ input: S3Model.GetBucketLifecycleRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketLifecycleOutput>) -> ()) throws -> ()
+    typealias GetBucketLifecycleConfigurationSyncType = (_ input: S3Model.GetBucketLifecycleConfigurationRequest) throws -> S3Model.GetBucketLifecycleConfigurationOutput
+    typealias GetBucketLifecycleConfigurationAsyncType = (_ input: S3Model.GetBucketLifecycleConfigurationRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketLifecycleConfigurationOutput>) -> ()) throws -> ()
+    typealias GetBucketLocationSyncType = (_ input: S3Model.GetBucketLocationRequest) throws -> S3Model.GetBucketLocationOutput
+    typealias GetBucketLocationAsyncType = (_ input: S3Model.GetBucketLocationRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketLocationOutput>) -> ()) throws -> ()
+    typealias GetBucketLoggingSyncType = (_ input: S3Model.GetBucketLoggingRequest) throws -> S3Model.GetBucketLoggingOutput
+    typealias GetBucketLoggingAsyncType = (_ input: S3Model.GetBucketLoggingRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketLoggingOutput>) -> ()) throws -> ()
+    typealias GetBucketMetricsConfigurationSyncType = (_ input: S3Model.GetBucketMetricsConfigurationRequest) throws -> S3Model.GetBucketMetricsConfigurationOutput
+    typealias GetBucketMetricsConfigurationAsyncType = (_ input: S3Model.GetBucketMetricsConfigurationRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketMetricsConfigurationOutput>) -> ()) throws -> ()
+    typealias GetBucketNotificationSyncType = (_ input: S3Model.GetBucketNotificationConfigurationRequest) throws -> S3Model.NotificationConfigurationDeprecated
+    typealias GetBucketNotificationAsyncType = (_ input: S3Model.GetBucketNotificationConfigurationRequest, _ completion: @escaping (HTTPResult<S3Model.NotificationConfigurationDeprecated>) -> ()) throws -> ()
+    typealias GetBucketNotificationConfigurationSyncType = (_ input: S3Model.GetBucketNotificationConfigurationRequest) throws -> S3Model.NotificationConfiguration
+    typealias GetBucketNotificationConfigurationAsyncType = (_ input: S3Model.GetBucketNotificationConfigurationRequest, _ completion: @escaping (HTTPResult<S3Model.NotificationConfiguration>) -> ()) throws -> ()
+    typealias GetBucketPolicySyncType = (_ input: S3Model.GetBucketPolicyRequest) throws -> S3Model.GetBucketPolicyOutput
+    typealias GetBucketPolicyAsyncType = (_ input: S3Model.GetBucketPolicyRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketPolicyOutput>) -> ()) throws -> ()
+    typealias GetBucketPolicyStatusSyncType = (_ input: S3Model.GetBucketPolicyStatusRequest) throws -> S3Model.GetBucketPolicyStatusOutput
+    typealias GetBucketPolicyStatusAsyncType = (_ input: S3Model.GetBucketPolicyStatusRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketPolicyStatusOutput>) -> ()) throws -> ()
+    typealias GetBucketReplicationSyncType = (_ input: S3Model.GetBucketReplicationRequest) throws -> S3Model.GetBucketReplicationOutput
+    typealias GetBucketReplicationAsyncType = (_ input: S3Model.GetBucketReplicationRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketReplicationOutput>) -> ()) throws -> ()
+    typealias GetBucketRequestPaymentSyncType = (_ input: S3Model.GetBucketRequestPaymentRequest) throws -> S3Model.GetBucketRequestPaymentOutput
+    typealias GetBucketRequestPaymentAsyncType = (_ input: S3Model.GetBucketRequestPaymentRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketRequestPaymentOutput>) -> ()) throws -> ()
+    typealias GetBucketTaggingSyncType = (_ input: S3Model.GetBucketTaggingRequest) throws -> S3Model.GetBucketTaggingOutput
+    typealias GetBucketTaggingAsyncType = (_ input: S3Model.GetBucketTaggingRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketTaggingOutput>) -> ()) throws -> ()
+    typealias GetBucketVersioningSyncType = (_ input: S3Model.GetBucketVersioningRequest) throws -> S3Model.GetBucketVersioningOutput
+    typealias GetBucketVersioningAsyncType = (_ input: S3Model.GetBucketVersioningRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketVersioningOutput>) -> ()) throws -> ()
+    typealias GetBucketWebsiteSyncType = (_ input: S3Model.GetBucketWebsiteRequest) throws -> S3Model.GetBucketWebsiteOutput
+    typealias GetBucketWebsiteAsyncType = (_ input: S3Model.GetBucketWebsiteRequest, _ completion: @escaping (HTTPResult<S3Model.GetBucketWebsiteOutput>) -> ()) throws -> ()
+    typealias GetObjectSyncType = (_ input: S3Model.GetObjectRequest) throws -> S3Model.GetObjectOutput
+    typealias GetObjectAsyncType = (_ input: S3Model.GetObjectRequest, _ completion: @escaping (HTTPResult<S3Model.GetObjectOutput>) -> ()) throws -> ()
+    typealias GetObjectAclSyncType = (_ input: S3Model.GetObjectAclRequest) throws -> S3Model.GetObjectAclOutput
+    typealias GetObjectAclAsyncType = (_ input: S3Model.GetObjectAclRequest, _ completion: @escaping (HTTPResult<S3Model.GetObjectAclOutput>) -> ()) throws -> ()
+    typealias GetObjectTaggingSyncType = (_ input: S3Model.GetObjectTaggingRequest) throws -> S3Model.GetObjectTaggingOutput
+    typealias GetObjectTaggingAsyncType = (_ input: S3Model.GetObjectTaggingRequest, _ completion: @escaping (HTTPResult<S3Model.GetObjectTaggingOutput>) -> ()) throws -> ()
+    typealias GetObjectTorrentSyncType = (_ input: S3Model.GetObjectTorrentRequest) throws -> S3Model.GetObjectTorrentOutput
+    typealias GetObjectTorrentAsyncType = (_ input: S3Model.GetObjectTorrentRequest, _ completion: @escaping (HTTPResult<S3Model.GetObjectTorrentOutput>) -> ()) throws -> ()
+    typealias GetPublicAccessBlockSyncType = (_ input: S3Model.GetPublicAccessBlockRequest) throws -> S3Model.GetPublicAccessBlockOutput
+    typealias GetPublicAccessBlockAsyncType = (_ input: S3Model.GetPublicAccessBlockRequest, _ completion: @escaping (HTTPResult<S3Model.GetPublicAccessBlockOutput>) -> ()) throws -> ()
+    typealias HeadBucketSyncType = (_ input: S3Model.HeadBucketRequest) throws -> ()
+    typealias HeadBucketAsyncType = (_ input: S3Model.HeadBucketRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias HeadObjectSyncType = (_ input: S3Model.HeadObjectRequest) throws -> S3Model.HeadObjectOutput
+    typealias HeadObjectAsyncType = (_ input: S3Model.HeadObjectRequest, _ completion: @escaping (HTTPResult<S3Model.HeadObjectOutput>) -> ()) throws -> ()
+    typealias ListBucketAnalyticsConfigurationsSyncType = (_ input: S3Model.ListBucketAnalyticsConfigurationsRequest) throws -> S3Model.ListBucketAnalyticsConfigurationsOutput
+    typealias ListBucketAnalyticsConfigurationsAsyncType = (_ input: S3Model.ListBucketAnalyticsConfigurationsRequest, _ completion: @escaping (HTTPResult<S3Model.ListBucketAnalyticsConfigurationsOutput>) -> ()) throws -> ()
+    typealias ListBucketInventoryConfigurationsSyncType = (_ input: S3Model.ListBucketInventoryConfigurationsRequest) throws -> S3Model.ListBucketInventoryConfigurationsOutput
+    typealias ListBucketInventoryConfigurationsAsyncType = (_ input: S3Model.ListBucketInventoryConfigurationsRequest, _ completion: @escaping (HTTPResult<S3Model.ListBucketInventoryConfigurationsOutput>) -> ()) throws -> ()
+    typealias ListBucketMetricsConfigurationsSyncType = (_ input: S3Model.ListBucketMetricsConfigurationsRequest) throws -> S3Model.ListBucketMetricsConfigurationsOutput
+    typealias ListBucketMetricsConfigurationsAsyncType = (_ input: S3Model.ListBucketMetricsConfigurationsRequest, _ completion: @escaping (HTTPResult<S3Model.ListBucketMetricsConfigurationsOutput>) -> ()) throws -> ()
+    typealias ListBucketsSyncType = () throws -> S3Model.ListBucketsOutput
+    typealias ListBucketsAsyncType = (_ completion: @escaping (HTTPResult<S3Model.ListBucketsOutput>) -> ()) throws -> ()
+    typealias ListMultipartUploadsSyncType = (_ input: S3Model.ListMultipartUploadsRequest) throws -> S3Model.ListMultipartUploadsOutput
+    typealias ListMultipartUploadsAsyncType = (_ input: S3Model.ListMultipartUploadsRequest, _ completion: @escaping (HTTPResult<S3Model.ListMultipartUploadsOutput>) -> ()) throws -> ()
+    typealias ListObjectVersionsSyncType = (_ input: S3Model.ListObjectVersionsRequest) throws -> S3Model.ListObjectVersionsOutput
+    typealias ListObjectVersionsAsyncType = (_ input: S3Model.ListObjectVersionsRequest, _ completion: @escaping (HTTPResult<S3Model.ListObjectVersionsOutput>) -> ()) throws -> ()
+    typealias ListObjectsSyncType = (_ input: S3Model.ListObjectsRequest) throws -> S3Model.ListObjectsOutput
+    typealias ListObjectsAsyncType = (_ input: S3Model.ListObjectsRequest, _ completion: @escaping (HTTPResult<S3Model.ListObjectsOutput>) -> ()) throws -> ()
+    typealias ListObjectsV2SyncType = (_ input: S3Model.ListObjectsV2Request) throws -> S3Model.ListObjectsV2Output
+    typealias ListObjectsV2AsyncType = (_ input: S3Model.ListObjectsV2Request, _ completion: @escaping (HTTPResult<S3Model.ListObjectsV2Output>) -> ()) throws -> ()
+    typealias ListPartsSyncType = (_ input: S3Model.ListPartsRequest) throws -> S3Model.ListPartsOutput
+    typealias ListPartsAsyncType = (_ input: S3Model.ListPartsRequest, _ completion: @escaping (HTTPResult<S3Model.ListPartsOutput>) -> ()) throws -> ()
+    typealias PutBucketAccelerateConfigurationSyncType = (_ input: S3Model.PutBucketAccelerateConfigurationRequest) throws -> ()
+    typealias PutBucketAccelerateConfigurationAsyncType = (_ input: S3Model.PutBucketAccelerateConfigurationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketAclSyncType = (_ input: S3Model.PutBucketAclRequest) throws -> ()
+    typealias PutBucketAclAsyncType = (_ input: S3Model.PutBucketAclRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketAnalyticsConfigurationSyncType = (_ input: S3Model.PutBucketAnalyticsConfigurationRequest) throws -> ()
+    typealias PutBucketAnalyticsConfigurationAsyncType = (_ input: S3Model.PutBucketAnalyticsConfigurationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketCorsSyncType = (_ input: S3Model.PutBucketCorsRequest) throws -> ()
+    typealias PutBucketCorsAsyncType = (_ input: S3Model.PutBucketCorsRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketEncryptionSyncType = (_ input: S3Model.PutBucketEncryptionRequest) throws -> ()
+    typealias PutBucketEncryptionAsyncType = (_ input: S3Model.PutBucketEncryptionRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketInventoryConfigurationSyncType = (_ input: S3Model.PutBucketInventoryConfigurationRequest) throws -> ()
+    typealias PutBucketInventoryConfigurationAsyncType = (_ input: S3Model.PutBucketInventoryConfigurationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketLifecycleSyncType = (_ input: S3Model.PutBucketLifecycleRequest) throws -> ()
+    typealias PutBucketLifecycleAsyncType = (_ input: S3Model.PutBucketLifecycleRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketLifecycleConfigurationSyncType = (_ input: S3Model.PutBucketLifecycleConfigurationRequest) throws -> ()
+    typealias PutBucketLifecycleConfigurationAsyncType = (_ input: S3Model.PutBucketLifecycleConfigurationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketLoggingSyncType = (_ input: S3Model.PutBucketLoggingRequest) throws -> ()
+    typealias PutBucketLoggingAsyncType = (_ input: S3Model.PutBucketLoggingRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketMetricsConfigurationSyncType = (_ input: S3Model.PutBucketMetricsConfigurationRequest) throws -> ()
+    typealias PutBucketMetricsConfigurationAsyncType = (_ input: S3Model.PutBucketMetricsConfigurationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketNotificationSyncType = (_ input: S3Model.PutBucketNotificationRequest) throws -> ()
+    typealias PutBucketNotificationAsyncType = (_ input: S3Model.PutBucketNotificationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketNotificationConfigurationSyncType = (_ input: S3Model.PutBucketNotificationConfigurationRequest) throws -> ()
+    typealias PutBucketNotificationConfigurationAsyncType = (_ input: S3Model.PutBucketNotificationConfigurationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketPolicySyncType = (_ input: S3Model.PutBucketPolicyRequest) throws -> ()
+    typealias PutBucketPolicyAsyncType = (_ input: S3Model.PutBucketPolicyRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketReplicationSyncType = (_ input: S3Model.PutBucketReplicationRequest) throws -> ()
+    typealias PutBucketReplicationAsyncType = (_ input: S3Model.PutBucketReplicationRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketRequestPaymentSyncType = (_ input: S3Model.PutBucketRequestPaymentRequest) throws -> ()
+    typealias PutBucketRequestPaymentAsyncType = (_ input: S3Model.PutBucketRequestPaymentRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketTaggingSyncType = (_ input: S3Model.PutBucketTaggingRequest) throws -> ()
+    typealias PutBucketTaggingAsyncType = (_ input: S3Model.PutBucketTaggingRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketVersioningSyncType = (_ input: S3Model.PutBucketVersioningRequest) throws -> ()
+    typealias PutBucketVersioningAsyncType = (_ input: S3Model.PutBucketVersioningRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutBucketWebsiteSyncType = (_ input: S3Model.PutBucketWebsiteRequest) throws -> ()
+    typealias PutBucketWebsiteAsyncType = (_ input: S3Model.PutBucketWebsiteRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias PutObjectSyncType = (_ input: S3Model.PutObjectRequest) throws -> S3Model.PutObjectOutput
+    typealias PutObjectAsyncType = (_ input: S3Model.PutObjectRequest, _ completion: @escaping (HTTPResult<S3Model.PutObjectOutput>) -> ()) throws -> ()
+    typealias PutObjectAclSyncType = (_ input: S3Model.PutObjectAclRequest) throws -> S3Model.PutObjectAclOutput
+    typealias PutObjectAclAsyncType = (_ input: S3Model.PutObjectAclRequest, _ completion: @escaping (HTTPResult<S3Model.PutObjectAclOutput>) -> ()) throws -> ()
+    typealias PutObjectTaggingSyncType = (_ input: S3Model.PutObjectTaggingRequest) throws -> S3Model.PutObjectTaggingOutput
+    typealias PutObjectTaggingAsyncType = (_ input: S3Model.PutObjectTaggingRequest, _ completion: @escaping (HTTPResult<S3Model.PutObjectTaggingOutput>) -> ()) throws -> ()
+    typealias PutPublicAccessBlockSyncType = (_ input: S3Model.PutPublicAccessBlockRequest) throws -> ()
+    typealias PutPublicAccessBlockAsyncType = (_ input: S3Model.PutPublicAccessBlockRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
+    typealias RestoreObjectSyncType = (_ input: S3Model.RestoreObjectRequest) throws -> S3Model.RestoreObjectOutput
+    typealias RestoreObjectAsyncType = (_ input: S3Model.RestoreObjectRequest, _ completion: @escaping (HTTPResult<S3Model.RestoreObjectOutput>) -> ()) throws -> ()
+    typealias SelectObjectContentSyncType = (_ input: S3Model.SelectObjectContentRequest) throws -> S3Model.SelectObjectContentOutput
+    typealias SelectObjectContentAsyncType = (_ input: S3Model.SelectObjectContentRequest, _ completion: @escaping (HTTPResult<S3Model.SelectObjectContentOutput>) -> ()) throws -> ()
+    typealias UploadPartSyncType = (_ input: S3Model.UploadPartRequest) throws -> S3Model.UploadPartOutput
+    typealias UploadPartAsyncType = (_ input: S3Model.UploadPartRequest, _ completion: @escaping (HTTPResult<S3Model.UploadPartOutput>) -> ()) throws -> ()
+    typealias UploadPartCopySyncType = (_ input: S3Model.UploadPartCopyRequest) throws -> S3Model.UploadPartCopyOutput
+    typealias UploadPartCopyAsyncType = (_ input: S3Model.UploadPartCopyRequest, _ completion: @escaping (HTTPResult<S3Model.UploadPartCopyOutput>) -> ()) throws -> ()
+
+    /**
+     Invokes the AbortMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated AbortMultipartUploadRequest object being passed to this operation.
+         - completion: The AbortMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The AbortMultipartUploadOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchUpload.
+     */
+    func abortMultipartUploadAsync(input: S3Model.AbortMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.AbortMultipartUploadOutput>) -> ()) throws
+
+    /**
+     Invokes the AbortMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated AbortMultipartUploadRequest object being passed to this operation.
+     - Returns: The AbortMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchUpload.
+     */
+    func abortMultipartUploadSync(input: S3Model.AbortMultipartUploadRequest) throws -> S3Model.AbortMultipartUploadOutput
+
+    /**
+     Invokes the CompleteMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CompleteMultipartUploadRequest object being passed to this operation.
+         - completion: The CompleteMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The CompleteMultipartUploadOutput
+           object will be validated before being returned to caller.
+     */
+    func completeMultipartUploadAsync(input: S3Model.CompleteMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.CompleteMultipartUploadOutput>) -> ()) throws
+
+    /**
+     Invokes the CompleteMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CompleteMultipartUploadRequest object being passed to this operation.
+     - Returns: The CompleteMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func completeMultipartUploadSync(input: S3Model.CompleteMultipartUploadRequest) throws -> S3Model.CompleteMultipartUploadOutput
+
+    /**
+     Invokes the CopyObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CopyObjectRequest object being passed to this operation.
+         - completion: The CopyObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The CopyObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: objectNotInActiveTier.
+     */
+    func copyObjectAsync(input: S3Model.CopyObjectRequest, completion: @escaping (HTTPResult<S3Model.CopyObjectOutput>) -> ()) throws
+
+    /**
+     Invokes the CopyObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CopyObjectRequest object being passed to this operation.
+     - Returns: The CopyObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: objectNotInActiveTier.
+     */
+    func copyObjectSync(input: S3Model.CopyObjectRequest) throws -> S3Model.CopyObjectOutput
+
+    /**
+     Invokes the CreateBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CreateBucketRequest object being passed to this operation.
+         - completion: The CreateBucketOutput object or an error will be passed to this 
+           callback when the operation is complete. The CreateBucketOutput
+           object will be validated before being returned to caller.
+           The possible errors are: bucketAlreadyExists, bucketAlreadyOwnedByYou.
+     */
+    func createBucketAsync(input: S3Model.CreateBucketRequest, completion: @escaping (HTTPResult<S3Model.CreateBucketOutput>) -> ()) throws
+
+    /**
+     Invokes the CreateBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CreateBucketRequest object being passed to this operation.
+     - Returns: The CreateBucketOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: bucketAlreadyExists, bucketAlreadyOwnedByYou.
+     */
+    func createBucketSync(input: S3Model.CreateBucketRequest) throws -> S3Model.CreateBucketOutput
+
+    /**
+     Invokes the CreateMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CreateMultipartUploadRequest object being passed to this operation.
+         - completion: The CreateMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The CreateMultipartUploadOutput
+           object will be validated before being returned to caller.
+     */
+    func createMultipartUploadAsync(input: S3Model.CreateMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.CreateMultipartUploadOutput>) -> ()) throws
+
+    /**
+     Invokes the CreateMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CreateMultipartUploadRequest object being passed to this operation.
+     - Returns: The CreateMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func createMultipartUploadSync(input: S3Model.CreateMultipartUploadRequest) throws -> S3Model.CreateMultipartUploadOutput
+
+    /**
+     Invokes the DeleteBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketAsync(input: S3Model.DeleteBucketRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketRequest object being passed to this operation.
+     */
+    func deleteBucketSync(input: S3Model.DeleteBucketRequest) throws
+
+    /**
+     Invokes the DeleteBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketAnalyticsConfigurationAsync(input: S3Model.DeleteBucketAnalyticsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketAnalyticsConfigurationRequest object being passed to this operation.
+     */
+    func deleteBucketAnalyticsConfigurationSync(input: S3Model.DeleteBucketAnalyticsConfigurationRequest) throws
+
+    /**
+     Invokes the DeleteBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketCorsRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketCorsAsync(input: S3Model.DeleteBucketCorsRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketCorsRequest object being passed to this operation.
+     */
+    func deleteBucketCorsSync(input: S3Model.DeleteBucketCorsRequest) throws
+
+    /**
+     Invokes the DeleteBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketEncryptionRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketEncryptionAsync(input: S3Model.DeleteBucketEncryptionRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketEncryptionRequest object being passed to this operation.
+     */
+    func deleteBucketEncryptionSync(input: S3Model.DeleteBucketEncryptionRequest) throws
+
+    /**
+     Invokes the DeleteBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketInventoryConfigurationAsync(input: S3Model.DeleteBucketInventoryConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketInventoryConfigurationRequest object being passed to this operation.
+     */
+    func deleteBucketInventoryConfigurationSync(input: S3Model.DeleteBucketInventoryConfigurationRequest) throws
+
+    /**
+     Invokes the DeleteBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketLifecycleRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketLifecycleAsync(input: S3Model.DeleteBucketLifecycleRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketLifecycleRequest object being passed to this operation.
+     */
+    func deleteBucketLifecycleSync(input: S3Model.DeleteBucketLifecycleRequest) throws
+
+    /**
+     Invokes the DeleteBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketMetricsConfigurationAsync(input: S3Model.DeleteBucketMetricsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketMetricsConfigurationRequest object being passed to this operation.
+     */
+    func deleteBucketMetricsConfigurationSync(input: S3Model.DeleteBucketMetricsConfigurationRequest) throws
+
+    /**
+     Invokes the DeleteBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketPolicyRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketPolicyAsync(input: S3Model.DeleteBucketPolicyRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketPolicyRequest object being passed to this operation.
+     */
+    func deleteBucketPolicySync(input: S3Model.DeleteBucketPolicyRequest) throws
+
+    /**
+     Invokes the DeleteBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketReplicationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketReplicationAsync(input: S3Model.DeleteBucketReplicationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketReplicationRequest object being passed to this operation.
+     */
+    func deleteBucketReplicationSync(input: S3Model.DeleteBucketReplicationRequest) throws
+
+    /**
+     Invokes the DeleteBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketTaggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketTaggingAsync(input: S3Model.DeleteBucketTaggingRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketTaggingRequest object being passed to this operation.
+     */
+    func deleteBucketTaggingSync(input: S3Model.DeleteBucketTaggingRequest) throws
+
+    /**
+     Invokes the DeleteBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketWebsiteRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deleteBucketWebsiteAsync(input: S3Model.DeleteBucketWebsiteRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeleteBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketWebsiteRequest object being passed to this operation.
+     */
+    func deleteBucketWebsiteSync(input: S3Model.DeleteBucketWebsiteRequest) throws
+
+    /**
+     Invokes the DeleteObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectRequest object being passed to this operation.
+         - completion: The DeleteObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectOutput
+           object will be validated before being returned to caller.
+     */
+    func deleteObjectAsync(input: S3Model.DeleteObjectRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectOutput>) -> ()) throws
+
+    /**
+     Invokes the DeleteObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectRequest object being passed to this operation.
+     - Returns: The DeleteObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func deleteObjectSync(input: S3Model.DeleteObjectRequest) throws -> S3Model.DeleteObjectOutput
+
+    /**
+     Invokes the DeleteObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectTaggingRequest object being passed to this operation.
+         - completion: The DeleteObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    func deleteObjectTaggingAsync(input: S3Model.DeleteObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectTaggingOutput>) -> ()) throws
+
+    /**
+     Invokes the DeleteObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectTaggingRequest object being passed to this operation.
+     - Returns: The DeleteObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func deleteObjectTaggingSync(input: S3Model.DeleteObjectTaggingRequest) throws -> S3Model.DeleteObjectTaggingOutput
+
+    /**
+     Invokes the DeleteObjects operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectsRequest object being passed to this operation.
+         - completion: The DeleteObjectsOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectsOutput
+           object will be validated before being returned to caller.
+     */
+    func deleteObjectsAsync(input: S3Model.DeleteObjectsRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectsOutput>) -> ()) throws
+
+    /**
+     Invokes the DeleteObjects operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectsRequest object being passed to this operation.
+     - Returns: The DeleteObjectsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func deleteObjectsSync(input: S3Model.DeleteObjectsRequest) throws -> S3Model.DeleteObjectsOutput
+
+    /**
+     Invokes the DeletePublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeletePublicAccessBlockRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func deletePublicAccessBlockAsync(input: S3Model.DeletePublicAccessBlockRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the DeletePublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeletePublicAccessBlockRequest object being passed to this operation.
+     */
+    func deletePublicAccessBlockSync(input: S3Model.DeletePublicAccessBlockRequest) throws
+
+    /**
+     Invokes the GetBucketAccelerateConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAccelerateConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketAccelerateConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAccelerateConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketAccelerateConfigurationAsync(input: S3Model.GetBucketAccelerateConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAccelerateConfigurationOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketAccelerateConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAccelerateConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketAccelerateConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketAccelerateConfigurationSync(input: S3Model.GetBucketAccelerateConfigurationRequest) throws -> S3Model.GetBucketAccelerateConfigurationOutput
+
+    /**
+     Invokes the GetBucketAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAclRequest object being passed to this operation.
+         - completion: The GetBucketAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAclOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketAclAsync(input: S3Model.GetBucketAclRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAclOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAclRequest object being passed to this operation.
+     - Returns: The GetBucketAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketAclSync(input: S3Model.GetBucketAclRequest) throws -> S3Model.GetBucketAclOutput
+
+    /**
+     Invokes the GetBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketAnalyticsConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAnalyticsConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketAnalyticsConfigurationAsync(input: S3Model.GetBucketAnalyticsConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAnalyticsConfigurationOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAnalyticsConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketAnalyticsConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketAnalyticsConfigurationSync(input: S3Model.GetBucketAnalyticsConfigurationRequest) throws -> S3Model.GetBucketAnalyticsConfigurationOutput
+
+    /**
+     Invokes the GetBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketCorsRequest object being passed to this operation.
+         - completion: The GetBucketCorsOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketCorsOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketCorsAsync(input: S3Model.GetBucketCorsRequest, completion: @escaping (HTTPResult<S3Model.GetBucketCorsOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketCorsRequest object being passed to this operation.
+     - Returns: The GetBucketCorsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketCorsSync(input: S3Model.GetBucketCorsRequest) throws -> S3Model.GetBucketCorsOutput
+
+    /**
+     Invokes the GetBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketEncryptionRequest object being passed to this operation.
+         - completion: The GetBucketEncryptionOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketEncryptionOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketEncryptionAsync(input: S3Model.GetBucketEncryptionRequest, completion: @escaping (HTTPResult<S3Model.GetBucketEncryptionOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketEncryptionRequest object being passed to this operation.
+     - Returns: The GetBucketEncryptionOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketEncryptionSync(input: S3Model.GetBucketEncryptionRequest) throws -> S3Model.GetBucketEncryptionOutput
+
+    /**
+     Invokes the GetBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketInventoryConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketInventoryConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketInventoryConfigurationAsync(input: S3Model.GetBucketInventoryConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketInventoryConfigurationOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketInventoryConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketInventoryConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketInventoryConfigurationSync(input: S3Model.GetBucketInventoryConfigurationRequest) throws -> S3Model.GetBucketInventoryConfigurationOutput
+
+    /**
+     Invokes the GetBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleRequest object being passed to this operation.
+         - completion: The GetBucketLifecycleOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLifecycleOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketLifecycleAsync(input: S3Model.GetBucketLifecycleRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLifecycleOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleRequest object being passed to this operation.
+     - Returns: The GetBucketLifecycleOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketLifecycleSync(input: S3Model.GetBucketLifecycleRequest) throws -> S3Model.GetBucketLifecycleOutput
+
+    /**
+     Invokes the GetBucketLifecycleConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketLifecycleConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLifecycleConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketLifecycleConfigurationAsync(input: S3Model.GetBucketLifecycleConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLifecycleConfigurationOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketLifecycleConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketLifecycleConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketLifecycleConfigurationSync(input: S3Model.GetBucketLifecycleConfigurationRequest) throws -> S3Model.GetBucketLifecycleConfigurationOutput
+
+    /**
+     Invokes the GetBucketLocation operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLocationRequest object being passed to this operation.
+         - completion: The GetBucketLocationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLocationOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketLocationAsync(input: S3Model.GetBucketLocationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLocationOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketLocation operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLocationRequest object being passed to this operation.
+     - Returns: The GetBucketLocationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketLocationSync(input: S3Model.GetBucketLocationRequest) throws -> S3Model.GetBucketLocationOutput
+
+    /**
+     Invokes the GetBucketLogging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLoggingRequest object being passed to this operation.
+         - completion: The GetBucketLoggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLoggingOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketLoggingAsync(input: S3Model.GetBucketLoggingRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLoggingOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketLogging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLoggingRequest object being passed to this operation.
+     - Returns: The GetBucketLoggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketLoggingSync(input: S3Model.GetBucketLoggingRequest) throws -> S3Model.GetBucketLoggingOutput
+
+    /**
+     Invokes the GetBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketMetricsConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketMetricsConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketMetricsConfigurationAsync(input: S3Model.GetBucketMetricsConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketMetricsConfigurationOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketMetricsConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketMetricsConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketMetricsConfigurationSync(input: S3Model.GetBucketMetricsConfigurationRequest) throws -> S3Model.GetBucketMetricsConfigurationOutput
+
+    /**
+     Invokes the GetBucketNotification operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: The NotificationConfigurationDeprecated object or an error will be passed to this 
+           callback when the operation is complete. The NotificationConfigurationDeprecated
+           object will be validated before being returned to caller.
+     */
+    func getBucketNotificationAsync(input: S3Model.GetBucketNotificationConfigurationRequest, completion: @escaping (HTTPResult<S3Model.NotificationConfigurationDeprecated>) -> ()) throws
+
+    /**
+     Invokes the GetBucketNotification operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+     - Returns: The NotificationConfigurationDeprecated object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketNotificationSync(input: S3Model.GetBucketNotificationConfigurationRequest) throws -> S3Model.NotificationConfigurationDeprecated
+
+    /**
+     Invokes the GetBucketNotificationConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: The NotificationConfiguration object or an error will be passed to this 
+           callback when the operation is complete. The NotificationConfiguration
+           object will be validated before being returned to caller.
+     */
+    func getBucketNotificationConfigurationAsync(input: S3Model.GetBucketNotificationConfigurationRequest, completion: @escaping (HTTPResult<S3Model.NotificationConfiguration>) -> ()) throws
+
+    /**
+     Invokes the GetBucketNotificationConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+     - Returns: The NotificationConfiguration object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketNotificationConfigurationSync(input: S3Model.GetBucketNotificationConfigurationRequest) throws -> S3Model.NotificationConfiguration
+
+    /**
+     Invokes the GetBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyRequest object being passed to this operation.
+         - completion: The GetBucketPolicyOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketPolicyOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketPolicyAsync(input: S3Model.GetBucketPolicyRequest, completion: @escaping (HTTPResult<S3Model.GetBucketPolicyOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyRequest object being passed to this operation.
+     - Returns: The GetBucketPolicyOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketPolicySync(input: S3Model.GetBucketPolicyRequest) throws -> S3Model.GetBucketPolicyOutput
+
+    /**
+     Invokes the GetBucketPolicyStatus operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyStatusRequest object being passed to this operation.
+         - completion: The GetBucketPolicyStatusOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketPolicyStatusOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketPolicyStatusAsync(input: S3Model.GetBucketPolicyStatusRequest, completion: @escaping (HTTPResult<S3Model.GetBucketPolicyStatusOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketPolicyStatus operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyStatusRequest object being passed to this operation.
+     - Returns: The GetBucketPolicyStatusOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketPolicyStatusSync(input: S3Model.GetBucketPolicyStatusRequest) throws -> S3Model.GetBucketPolicyStatusOutput
+
+    /**
+     Invokes the GetBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketReplicationRequest object being passed to this operation.
+         - completion: The GetBucketReplicationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketReplicationOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketReplicationAsync(input: S3Model.GetBucketReplicationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketReplicationOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketReplicationRequest object being passed to this operation.
+     - Returns: The GetBucketReplicationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketReplicationSync(input: S3Model.GetBucketReplicationRequest) throws -> S3Model.GetBucketReplicationOutput
+
+    /**
+     Invokes the GetBucketRequestPayment operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketRequestPaymentRequest object being passed to this operation.
+         - completion: The GetBucketRequestPaymentOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketRequestPaymentOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketRequestPaymentAsync(input: S3Model.GetBucketRequestPaymentRequest, completion: @escaping (HTTPResult<S3Model.GetBucketRequestPaymentOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketRequestPayment operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketRequestPaymentRequest object being passed to this operation.
+     - Returns: The GetBucketRequestPaymentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketRequestPaymentSync(input: S3Model.GetBucketRequestPaymentRequest) throws -> S3Model.GetBucketRequestPaymentOutput
+
+    /**
+     Invokes the GetBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketTaggingRequest object being passed to this operation.
+         - completion: The GetBucketTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketTaggingAsync(input: S3Model.GetBucketTaggingRequest, completion: @escaping (HTTPResult<S3Model.GetBucketTaggingOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketTaggingRequest object being passed to this operation.
+     - Returns: The GetBucketTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketTaggingSync(input: S3Model.GetBucketTaggingRequest) throws -> S3Model.GetBucketTaggingOutput
+
+    /**
+     Invokes the GetBucketVersioning operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketVersioningRequest object being passed to this operation.
+         - completion: The GetBucketVersioningOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketVersioningOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketVersioningAsync(input: S3Model.GetBucketVersioningRequest, completion: @escaping (HTTPResult<S3Model.GetBucketVersioningOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketVersioning operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketVersioningRequest object being passed to this operation.
+     - Returns: The GetBucketVersioningOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketVersioningSync(input: S3Model.GetBucketVersioningRequest) throws -> S3Model.GetBucketVersioningOutput
+
+    /**
+     Invokes the GetBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketWebsiteRequest object being passed to this operation.
+         - completion: The GetBucketWebsiteOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketWebsiteOutput
+           object will be validated before being returned to caller.
+     */
+    func getBucketWebsiteAsync(input: S3Model.GetBucketWebsiteRequest, completion: @escaping (HTTPResult<S3Model.GetBucketWebsiteOutput>) -> ()) throws
+
+    /**
+     Invokes the GetBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketWebsiteRequest object being passed to this operation.
+     - Returns: The GetBucketWebsiteOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getBucketWebsiteSync(input: S3Model.GetBucketWebsiteRequest) throws -> S3Model.GetBucketWebsiteOutput
+
+    /**
+     Invokes the GetObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectRequest object being passed to this operation.
+         - completion: The GetObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    func getObjectAsync(input: S3Model.GetObjectRequest, completion: @escaping (HTTPResult<S3Model.GetObjectOutput>) -> ()) throws
+
+    /**
+     Invokes the GetObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectRequest object being passed to this operation.
+     - Returns: The GetObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    func getObjectSync(input: S3Model.GetObjectRequest) throws -> S3Model.GetObjectOutput
+
+    /**
+     Invokes the GetObjectAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectAclRequest object being passed to this operation.
+         - completion: The GetObjectAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectAclOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    func getObjectAclAsync(input: S3Model.GetObjectAclRequest, completion: @escaping (HTTPResult<S3Model.GetObjectAclOutput>) -> ()) throws
+
+    /**
+     Invokes the GetObjectAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectAclRequest object being passed to this operation.
+     - Returns: The GetObjectAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    func getObjectAclSync(input: S3Model.GetObjectAclRequest) throws -> S3Model.GetObjectAclOutput
+
+    /**
+     Invokes the GetObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectTaggingRequest object being passed to this operation.
+         - completion: The GetObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    func getObjectTaggingAsync(input: S3Model.GetObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.GetObjectTaggingOutput>) -> ()) throws
+
+    /**
+     Invokes the GetObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectTaggingRequest object being passed to this operation.
+     - Returns: The GetObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getObjectTaggingSync(input: S3Model.GetObjectTaggingRequest) throws -> S3Model.GetObjectTaggingOutput
+
+    /**
+     Invokes the GetObjectTorrent operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectTorrentRequest object being passed to this operation.
+         - completion: The GetObjectTorrentOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectTorrentOutput
+           object will be validated before being returned to caller.
+     */
+    func getObjectTorrentAsync(input: S3Model.GetObjectTorrentRequest, completion: @escaping (HTTPResult<S3Model.GetObjectTorrentOutput>) -> ()) throws
+
+    /**
+     Invokes the GetObjectTorrent operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectTorrentRequest object being passed to this operation.
+     - Returns: The GetObjectTorrentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getObjectTorrentSync(input: S3Model.GetObjectTorrentRequest) throws -> S3Model.GetObjectTorrentOutput
+
+    /**
+     Invokes the GetPublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetPublicAccessBlockRequest object being passed to this operation.
+         - completion: The GetPublicAccessBlockOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetPublicAccessBlockOutput
+           object will be validated before being returned to caller.
+     */
+    func getPublicAccessBlockAsync(input: S3Model.GetPublicAccessBlockRequest, completion: @escaping (HTTPResult<S3Model.GetPublicAccessBlockOutput>) -> ()) throws
+
+    /**
+     Invokes the GetPublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetPublicAccessBlockRequest object being passed to this operation.
+     - Returns: The GetPublicAccessBlockOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func getPublicAccessBlockSync(input: S3Model.GetPublicAccessBlockRequest) throws -> S3Model.GetPublicAccessBlockOutput
+
+    /**
+     Invokes the HeadBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated HeadBucketRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+           The possible errors are: noSuchBucket.
+     */
+    func headBucketAsync(input: S3Model.HeadBucketRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the HeadBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated HeadBucketRequest object being passed to this operation.
+     - Throws: noSuchBucket.
+     */
+    func headBucketSync(input: S3Model.HeadBucketRequest) throws
+
+    /**
+     Invokes the HeadObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated HeadObjectRequest object being passed to this operation.
+         - completion: The HeadObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The HeadObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    func headObjectAsync(input: S3Model.HeadObjectRequest, completion: @escaping (HTTPResult<S3Model.HeadObjectOutput>) -> ()) throws
+
+    /**
+     Invokes the HeadObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated HeadObjectRequest object being passed to this operation.
+     - Returns: The HeadObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    func headObjectSync(input: S3Model.HeadObjectRequest) throws -> S3Model.HeadObjectOutput
+
+    /**
+     Invokes the ListBucketAnalyticsConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketAnalyticsConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketAnalyticsConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketAnalyticsConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    func listBucketAnalyticsConfigurationsAsync(input: S3Model.ListBucketAnalyticsConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketAnalyticsConfigurationsOutput>) -> ()) throws
+
+    /**
+     Invokes the ListBucketAnalyticsConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketAnalyticsConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketAnalyticsConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func listBucketAnalyticsConfigurationsSync(input: S3Model.ListBucketAnalyticsConfigurationsRequest) throws -> S3Model.ListBucketAnalyticsConfigurationsOutput
+
+    /**
+     Invokes the ListBucketInventoryConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketInventoryConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketInventoryConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketInventoryConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    func listBucketInventoryConfigurationsAsync(input: S3Model.ListBucketInventoryConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketInventoryConfigurationsOutput>) -> ()) throws
+
+    /**
+     Invokes the ListBucketInventoryConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketInventoryConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketInventoryConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func listBucketInventoryConfigurationsSync(input: S3Model.ListBucketInventoryConfigurationsRequest) throws -> S3Model.ListBucketInventoryConfigurationsOutput
+
+    /**
+     Invokes the ListBucketMetricsConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketMetricsConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketMetricsConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketMetricsConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    func listBucketMetricsConfigurationsAsync(input: S3Model.ListBucketMetricsConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketMetricsConfigurationsOutput>) -> ()) throws
+
+    /**
+     Invokes the ListBucketMetricsConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketMetricsConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketMetricsConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func listBucketMetricsConfigurationsSync(input: S3Model.ListBucketMetricsConfigurationsRequest) throws -> S3Model.ListBucketMetricsConfigurationsOutput
+
+    /**
+     Invokes the ListBuckets operation returning immediately and passing the response to a callback.
+         - completion: The ListBucketsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketsOutput
+           object will be validated before being returned to caller.
+     */
+    func listBucketsAsync(completion: @escaping (HTTPResult<S3Model.ListBucketsOutput>) -> ()) throws
+
+    /**
+     Invokes the ListBuckets operation waiting for the response before returning.
+     - Returns: The ListBucketsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func listBucketsSync() throws -> S3Model.ListBucketsOutput
+
+    /**
+     Invokes the ListMultipartUploads operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListMultipartUploadsRequest object being passed to this operation.
+         - completion: The ListMultipartUploadsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListMultipartUploadsOutput
+           object will be validated before being returned to caller.
+     */
+    func listMultipartUploadsAsync(input: S3Model.ListMultipartUploadsRequest, completion: @escaping (HTTPResult<S3Model.ListMultipartUploadsOutput>) -> ()) throws
+
+    /**
+     Invokes the ListMultipartUploads operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListMultipartUploadsRequest object being passed to this operation.
+     - Returns: The ListMultipartUploadsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func listMultipartUploadsSync(input: S3Model.ListMultipartUploadsRequest) throws -> S3Model.ListMultipartUploadsOutput
+
+    /**
+     Invokes the ListObjectVersions operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectVersionsRequest object being passed to this operation.
+         - completion: The ListObjectVersionsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectVersionsOutput
+           object will be validated before being returned to caller.
+     */
+    func listObjectVersionsAsync(input: S3Model.ListObjectVersionsRequest, completion: @escaping (HTTPResult<S3Model.ListObjectVersionsOutput>) -> ()) throws
+
+    /**
+     Invokes the ListObjectVersions operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectVersionsRequest object being passed to this operation.
+     - Returns: The ListObjectVersionsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func listObjectVersionsSync(input: S3Model.ListObjectVersionsRequest) throws -> S3Model.ListObjectVersionsOutput
+
+    /**
+     Invokes the ListObjects operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectsRequest object being passed to this operation.
+         - completion: The ListObjectsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectsOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchBucket.
+     */
+    func listObjectsAsync(input: S3Model.ListObjectsRequest, completion: @escaping (HTTPResult<S3Model.ListObjectsOutput>) -> ()) throws
+
+    /**
+     Invokes the ListObjects operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectsRequest object being passed to this operation.
+     - Returns: The ListObjectsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchBucket.
+     */
+    func listObjectsSync(input: S3Model.ListObjectsRequest) throws -> S3Model.ListObjectsOutput
+
+    /**
+     Invokes the ListObjectsV2 operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectsV2Request object being passed to this operation.
+         - completion: The ListObjectsV2Output object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectsV2Output
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchBucket.
+     */
+    func listObjectsV2Async(input: S3Model.ListObjectsV2Request, completion: @escaping (HTTPResult<S3Model.ListObjectsV2Output>) -> ()) throws
+
+    /**
+     Invokes the ListObjectsV2 operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectsV2Request object being passed to this operation.
+     - Returns: The ListObjectsV2Output object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchBucket.
+     */
+    func listObjectsV2Sync(input: S3Model.ListObjectsV2Request) throws -> S3Model.ListObjectsV2Output
+
+    /**
+     Invokes the ListParts operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListPartsRequest object being passed to this operation.
+         - completion: The ListPartsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListPartsOutput
+           object will be validated before being returned to caller.
+     */
+    func listPartsAsync(input: S3Model.ListPartsRequest, completion: @escaping (HTTPResult<S3Model.ListPartsOutput>) -> ()) throws
+
+    /**
+     Invokes the ListParts operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListPartsRequest object being passed to this operation.
+     - Returns: The ListPartsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func listPartsSync(input: S3Model.ListPartsRequest) throws -> S3Model.ListPartsOutput
+
+    /**
+     Invokes the PutBucketAccelerateConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAccelerateConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketAccelerateConfigurationAsync(input: S3Model.PutBucketAccelerateConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketAccelerateConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAccelerateConfigurationRequest object being passed to this operation.
+     */
+    func putBucketAccelerateConfigurationSync(input: S3Model.PutBucketAccelerateConfigurationRequest) throws
+
+    /**
+     Invokes the PutBucketAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAclRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketAclAsync(input: S3Model.PutBucketAclRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAclRequest object being passed to this operation.
+     */
+    func putBucketAclSync(input: S3Model.PutBucketAclRequest) throws
+
+    /**
+     Invokes the PutBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketAnalyticsConfigurationAsync(input: S3Model.PutBucketAnalyticsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAnalyticsConfigurationRequest object being passed to this operation.
+     */
+    func putBucketAnalyticsConfigurationSync(input: S3Model.PutBucketAnalyticsConfigurationRequest) throws
+
+    /**
+     Invokes the PutBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketCorsRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketCorsAsync(input: S3Model.PutBucketCorsRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketCorsRequest object being passed to this operation.
+     */
+    func putBucketCorsSync(input: S3Model.PutBucketCorsRequest) throws
+
+    /**
+     Invokes the PutBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketEncryptionRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketEncryptionAsync(input: S3Model.PutBucketEncryptionRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketEncryptionRequest object being passed to this operation.
+     */
+    func putBucketEncryptionSync(input: S3Model.PutBucketEncryptionRequest) throws
+
+    /**
+     Invokes the PutBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketInventoryConfigurationAsync(input: S3Model.PutBucketInventoryConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketInventoryConfigurationRequest object being passed to this operation.
+     */
+    func putBucketInventoryConfigurationSync(input: S3Model.PutBucketInventoryConfigurationRequest) throws
+
+    /**
+     Invokes the PutBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketLifecycleAsync(input: S3Model.PutBucketLifecycleRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleRequest object being passed to this operation.
+     */
+    func putBucketLifecycleSync(input: S3Model.PutBucketLifecycleRequest) throws
+
+    /**
+     Invokes the PutBucketLifecycleConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketLifecycleConfigurationAsync(input: S3Model.PutBucketLifecycleConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketLifecycleConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleConfigurationRequest object being passed to this operation.
+     */
+    func putBucketLifecycleConfigurationSync(input: S3Model.PutBucketLifecycleConfigurationRequest) throws
+
+    /**
+     Invokes the PutBucketLogging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLoggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketLoggingAsync(input: S3Model.PutBucketLoggingRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketLogging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLoggingRequest object being passed to this operation.
+     */
+    func putBucketLoggingSync(input: S3Model.PutBucketLoggingRequest) throws
+
+    /**
+     Invokes the PutBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketMetricsConfigurationAsync(input: S3Model.PutBucketMetricsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketMetricsConfigurationRequest object being passed to this operation.
+     */
+    func putBucketMetricsConfigurationSync(input: S3Model.PutBucketMetricsConfigurationRequest) throws
+
+    /**
+     Invokes the PutBucketNotification operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketNotificationAsync(input: S3Model.PutBucketNotificationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketNotification operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationRequest object being passed to this operation.
+     */
+    func putBucketNotificationSync(input: S3Model.PutBucketNotificationRequest) throws
+
+    /**
+     Invokes the PutBucketNotificationConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketNotificationConfigurationAsync(input: S3Model.PutBucketNotificationConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketNotificationConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationConfigurationRequest object being passed to this operation.
+     */
+    func putBucketNotificationConfigurationSync(input: S3Model.PutBucketNotificationConfigurationRequest) throws
+
+    /**
+     Invokes the PutBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketPolicyRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketPolicyAsync(input: S3Model.PutBucketPolicyRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketPolicyRequest object being passed to this operation.
+     */
+    func putBucketPolicySync(input: S3Model.PutBucketPolicyRequest) throws
+
+    /**
+     Invokes the PutBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketReplicationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketReplicationAsync(input: S3Model.PutBucketReplicationRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketReplicationRequest object being passed to this operation.
+     */
+    func putBucketReplicationSync(input: S3Model.PutBucketReplicationRequest) throws
+
+    /**
+     Invokes the PutBucketRequestPayment operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketRequestPaymentRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketRequestPaymentAsync(input: S3Model.PutBucketRequestPaymentRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketRequestPayment operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketRequestPaymentRequest object being passed to this operation.
+     */
+    func putBucketRequestPaymentSync(input: S3Model.PutBucketRequestPaymentRequest) throws
+
+    /**
+     Invokes the PutBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketTaggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketTaggingAsync(input: S3Model.PutBucketTaggingRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketTaggingRequest object being passed to this operation.
+     */
+    func putBucketTaggingSync(input: S3Model.PutBucketTaggingRequest) throws
+
+    /**
+     Invokes the PutBucketVersioning operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketVersioningRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketVersioningAsync(input: S3Model.PutBucketVersioningRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketVersioning operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketVersioningRequest object being passed to this operation.
+     */
+    func putBucketVersioningSync(input: S3Model.PutBucketVersioningRequest) throws
+
+    /**
+     Invokes the PutBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketWebsiteRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putBucketWebsiteAsync(input: S3Model.PutBucketWebsiteRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketWebsiteRequest object being passed to this operation.
+     */
+    func putBucketWebsiteSync(input: S3Model.PutBucketWebsiteRequest) throws
+
+    /**
+     Invokes the PutObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectRequest object being passed to this operation.
+         - completion: The PutObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectOutput
+           object will be validated before being returned to caller.
+     */
+    func putObjectAsync(input: S3Model.PutObjectRequest, completion: @escaping (HTTPResult<S3Model.PutObjectOutput>) -> ()) throws
+
+    /**
+     Invokes the PutObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectRequest object being passed to this operation.
+     - Returns: The PutObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func putObjectSync(input: S3Model.PutObjectRequest) throws -> S3Model.PutObjectOutput
+
+    /**
+     Invokes the PutObjectAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectAclRequest object being passed to this operation.
+         - completion: The PutObjectAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectAclOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    func putObjectAclAsync(input: S3Model.PutObjectAclRequest, completion: @escaping (HTTPResult<S3Model.PutObjectAclOutput>) -> ()) throws
+
+    /**
+     Invokes the PutObjectAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectAclRequest object being passed to this operation.
+     - Returns: The PutObjectAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    func putObjectAclSync(input: S3Model.PutObjectAclRequest) throws -> S3Model.PutObjectAclOutput
+
+    /**
+     Invokes the PutObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectTaggingRequest object being passed to this operation.
+         - completion: The PutObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    func putObjectTaggingAsync(input: S3Model.PutObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.PutObjectTaggingOutput>) -> ()) throws
+
+    /**
+     Invokes the PutObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectTaggingRequest object being passed to this operation.
+     - Returns: The PutObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func putObjectTaggingSync(input: S3Model.PutObjectTaggingRequest) throws -> S3Model.PutObjectTaggingOutput
+
+    /**
+     Invokes the PutPublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutPublicAccessBlockRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    func putPublicAccessBlockAsync(input: S3Model.PutPublicAccessBlockRequest, completion: @escaping (Swift.Error?) -> ()) throws
+
+    /**
+     Invokes the PutPublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutPublicAccessBlockRequest object being passed to this operation.
+     */
+    func putPublicAccessBlockSync(input: S3Model.PutPublicAccessBlockRequest) throws
+
+    /**
+     Invokes the RestoreObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated RestoreObjectRequest object being passed to this operation.
+         - completion: The RestoreObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The RestoreObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: objectAlreadyInActiveTier.
+     */
+    func restoreObjectAsync(input: S3Model.RestoreObjectRequest, completion: @escaping (HTTPResult<S3Model.RestoreObjectOutput>) -> ()) throws
+
+    /**
+     Invokes the RestoreObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated RestoreObjectRequest object being passed to this operation.
+     - Returns: The RestoreObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: objectAlreadyInActiveTier.
+     */
+    func restoreObjectSync(input: S3Model.RestoreObjectRequest) throws -> S3Model.RestoreObjectOutput
+
+    /**
+     Invokes the SelectObjectContent operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated SelectObjectContentRequest object being passed to this operation.
+         - completion: The SelectObjectContentOutput object or an error will be passed to this 
+           callback when the operation is complete. The SelectObjectContentOutput
+           object will be validated before being returned to caller.
+     */
+    func selectObjectContentAsync(input: S3Model.SelectObjectContentRequest, completion: @escaping (HTTPResult<S3Model.SelectObjectContentOutput>) -> ()) throws
+
+    /**
+     Invokes the SelectObjectContent operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated SelectObjectContentRequest object being passed to this operation.
+     - Returns: The SelectObjectContentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func selectObjectContentSync(input: S3Model.SelectObjectContentRequest) throws -> S3Model.SelectObjectContentOutput
+
+    /**
+     Invokes the UploadPart operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated UploadPartRequest object being passed to this operation.
+         - completion: The UploadPartOutput object or an error will be passed to this 
+           callback when the operation is complete. The UploadPartOutput
+           object will be validated before being returned to caller.
+     */
+    func uploadPartAsync(input: S3Model.UploadPartRequest, completion: @escaping (HTTPResult<S3Model.UploadPartOutput>) -> ()) throws
+
+    /**
+     Invokes the UploadPart operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated UploadPartRequest object being passed to this operation.
+     - Returns: The UploadPartOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func uploadPartSync(input: S3Model.UploadPartRequest) throws -> S3Model.UploadPartOutput
+
+    /**
+     Invokes the UploadPartCopy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated UploadPartCopyRequest object being passed to this operation.
+         - completion: The UploadPartCopyOutput object or an error will be passed to this 
+           callback when the operation is complete. The UploadPartCopyOutput
+           object will be validated before being returned to caller.
+     */
+    func uploadPartCopyAsync(input: S3Model.UploadPartCopyRequest, completion: @escaping (HTTPResult<S3Model.UploadPartCopyOutput>) -> ()) throws
+
+    /**
+     Invokes the UploadPartCopy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated UploadPartCopyRequest object being passed to this operation.
+     - Returns: The UploadPartCopyOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    func uploadPartCopySync(input: S3Model.UploadPartCopyRequest) throws -> S3Model.UploadPartCopyOutput
+}

--- a/Sources/S3Client/S3OperationsClientInput.swift
+++ b/Sources/S3Client/S3OperationsClientInput.swift
@@ -1,0 +1,1483 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// S3OperationsClientInput.swift
+// S3Client
+//
+
+import Foundation
+import SmokeHTTPClient
+import S3Model
+
+/**
+ Type to handle the input to the AbortMultipartUpload operation in a HTTP client.
+ */
+public struct AbortMultipartUploadOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: AbortMultipartUploadOperationInputQuery?
+    public let pathEncodable: AbortMultipartUploadOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: AbortMultipartUploadOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: AbortMultipartUploadRequest) {
+        self.queryEncodable = encodable.asS3ModelAbortMultipartUploadOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelAbortMultipartUploadOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelAbortMultipartUploadOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the CompleteMultipartUpload operation in a HTTP client.
+ */
+public struct CompleteMultipartUploadOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: CompleteMultipartUploadOperationInputQuery?
+    public let pathEncodable: CompleteMultipartUploadOperationInputPath?
+    public let bodyEncodable: CompletedMultipartUpload?
+    public let additionalHeadersEncodable: CompleteMultipartUploadOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: CompleteMultipartUploadRequest) {
+        self.queryEncodable = encodable.asS3ModelCompleteMultipartUploadOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelCompleteMultipartUploadOperationInputPath()
+        self.bodyEncodable = encodable.multipartUpload
+        self.additionalHeadersEncodable = encodable.asS3ModelCompleteMultipartUploadOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the CopyObject operation in a HTTP client.
+ */
+public struct CopyObjectOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: CopyObjectOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: CopyObjectOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: CopyObjectRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelCopyObjectOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelCopyObjectOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the CreateBucket operation in a HTTP client.
+ */
+public struct CreateBucketOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: CreateBucketOperationInputPath?
+    public let bodyEncodable: CreateBucketConfiguration?
+    public let additionalHeadersEncodable: CreateBucketOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: CreateBucketRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelCreateBucketOperationInputPath()
+        self.bodyEncodable = encodable.createBucketConfiguration
+        self.additionalHeadersEncodable = encodable.asS3ModelCreateBucketOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the CreateMultipartUpload operation in a HTTP client.
+ */
+public struct CreateMultipartUploadOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: CreateMultipartUploadOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: CreateMultipartUploadOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: CreateMultipartUploadRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelCreateMultipartUploadOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelCreateMultipartUploadOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucket operation in a HTTP client.
+ */
+public struct DeleteBucketOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: DeleteBucketOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelDeleteBucketOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucketAnalyticsConfiguration operation in a HTTP client.
+ */
+public struct DeleteBucketAnalyticsConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: DeleteBucketAnalyticsConfigurationOperationInputQuery?
+    public let pathEncodable: DeleteBucketAnalyticsConfigurationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketAnalyticsConfigurationRequest) {
+        self.queryEncodable = encodable.asS3ModelDeleteBucketAnalyticsConfigurationOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelDeleteBucketAnalyticsConfigurationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucketCors operation in a HTTP client.
+ */
+public struct DeleteBucketCorsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: DeleteBucketCorsOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketCorsRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelDeleteBucketCorsOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucketEncryption operation in a HTTP client.
+ */
+public struct DeleteBucketEncryptionOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: DeleteBucketEncryptionOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketEncryptionRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelDeleteBucketEncryptionOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucketInventoryConfiguration operation in a HTTP client.
+ */
+public struct DeleteBucketInventoryConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: DeleteBucketInventoryConfigurationOperationInputQuery?
+    public let pathEncodable: DeleteBucketInventoryConfigurationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketInventoryConfigurationRequest) {
+        self.queryEncodable = encodable.asS3ModelDeleteBucketInventoryConfigurationOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelDeleteBucketInventoryConfigurationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucketLifecycle operation in a HTTP client.
+ */
+public struct DeleteBucketLifecycleOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: DeleteBucketLifecycleOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketLifecycleRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelDeleteBucketLifecycleOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucketMetricsConfiguration operation in a HTTP client.
+ */
+public struct DeleteBucketMetricsConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: DeleteBucketMetricsConfigurationOperationInputQuery?
+    public let pathEncodable: DeleteBucketMetricsConfigurationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketMetricsConfigurationRequest) {
+        self.queryEncodable = encodable.asS3ModelDeleteBucketMetricsConfigurationOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelDeleteBucketMetricsConfigurationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucketPolicy operation in a HTTP client.
+ */
+public struct DeleteBucketPolicyOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: DeleteBucketPolicyOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketPolicyRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelDeleteBucketPolicyOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucketReplication operation in a HTTP client.
+ */
+public struct DeleteBucketReplicationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: DeleteBucketReplicationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketReplicationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelDeleteBucketReplicationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucketTagging operation in a HTTP client.
+ */
+public struct DeleteBucketTaggingOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: DeleteBucketTaggingOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketTaggingRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelDeleteBucketTaggingOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteBucketWebsite operation in a HTTP client.
+ */
+public struct DeleteBucketWebsiteOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: DeleteBucketWebsiteOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteBucketWebsiteRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelDeleteBucketWebsiteOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteObject operation in a HTTP client.
+ */
+public struct DeleteObjectOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: DeleteObjectOperationInputQuery?
+    public let pathEncodable: DeleteObjectOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: DeleteObjectOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteObjectRequest) {
+        self.queryEncodable = encodable.asS3ModelDeleteObjectOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelDeleteObjectOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelDeleteObjectOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteObjectTagging operation in a HTTP client.
+ */
+public struct DeleteObjectTaggingOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: DeleteObjectTaggingOperationInputQuery?
+    public let pathEncodable: DeleteObjectTaggingOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteObjectTaggingRequest) {
+        self.queryEncodable = encodable.asS3ModelDeleteObjectTaggingOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelDeleteObjectTaggingOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeleteObjects operation in a HTTP client.
+ */
+public struct DeleteObjectsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: DeleteObjectsOperationInputPath?
+    public let bodyEncodable: Delete?
+    public let additionalHeadersEncodable: DeleteObjectsOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: DeleteObjectsRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelDeleteObjectsOperationInputPath()
+        self.bodyEncodable = encodable.delete
+        self.additionalHeadersEncodable = encodable.asS3ModelDeleteObjectsOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the DeletePublicAccessBlock operation in a HTTP client.
+ */
+public struct DeletePublicAccessBlockOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: DeletePublicAccessBlockOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: DeletePublicAccessBlockRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelDeletePublicAccessBlockOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketAccelerateConfiguration operation in a HTTP client.
+ */
+public struct GetBucketAccelerateConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketAccelerateConfigurationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketAccelerateConfigurationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketAccelerateConfigurationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketAcl operation in a HTTP client.
+ */
+public struct GetBucketAclOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketAclOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketAclRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketAclOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketAnalyticsConfiguration operation in a HTTP client.
+ */
+public struct GetBucketAnalyticsConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: GetBucketAnalyticsConfigurationOperationInputQuery?
+    public let pathEncodable: GetBucketAnalyticsConfigurationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketAnalyticsConfigurationRequest) {
+        self.queryEncodable = encodable.asS3ModelGetBucketAnalyticsConfigurationOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelGetBucketAnalyticsConfigurationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketCors operation in a HTTP client.
+ */
+public struct GetBucketCorsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketCorsOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketCorsRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketCorsOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketEncryption operation in a HTTP client.
+ */
+public struct GetBucketEncryptionOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketEncryptionOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketEncryptionRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketEncryptionOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketInventoryConfiguration operation in a HTTP client.
+ */
+public struct GetBucketInventoryConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: GetBucketInventoryConfigurationOperationInputQuery?
+    public let pathEncodable: GetBucketInventoryConfigurationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketInventoryConfigurationRequest) {
+        self.queryEncodable = encodable.asS3ModelGetBucketInventoryConfigurationOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelGetBucketInventoryConfigurationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketLifecycle operation in a HTTP client.
+ */
+public struct GetBucketLifecycleOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketLifecycleOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketLifecycleRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketLifecycleOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketLifecycleConfiguration operation in a HTTP client.
+ */
+public struct GetBucketLifecycleConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketLifecycleConfigurationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketLifecycleConfigurationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketLifecycleConfigurationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketLocation operation in a HTTP client.
+ */
+public struct GetBucketLocationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketLocationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketLocationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketLocationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketLogging operation in a HTTP client.
+ */
+public struct GetBucketLoggingOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketLoggingOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketLoggingRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketLoggingOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketMetricsConfiguration operation in a HTTP client.
+ */
+public struct GetBucketMetricsConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: GetBucketMetricsConfigurationOperationInputQuery?
+    public let pathEncodable: GetBucketMetricsConfigurationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketMetricsConfigurationRequest) {
+        self.queryEncodable = encodable.asS3ModelGetBucketMetricsConfigurationOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelGetBucketMetricsConfigurationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketNotification operation in a HTTP client.
+ */
+public struct GetBucketNotificationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketNotificationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketNotificationConfigurationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketNotificationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketNotificationConfiguration operation in a HTTP client.
+ */
+public struct GetBucketNotificationConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketNotificationConfigurationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketNotificationConfigurationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketNotificationConfigurationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketPolicy operation in a HTTP client.
+ */
+public struct GetBucketPolicyOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketPolicyOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketPolicyRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketPolicyOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketPolicyStatus operation in a HTTP client.
+ */
+public struct GetBucketPolicyStatusOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketPolicyStatusOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketPolicyStatusRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketPolicyStatusOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketReplication operation in a HTTP client.
+ */
+public struct GetBucketReplicationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketReplicationOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketReplicationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketReplicationOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketRequestPayment operation in a HTTP client.
+ */
+public struct GetBucketRequestPaymentOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketRequestPaymentOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketRequestPaymentRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketRequestPaymentOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketTagging operation in a HTTP client.
+ */
+public struct GetBucketTaggingOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketTaggingOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketTaggingRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketTaggingOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketVersioning operation in a HTTP client.
+ */
+public struct GetBucketVersioningOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketVersioningOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketVersioningRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketVersioningOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetBucketWebsite operation in a HTTP client.
+ */
+public struct GetBucketWebsiteOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetBucketWebsiteOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetBucketWebsiteRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetBucketWebsiteOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetObject operation in a HTTP client.
+ */
+public struct GetObjectOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: GetObjectOperationInputQuery?
+    public let pathEncodable: GetObjectOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: GetObjectOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: GetObjectRequest) {
+        self.queryEncodable = encodable.asS3ModelGetObjectOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelGetObjectOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelGetObjectOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetObjectAcl operation in a HTTP client.
+ */
+public struct GetObjectAclOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: GetObjectAclOperationInputQuery?
+    public let pathEncodable: GetObjectAclOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: GetObjectAclOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: GetObjectAclRequest) {
+        self.queryEncodable = encodable.asS3ModelGetObjectAclOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelGetObjectAclOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelGetObjectAclOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetObjectTagging operation in a HTTP client.
+ */
+public struct GetObjectTaggingOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: GetObjectTaggingOperationInputQuery?
+    public let pathEncodable: GetObjectTaggingOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetObjectTaggingRequest) {
+        self.queryEncodable = encodable.asS3ModelGetObjectTaggingOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelGetObjectTaggingOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetObjectTorrent operation in a HTTP client.
+ */
+public struct GetObjectTorrentOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetObjectTorrentOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: GetObjectTorrentOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: GetObjectTorrentRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetObjectTorrentOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelGetObjectTorrentOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the GetPublicAccessBlock operation in a HTTP client.
+ */
+public struct GetPublicAccessBlockOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: GetPublicAccessBlockOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: GetPublicAccessBlockRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelGetPublicAccessBlockOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the HeadBucket operation in a HTTP client.
+ */
+public struct HeadBucketOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: HeadBucketOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: HeadBucketRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelHeadBucketOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the HeadObject operation in a HTTP client.
+ */
+public struct HeadObjectOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: HeadObjectOperationInputQuery?
+    public let pathEncodable: HeadObjectOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: HeadObjectOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: HeadObjectRequest) {
+        self.queryEncodable = encodable.asS3ModelHeadObjectOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelHeadObjectOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelHeadObjectOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the ListBucketAnalyticsConfigurations operation in a HTTP client.
+ */
+public struct ListBucketAnalyticsConfigurationsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ListBucketAnalyticsConfigurationsOperationInputQuery?
+    public let pathEncodable: ListBucketAnalyticsConfigurationsOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: ListBucketAnalyticsConfigurationsRequest) {
+        self.queryEncodable = encodable.asS3ModelListBucketAnalyticsConfigurationsOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelListBucketAnalyticsConfigurationsOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the ListBucketInventoryConfigurations operation in a HTTP client.
+ */
+public struct ListBucketInventoryConfigurationsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ListBucketInventoryConfigurationsOperationInputQuery?
+    public let pathEncodable: ListBucketInventoryConfigurationsOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: ListBucketInventoryConfigurationsRequest) {
+        self.queryEncodable = encodable.asS3ModelListBucketInventoryConfigurationsOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelListBucketInventoryConfigurationsOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the ListBucketMetricsConfigurations operation in a HTTP client.
+ */
+public struct ListBucketMetricsConfigurationsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ListBucketMetricsConfigurationsOperationInputQuery?
+    public let pathEncodable: ListBucketMetricsConfigurationsOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: ListBucketMetricsConfigurationsRequest) {
+        self.queryEncodable = encodable.asS3ModelListBucketMetricsConfigurationsOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelListBucketMetricsConfigurationsOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the ListMultipartUploads operation in a HTTP client.
+ */
+public struct ListMultipartUploadsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ListMultipartUploadsOperationInputQuery?
+    public let pathEncodable: ListMultipartUploadsOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: ListMultipartUploadsRequest) {
+        self.queryEncodable = encodable.asS3ModelListMultipartUploadsOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelListMultipartUploadsOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the ListObjectVersions operation in a HTTP client.
+ */
+public struct ListObjectVersionsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ListObjectVersionsOperationInputQuery?
+    public let pathEncodable: ListObjectVersionsOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: ListObjectVersionsRequest) {
+        self.queryEncodable = encodable.asS3ModelListObjectVersionsOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelListObjectVersionsOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the ListObjects operation in a HTTP client.
+ */
+public struct ListObjectsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ListObjectsOperationInputQuery?
+    public let pathEncodable: ListObjectsOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: ListObjectsOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: ListObjectsRequest) {
+        self.queryEncodable = encodable.asS3ModelListObjectsOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelListObjectsOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelListObjectsOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the ListObjectsV2 operation in a HTTP client.
+ */
+public struct ListObjectsV2OperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ListObjectsV2OperationInputQuery?
+    public let pathEncodable: ListObjectsV2OperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: ListObjectsV2OperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: ListObjectsV2Request) {
+        self.queryEncodable = encodable.asS3ModelListObjectsV2OperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelListObjectsV2OperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelListObjectsV2OperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the ListParts operation in a HTTP client.
+ */
+public struct ListPartsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ListPartsOperationInputQuery?
+    public let pathEncodable: ListPartsOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: ListPartsOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: ListPartsRequest) {
+        self.queryEncodable = encodable.asS3ModelListPartsOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelListPartsOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelListPartsOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketAccelerateConfiguration operation in a HTTP client.
+ */
+public struct PutBucketAccelerateConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketAccelerateConfigurationOperationInputPath?
+    public let bodyEncodable: AccelerateConfiguration?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketAccelerateConfigurationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketAccelerateConfigurationOperationInputPath()
+        self.bodyEncodable = encodable.accelerateConfiguration
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketAcl operation in a HTTP client.
+ */
+public struct PutBucketAclOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketAclOperationInputPath?
+    public let bodyEncodable: AccessControlPolicy?
+    public let additionalHeadersEncodable: PutBucketAclOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketAclRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketAclOperationInputPath()
+        self.bodyEncodable = encodable.accessControlPolicy
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketAclOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketAnalyticsConfiguration operation in a HTTP client.
+ */
+public struct PutBucketAnalyticsConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: PutBucketAnalyticsConfigurationOperationInputQuery?
+    public let pathEncodable: PutBucketAnalyticsConfigurationOperationInputPath?
+    public let bodyEncodable: AnalyticsConfiguration?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketAnalyticsConfigurationRequest) {
+        self.queryEncodable = encodable.asS3ModelPutBucketAnalyticsConfigurationOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelPutBucketAnalyticsConfigurationOperationInputPath()
+        self.bodyEncodable = encodable.analyticsConfiguration
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketCors operation in a HTTP client.
+ */
+public struct PutBucketCorsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketCorsOperationInputPath?
+    public let bodyEncodable: CORSConfiguration?
+    public let additionalHeadersEncodable: PutBucketCorsOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketCorsRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketCorsOperationInputPath()
+        self.bodyEncodable = encodable.cORSConfiguration
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketCorsOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketEncryption operation in a HTTP client.
+ */
+public struct PutBucketEncryptionOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketEncryptionOperationInputPath?
+    public let bodyEncodable: ServerSideEncryptionConfiguration?
+    public let additionalHeadersEncodable: PutBucketEncryptionOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketEncryptionRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketEncryptionOperationInputPath()
+        self.bodyEncodable = encodable.serverSideEncryptionConfiguration
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketEncryptionOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketInventoryConfiguration operation in a HTTP client.
+ */
+public struct PutBucketInventoryConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: PutBucketInventoryConfigurationOperationInputQuery?
+    public let pathEncodable: PutBucketInventoryConfigurationOperationInputPath?
+    public let bodyEncodable: InventoryConfiguration?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketInventoryConfigurationRequest) {
+        self.queryEncodable = encodable.asS3ModelPutBucketInventoryConfigurationOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelPutBucketInventoryConfigurationOperationInputPath()
+        self.bodyEncodable = encodable.inventoryConfiguration
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketLifecycle operation in a HTTP client.
+ */
+public struct PutBucketLifecycleOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketLifecycleOperationInputPath?
+    public let bodyEncodable: LifecycleConfiguration?
+    public let additionalHeadersEncodable: PutBucketLifecycleOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketLifecycleRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketLifecycleOperationInputPath()
+        self.bodyEncodable = encodable.lifecycleConfiguration
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketLifecycleOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketLifecycleConfiguration operation in a HTTP client.
+ */
+public struct PutBucketLifecycleConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketLifecycleConfigurationOperationInputPath?
+    public let bodyEncodable: BucketLifecycleConfiguration?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketLifecycleConfigurationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketLifecycleConfigurationOperationInputPath()
+        self.bodyEncodable = encodable.lifecycleConfiguration
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketLogging operation in a HTTP client.
+ */
+public struct PutBucketLoggingOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketLoggingOperationInputPath?
+    public let bodyEncodable: BucketLoggingStatus?
+    public let additionalHeadersEncodable: PutBucketLoggingOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketLoggingRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketLoggingOperationInputPath()
+        self.bodyEncodable = encodable.bucketLoggingStatus
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketLoggingOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketMetricsConfiguration operation in a HTTP client.
+ */
+public struct PutBucketMetricsConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: PutBucketMetricsConfigurationOperationInputQuery?
+    public let pathEncodable: PutBucketMetricsConfigurationOperationInputPath?
+    public let bodyEncodable: MetricsConfiguration?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketMetricsConfigurationRequest) {
+        self.queryEncodable = encodable.asS3ModelPutBucketMetricsConfigurationOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelPutBucketMetricsConfigurationOperationInputPath()
+        self.bodyEncodable = encodable.metricsConfiguration
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketNotification operation in a HTTP client.
+ */
+public struct PutBucketNotificationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketNotificationOperationInputPath?
+    public let bodyEncodable: NotificationConfigurationDeprecated?
+    public let additionalHeadersEncodable: PutBucketNotificationOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketNotificationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketNotificationOperationInputPath()
+        self.bodyEncodable = encodable.notificationConfiguration
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketNotificationOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketNotificationConfiguration operation in a HTTP client.
+ */
+public struct PutBucketNotificationConfigurationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketNotificationConfigurationOperationInputPath?
+    public let bodyEncodable: NotificationConfiguration?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketNotificationConfigurationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketNotificationConfigurationOperationInputPath()
+        self.bodyEncodable = encodable.notificationConfiguration
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketPolicy operation in a HTTP client.
+ */
+public struct PutBucketPolicyOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketPolicyOperationInputPath?
+    public let bodyEncodable: Policy?
+    public let additionalHeadersEncodable: PutBucketPolicyOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketPolicyRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketPolicyOperationInputPath()
+        self.bodyEncodable = encodable.policy
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketPolicyOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketReplication operation in a HTTP client.
+ */
+public struct PutBucketReplicationOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketReplicationOperationInputPath?
+    public let bodyEncodable: ReplicationConfiguration?
+    public let additionalHeadersEncodable: PutBucketReplicationOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketReplicationRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketReplicationOperationInputPath()
+        self.bodyEncodable = encodable.replicationConfiguration
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketReplicationOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketRequestPayment operation in a HTTP client.
+ */
+public struct PutBucketRequestPaymentOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketRequestPaymentOperationInputPath?
+    public let bodyEncodable: RequestPaymentConfiguration?
+    public let additionalHeadersEncodable: PutBucketRequestPaymentOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketRequestPaymentRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketRequestPaymentOperationInputPath()
+        self.bodyEncodable = encodable.requestPaymentConfiguration
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketRequestPaymentOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketTagging operation in a HTTP client.
+ */
+public struct PutBucketTaggingOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketTaggingOperationInputPath?
+    public let bodyEncodable: Tagging?
+    public let additionalHeadersEncodable: PutBucketTaggingOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketTaggingRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketTaggingOperationInputPath()
+        self.bodyEncodable = encodable.tagging
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketTaggingOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketVersioning operation in a HTTP client.
+ */
+public struct PutBucketVersioningOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketVersioningOperationInputPath?
+    public let bodyEncodable: VersioningConfiguration?
+    public let additionalHeadersEncodable: PutBucketVersioningOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketVersioningRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketVersioningOperationInputPath()
+        self.bodyEncodable = encodable.versioningConfiguration
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketVersioningOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutBucketWebsite operation in a HTTP client.
+ */
+public struct PutBucketWebsiteOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutBucketWebsiteOperationInputPath?
+    public let bodyEncodable: WebsiteConfiguration?
+    public let additionalHeadersEncodable: PutBucketWebsiteOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutBucketWebsiteRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutBucketWebsiteOperationInputPath()
+        self.bodyEncodable = encodable.websiteConfiguration
+        self.additionalHeadersEncodable = encodable.asS3ModelPutBucketWebsiteOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutObject operation in a HTTP client.
+ */
+public struct PutObjectOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutObjectOperationInputPath?
+    public let bodyEncodable: Body?
+    public let additionalHeadersEncodable: PutObjectOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutObjectRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutObjectOperationInputPath()
+        self.bodyEncodable = encodable.body
+        self.additionalHeadersEncodable = encodable.asS3ModelPutObjectOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutObjectAcl operation in a HTTP client.
+ */
+public struct PutObjectAclOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: PutObjectAclOperationInputQuery?
+    public let pathEncodable: PutObjectAclOperationInputPath?
+    public let bodyEncodable: AccessControlPolicy?
+    public let additionalHeadersEncodable: PutObjectAclOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutObjectAclRequest) {
+        self.queryEncodable = encodable.asS3ModelPutObjectAclOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelPutObjectAclOperationInputPath()
+        self.bodyEncodable = encodable.accessControlPolicy
+        self.additionalHeadersEncodable = encodable.asS3ModelPutObjectAclOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutObjectTagging operation in a HTTP client.
+ */
+public struct PutObjectTaggingOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: PutObjectTaggingOperationInputQuery?
+    public let pathEncodable: PutObjectTaggingOperationInputPath?
+    public let bodyEncodable: Tagging?
+    public let additionalHeadersEncodable: PutObjectTaggingOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutObjectTaggingRequest) {
+        self.queryEncodable = encodable.asS3ModelPutObjectTaggingOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelPutObjectTaggingOperationInputPath()
+        self.bodyEncodable = encodable.tagging
+        self.additionalHeadersEncodable = encodable.asS3ModelPutObjectTaggingOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the PutPublicAccessBlock operation in a HTTP client.
+ */
+public struct PutPublicAccessBlockOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: PutPublicAccessBlockOperationInputPath?
+    public let bodyEncodable: PublicAccessBlockConfiguration?
+    public let additionalHeadersEncodable: PutPublicAccessBlockOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: PutPublicAccessBlockRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelPutPublicAccessBlockOperationInputPath()
+        self.bodyEncodable = encodable.publicAccessBlockConfiguration
+        self.additionalHeadersEncodable = encodable.asS3ModelPutPublicAccessBlockOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the RestoreObject operation in a HTTP client.
+ */
+public struct RestoreObjectOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: RestoreObjectOperationInputQuery?
+    public let pathEncodable: RestoreObjectOperationInputPath?
+    public let bodyEncodable: RestoreRequest?
+    public let additionalHeadersEncodable: RestoreObjectOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: RestoreObjectRequest) {
+        self.queryEncodable = encodable.asS3ModelRestoreObjectOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelRestoreObjectOperationInputPath()
+        self.bodyEncodable = encodable.restoreRequest
+        self.additionalHeadersEncodable = encodable.asS3ModelRestoreObjectOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the SelectObjectContent operation in a HTTP client.
+ */
+public struct SelectObjectContentOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: SelectObjectContentOperationInputPath?
+    public let bodyEncodable: SelectObjectContentOperationInputBody?
+    public let additionalHeadersEncodable: SelectObjectContentOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: SelectObjectContentRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = encodable.asS3ModelSelectObjectContentOperationInputPath()
+        self.bodyEncodable = encodable.asS3ModelSelectObjectContentOperationInputBody()
+        self.additionalHeadersEncodable = encodable.asS3ModelSelectObjectContentOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the UploadPart operation in a HTTP client.
+ */
+public struct UploadPartOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: UploadPartOperationInputQuery?
+    public let pathEncodable: UploadPartOperationInputPath?
+    public let bodyEncodable: Body?
+    public let additionalHeadersEncodable: UploadPartOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: UploadPartRequest) {
+        self.queryEncodable = encodable.asS3ModelUploadPartOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelUploadPartOperationInputPath()
+        self.bodyEncodable = encodable.body
+        self.additionalHeadersEncodable = encodable.asS3ModelUploadPartOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}
+/**
+ Type to handle the input to the UploadPartCopy operation in a HTTP client.
+ */
+public struct UploadPartCopyOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: UploadPartCopyOperationInputQuery?
+    public let pathEncodable: UploadPartCopyOperationInputPath?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: UploadPartCopyOperationInputAdditionalHeaders?
+    public let pathPostfix: String?
+
+    public init(encodable: UploadPartCopyRequest) {
+        self.queryEncodable = encodable.asS3ModelUploadPartCopyOperationInputQuery()
+        self.pathEncodable = encodable.asS3ModelUploadPartCopyOperationInputPath()
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = encodable.asS3ModelUploadPartCopyOperationInputAdditionalHeaders()
+        self.pathPostfix = nil
+    }
+}

--- a/Sources/S3Client/S3OperationsClientOutput.swift
+++ b/Sources/S3Client/S3OperationsClientOutput.swift
@@ -1,0 +1,792 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// S3OperationsClientOutput.swift
+// S3Client
+//
+
+import Foundation
+import SmokeHTTPClient
+import S3Model
+
+/**
+ Type to handle the output from the AbortMultipartUpload operation in a HTTP client.
+ */
+extension AbortMultipartUploadOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = AbortMultipartUploadOutput
+    public typealias HeadersType = AbortMultipartUploadOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AbortMultipartUploadOutput {
+        return try headersDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CompleteMultipartUpload operation in a HTTP client.
+ */
+extension CompleteMultipartUploadOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = CompleteMultipartUploadOperationOutputBody
+    public typealias HeadersType = CompleteMultipartUploadOperationOutputHeaders
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CompleteMultipartUploadOutput {
+        let body = try bodyDecodableProvider()
+        let headers = try headersDecodableProvider()
+
+        return S3Model.CompleteMultipartUploadOutput(
+            bucket: body.bucket,
+            eTag: body.eTag,
+            expiration: headers.expiration,
+            key: body.key,
+            location: body.location,
+            requestCharged: headers.requestCharged,
+            sSEKMSKeyId: headers.sSEKMSKeyId,
+            serverSideEncryption: headers.serverSideEncryption,
+            versionId: headers.versionId)
+    }
+}
+
+/**
+ Type to handle the output from the CopyObject operation in a HTTP client.
+ */
+extension CopyObjectOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = CopyObjectResult
+    public typealias HeadersType = CopyObjectOperationOutputHeaders
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CopyObjectOutput {
+        let body = try bodyDecodableProvider()
+        let headers = try headersDecodableProvider()
+
+        return S3Model.CopyObjectOutput(
+            copyObjectResult: body,
+            copySourceVersionId: headers.copySourceVersionId,
+            expiration: headers.expiration,
+            requestCharged: headers.requestCharged,
+            sSECustomerAlgorithm: headers.sSECustomerAlgorithm,
+            sSECustomerKeyMD5: headers.sSECustomerKeyMD5,
+            sSEKMSKeyId: headers.sSEKMSKeyId,
+            serverSideEncryption: headers.serverSideEncryption,
+            versionId: headers.versionId)
+    }
+}
+
+/**
+ Type to handle the output from the CreateBucket operation in a HTTP client.
+ */
+extension CreateBucketOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateBucketOutput
+    public typealias HeadersType = CreateBucketOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateBucketOutput {
+        return try headersDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateMultipartUpload operation in a HTTP client.
+ */
+extension CreateMultipartUploadOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateMultipartUploadOperationOutputBody
+    public typealias HeadersType = CreateMultipartUploadOperationOutputHeaders
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateMultipartUploadOutput {
+        let body = try bodyDecodableProvider()
+        let headers = try headersDecodableProvider()
+
+        return S3Model.CreateMultipartUploadOutput(
+            abortDate: headers.abortDate,
+            abortRuleId: headers.abortRuleId,
+            bucket: body.bucket,
+            key: body.key,
+            requestCharged: headers.requestCharged,
+            sSECustomerAlgorithm: headers.sSECustomerAlgorithm,
+            sSECustomerKeyMD5: headers.sSECustomerKeyMD5,
+            sSEKMSKeyId: headers.sSEKMSKeyId,
+            serverSideEncryption: headers.serverSideEncryption,
+            uploadId: body.uploadId)
+    }
+}
+
+/**
+ Type to handle the output from the DeleteObject operation in a HTTP client.
+ */
+extension DeleteObjectOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteObjectOutput
+    public typealias HeadersType = DeleteObjectOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteObjectOutput {
+        return try headersDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteObjectTagging operation in a HTTP client.
+ */
+extension DeleteObjectTaggingOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteObjectTaggingOutput
+    public typealias HeadersType = DeleteObjectTaggingOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteObjectTaggingOutput {
+        return try headersDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteObjects operation in a HTTP client.
+ */
+extension DeleteObjectsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteObjectsOperationOutputBody
+    public typealias HeadersType = DeleteObjectsOperationOutputHeaders
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteObjectsOutput {
+        let body = try bodyDecodableProvider()
+        let headers = try headersDecodableProvider()
+
+        return S3Model.DeleteObjectsOutput(
+            deleted: body.deleted,
+            errors: body.errors,
+            requestCharged: headers.requestCharged)
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketAccelerateConfiguration operation in a HTTP client.
+ */
+extension GetBucketAccelerateConfigurationOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketAccelerateConfigurationOutput
+    public typealias HeadersType = GetBucketAccelerateConfigurationOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketAccelerateConfigurationOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketAcl operation in a HTTP client.
+ */
+extension GetBucketAclOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketAclOutput
+    public typealias HeadersType = GetBucketAclOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketAclOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketAnalyticsConfiguration operation in a HTTP client.
+ */
+extension GetBucketAnalyticsConfigurationOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketAnalyticsConfigurationOutput
+    public typealias HeadersType = GetBucketAnalyticsConfigurationOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketAnalyticsConfigurationOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketCors operation in a HTTP client.
+ */
+extension GetBucketCorsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketCorsOutput
+    public typealias HeadersType = GetBucketCorsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketCorsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketEncryption operation in a HTTP client.
+ */
+extension GetBucketEncryptionOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketEncryptionOutput
+    public typealias HeadersType = GetBucketEncryptionOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketEncryptionOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketInventoryConfiguration operation in a HTTP client.
+ */
+extension GetBucketInventoryConfigurationOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketInventoryConfigurationOutput
+    public typealias HeadersType = GetBucketInventoryConfigurationOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketInventoryConfigurationOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketLifecycle operation in a HTTP client.
+ */
+extension GetBucketLifecycleOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketLifecycleOutput
+    public typealias HeadersType = GetBucketLifecycleOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketLifecycleOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketLifecycleConfiguration operation in a HTTP client.
+ */
+extension GetBucketLifecycleConfigurationOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketLifecycleConfigurationOutput
+    public typealias HeadersType = GetBucketLifecycleConfigurationOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketLifecycleConfigurationOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketLocation operation in a HTTP client.
+ */
+extension GetBucketLocationOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketLocationOutput
+    public typealias HeadersType = GetBucketLocationOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketLocationOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketLogging operation in a HTTP client.
+ */
+extension GetBucketLoggingOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketLoggingOutput
+    public typealias HeadersType = GetBucketLoggingOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketLoggingOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketMetricsConfiguration operation in a HTTP client.
+ */
+extension GetBucketMetricsConfigurationOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketMetricsConfigurationOutput
+    public typealias HeadersType = GetBucketMetricsConfigurationOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketMetricsConfigurationOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketNotification operation in a HTTP client.
+ */
+extension NotificationConfigurationDeprecated: HTTPResponseOutputProtocol {
+    public typealias BodyType = NotificationConfigurationDeprecated
+    public typealias HeadersType = NotificationConfigurationDeprecated
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> NotificationConfigurationDeprecated {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketNotificationConfiguration operation in a HTTP client.
+ */
+extension NotificationConfiguration: HTTPResponseOutputProtocol {
+    public typealias BodyType = NotificationConfiguration
+    public typealias HeadersType = NotificationConfiguration
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> NotificationConfiguration {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketPolicy operation in a HTTP client.
+ */
+extension GetBucketPolicyOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketPolicyOutput
+    public typealias HeadersType = GetBucketPolicyOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketPolicyOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketPolicyStatus operation in a HTTP client.
+ */
+extension GetBucketPolicyStatusOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketPolicyStatusOutput
+    public typealias HeadersType = GetBucketPolicyStatusOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketPolicyStatusOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketReplication operation in a HTTP client.
+ */
+extension GetBucketReplicationOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketReplicationOutput
+    public typealias HeadersType = GetBucketReplicationOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketReplicationOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketRequestPayment operation in a HTTP client.
+ */
+extension GetBucketRequestPaymentOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketRequestPaymentOutput
+    public typealias HeadersType = GetBucketRequestPaymentOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketRequestPaymentOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketTagging operation in a HTTP client.
+ */
+extension GetBucketTaggingOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketTaggingOutput
+    public typealias HeadersType = GetBucketTaggingOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketTaggingOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketVersioning operation in a HTTP client.
+ */
+extension GetBucketVersioningOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketVersioningOutput
+    public typealias HeadersType = GetBucketVersioningOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketVersioningOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetBucketWebsite operation in a HTTP client.
+ */
+extension GetBucketWebsiteOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetBucketWebsiteOutput
+    public typealias HeadersType = GetBucketWebsiteOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetBucketWebsiteOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetObject operation in a HTTP client.
+ */
+extension GetObjectOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = Body
+    public typealias HeadersType = GetObjectOperationOutputHeaders
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetObjectOutput {
+        let body = try bodyDecodableProvider()
+        let headers = try headersDecodableProvider()
+
+        return S3Model.GetObjectOutput(
+            acceptRanges: headers.acceptRanges,
+            body: body,
+            cacheControl: headers.cacheControl,
+            contentDisposition: headers.contentDisposition,
+            contentEncoding: headers.contentEncoding,
+            contentLanguage: headers.contentLanguage,
+            contentLength: headers.contentLength,
+            contentRange: headers.contentRange,
+            contentType: headers.contentType,
+            deleteMarker: headers.deleteMarker,
+            eTag: headers.eTag,
+            expiration: headers.expiration,
+            expires: headers.expires,
+            lastModified: headers.lastModified,
+            metadata: headers.metadata,
+            missingMeta: headers.missingMeta,
+            partsCount: headers.partsCount,
+            replicationStatus: headers.replicationStatus,
+            requestCharged: headers.requestCharged,
+            restore: headers.restore,
+            sSECustomerAlgorithm: headers.sSECustomerAlgorithm,
+            sSECustomerKeyMD5: headers.sSECustomerKeyMD5,
+            sSEKMSKeyId: headers.sSEKMSKeyId,
+            serverSideEncryption: headers.serverSideEncryption,
+            storageClass: headers.storageClass,
+            tagCount: headers.tagCount,
+            versionId: headers.versionId,
+            websiteRedirectLocation: headers.websiteRedirectLocation)
+    }
+}
+
+/**
+ Type to handle the output from the GetObjectAcl operation in a HTTP client.
+ */
+extension GetObjectAclOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetObjectAclOperationOutputBody
+    public typealias HeadersType = GetObjectAclOperationOutputHeaders
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetObjectAclOutput {
+        let body = try bodyDecodableProvider()
+        let headers = try headersDecodableProvider()
+
+        return S3Model.GetObjectAclOutput(
+            grants: body.grants,
+            owner: body.owner,
+            requestCharged: headers.requestCharged)
+    }
+}
+
+/**
+ Type to handle the output from the GetObjectTagging operation in a HTTP client.
+ */
+extension GetObjectTaggingOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetObjectTaggingOperationOutputBody
+    public typealias HeadersType = GetObjectTaggingOperationOutputHeaders
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetObjectTaggingOutput {
+        let body = try bodyDecodableProvider()
+        let headers = try headersDecodableProvider()
+
+        return S3Model.GetObjectTaggingOutput(
+            tagSet: body.tagSet,
+            versionId: headers.versionId)
+    }
+}
+
+/**
+ Type to handle the output from the GetObjectTorrent operation in a HTTP client.
+ */
+extension GetObjectTorrentOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = Body
+    public typealias HeadersType = GetObjectTorrentOperationOutputHeaders
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetObjectTorrentOutput {
+        let body = try bodyDecodableProvider()
+        let headers = try headersDecodableProvider()
+
+        return S3Model.GetObjectTorrentOutput(
+            body: body,
+            requestCharged: headers.requestCharged)
+    }
+}
+
+/**
+ Type to handle the output from the GetPublicAccessBlock operation in a HTTP client.
+ */
+extension GetPublicAccessBlockOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetPublicAccessBlockOutput
+    public typealias HeadersType = GetPublicAccessBlockOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetPublicAccessBlockOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the HeadObject operation in a HTTP client.
+ */
+extension HeadObjectOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = HeadObjectOutput
+    public typealias HeadersType = HeadObjectOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> HeadObjectOutput {
+        return try headersDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListBucketAnalyticsConfigurations operation in a HTTP client.
+ */
+extension ListBucketAnalyticsConfigurationsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListBucketAnalyticsConfigurationsOutput
+    public typealias HeadersType = ListBucketAnalyticsConfigurationsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListBucketAnalyticsConfigurationsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListBucketInventoryConfigurations operation in a HTTP client.
+ */
+extension ListBucketInventoryConfigurationsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListBucketInventoryConfigurationsOutput
+    public typealias HeadersType = ListBucketInventoryConfigurationsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListBucketInventoryConfigurationsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListBucketMetricsConfigurations operation in a HTTP client.
+ */
+extension ListBucketMetricsConfigurationsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListBucketMetricsConfigurationsOutput
+    public typealias HeadersType = ListBucketMetricsConfigurationsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListBucketMetricsConfigurationsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListBuckets operation in a HTTP client.
+ */
+extension ListBucketsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListBucketsOutput
+    public typealias HeadersType = ListBucketsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListBucketsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListMultipartUploads operation in a HTTP client.
+ */
+extension ListMultipartUploadsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListMultipartUploadsOutput
+    public typealias HeadersType = ListMultipartUploadsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListMultipartUploadsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListObjectVersions operation in a HTTP client.
+ */
+extension ListObjectVersionsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListObjectVersionsOutput
+    public typealias HeadersType = ListObjectVersionsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListObjectVersionsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListObjects operation in a HTTP client.
+ */
+extension ListObjectsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListObjectsOutput
+    public typealias HeadersType = ListObjectsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListObjectsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListObjectsV2 operation in a HTTP client.
+ */
+extension ListObjectsV2Output: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListObjectsV2Output
+    public typealias HeadersType = ListObjectsV2Output
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListObjectsV2Output {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListParts operation in a HTTP client.
+ */
+extension ListPartsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListPartsOperationOutputBody
+    public typealias HeadersType = ListPartsOperationOutputHeaders
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListPartsOutput {
+        let body = try bodyDecodableProvider()
+        let headers = try headersDecodableProvider()
+
+        return S3Model.ListPartsOutput(
+            abortDate: headers.abortDate,
+            abortRuleId: headers.abortRuleId,
+            bucket: body.bucket,
+            initiator: body.initiator,
+            isTruncated: body.isTruncated,
+            key: body.key,
+            maxParts: body.maxParts,
+            nextPartNumberMarker: body.nextPartNumberMarker,
+            owner: body.owner,
+            partNumberMarker: body.partNumberMarker,
+            parts: body.parts,
+            requestCharged: headers.requestCharged,
+            storageClass: body.storageClass,
+            uploadId: body.uploadId)
+    }
+}
+
+/**
+ Type to handle the output from the PutObject operation in a HTTP client.
+ */
+extension PutObjectOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = PutObjectOutput
+    public typealias HeadersType = PutObjectOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PutObjectOutput {
+        return try headersDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PutObjectAcl operation in a HTTP client.
+ */
+extension PutObjectAclOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = PutObjectAclOutput
+    public typealias HeadersType = PutObjectAclOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PutObjectAclOutput {
+        return try headersDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PutObjectTagging operation in a HTTP client.
+ */
+extension PutObjectTaggingOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = PutObjectTaggingOutput
+    public typealias HeadersType = PutObjectTaggingOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PutObjectTaggingOutput {
+        return try headersDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RestoreObject operation in a HTTP client.
+ */
+extension RestoreObjectOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = RestoreObjectOutput
+    public typealias HeadersType = RestoreObjectOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> RestoreObjectOutput {
+        return try headersDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the SelectObjectContent operation in a HTTP client.
+ */
+extension SelectObjectContentOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = SelectObjectContentOutput
+    public typealias HeadersType = SelectObjectContentOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> SelectObjectContentOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UploadPart operation in a HTTP client.
+ */
+extension UploadPartOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = UploadPartOutput
+    public typealias HeadersType = UploadPartOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UploadPartOutput {
+        return try headersDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UploadPartCopy operation in a HTTP client.
+ */
+extension UploadPartCopyOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = CopyPartResult
+    public typealias HeadersType = UploadPartCopyOperationOutputHeaders
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UploadPartCopyOutput {
+        let body = try bodyDecodableProvider()
+        let headers = try headersDecodableProvider()
+
+        return S3Model.UploadPartCopyOutput(
+            copyPartResult: body,
+            copySourceVersionId: headers.copySourceVersionId,
+            requestCharged: headers.requestCharged,
+            sSECustomerAlgorithm: headers.sSECustomerAlgorithm,
+            sSECustomerKeyMD5: headers.sSECustomerKeyMD5,
+            sSEKMSKeyId: headers.sSEKMSKeyId,
+            serverSideEncryption: headers.serverSideEncryption)
+    }
+}
+

--- a/Sources/S3Client/ThrowingS3Client.swift
+++ b/Sources/S3Client/ThrowingS3Client.swift
@@ -1,0 +1,3157 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment type_body_length
+// -- Generated Code; do not edit --
+//
+// ThrowingS3Client.swift
+// S3Client
+//
+
+import Foundation
+import S3Model
+import SmokeHTTPClient
+
+/**
+ Mock Client for the S3 service that by default always throws from its methods.
+ */
+public struct ThrowingS3Client: S3ClientProtocol {
+    let error: Swift.Error
+    let abortMultipartUploadAsyncOverride: S3ClientProtocol.AbortMultipartUploadAsyncType?
+    let abortMultipartUploadSyncOverride: S3ClientProtocol.AbortMultipartUploadSyncType?
+    let completeMultipartUploadAsyncOverride: S3ClientProtocol.CompleteMultipartUploadAsyncType?
+    let completeMultipartUploadSyncOverride: S3ClientProtocol.CompleteMultipartUploadSyncType?
+    let copyObjectAsyncOverride: S3ClientProtocol.CopyObjectAsyncType?
+    let copyObjectSyncOverride: S3ClientProtocol.CopyObjectSyncType?
+    let createBucketAsyncOverride: S3ClientProtocol.CreateBucketAsyncType?
+    let createBucketSyncOverride: S3ClientProtocol.CreateBucketSyncType?
+    let createMultipartUploadAsyncOverride: S3ClientProtocol.CreateMultipartUploadAsyncType?
+    let createMultipartUploadSyncOverride: S3ClientProtocol.CreateMultipartUploadSyncType?
+    let deleteBucketAsyncOverride: S3ClientProtocol.DeleteBucketAsyncType?
+    let deleteBucketSyncOverride: S3ClientProtocol.DeleteBucketSyncType?
+    let deleteBucketAnalyticsConfigurationAsyncOverride: S3ClientProtocol.DeleteBucketAnalyticsConfigurationAsyncType?
+    let deleteBucketAnalyticsConfigurationSyncOverride: S3ClientProtocol.DeleteBucketAnalyticsConfigurationSyncType?
+    let deleteBucketCorsAsyncOverride: S3ClientProtocol.DeleteBucketCorsAsyncType?
+    let deleteBucketCorsSyncOverride: S3ClientProtocol.DeleteBucketCorsSyncType?
+    let deleteBucketEncryptionAsyncOverride: S3ClientProtocol.DeleteBucketEncryptionAsyncType?
+    let deleteBucketEncryptionSyncOverride: S3ClientProtocol.DeleteBucketEncryptionSyncType?
+    let deleteBucketInventoryConfigurationAsyncOverride: S3ClientProtocol.DeleteBucketInventoryConfigurationAsyncType?
+    let deleteBucketInventoryConfigurationSyncOverride: S3ClientProtocol.DeleteBucketInventoryConfigurationSyncType?
+    let deleteBucketLifecycleAsyncOverride: S3ClientProtocol.DeleteBucketLifecycleAsyncType?
+    let deleteBucketLifecycleSyncOverride: S3ClientProtocol.DeleteBucketLifecycleSyncType?
+    let deleteBucketMetricsConfigurationAsyncOverride: S3ClientProtocol.DeleteBucketMetricsConfigurationAsyncType?
+    let deleteBucketMetricsConfigurationSyncOverride: S3ClientProtocol.DeleteBucketMetricsConfigurationSyncType?
+    let deleteBucketPolicyAsyncOverride: S3ClientProtocol.DeleteBucketPolicyAsyncType?
+    let deleteBucketPolicySyncOverride: S3ClientProtocol.DeleteBucketPolicySyncType?
+    let deleteBucketReplicationAsyncOverride: S3ClientProtocol.DeleteBucketReplicationAsyncType?
+    let deleteBucketReplicationSyncOverride: S3ClientProtocol.DeleteBucketReplicationSyncType?
+    let deleteBucketTaggingAsyncOverride: S3ClientProtocol.DeleteBucketTaggingAsyncType?
+    let deleteBucketTaggingSyncOverride: S3ClientProtocol.DeleteBucketTaggingSyncType?
+    let deleteBucketWebsiteAsyncOverride: S3ClientProtocol.DeleteBucketWebsiteAsyncType?
+    let deleteBucketWebsiteSyncOverride: S3ClientProtocol.DeleteBucketWebsiteSyncType?
+    let deleteObjectAsyncOverride: S3ClientProtocol.DeleteObjectAsyncType?
+    let deleteObjectSyncOverride: S3ClientProtocol.DeleteObjectSyncType?
+    let deleteObjectTaggingAsyncOverride: S3ClientProtocol.DeleteObjectTaggingAsyncType?
+    let deleteObjectTaggingSyncOverride: S3ClientProtocol.DeleteObjectTaggingSyncType?
+    let deleteObjectsAsyncOverride: S3ClientProtocol.DeleteObjectsAsyncType?
+    let deleteObjectsSyncOverride: S3ClientProtocol.DeleteObjectsSyncType?
+    let deletePublicAccessBlockAsyncOverride: S3ClientProtocol.DeletePublicAccessBlockAsyncType?
+    let deletePublicAccessBlockSyncOverride: S3ClientProtocol.DeletePublicAccessBlockSyncType?
+    let getBucketAccelerateConfigurationAsyncOverride: S3ClientProtocol.GetBucketAccelerateConfigurationAsyncType?
+    let getBucketAccelerateConfigurationSyncOverride: S3ClientProtocol.GetBucketAccelerateConfigurationSyncType?
+    let getBucketAclAsyncOverride: S3ClientProtocol.GetBucketAclAsyncType?
+    let getBucketAclSyncOverride: S3ClientProtocol.GetBucketAclSyncType?
+    let getBucketAnalyticsConfigurationAsyncOverride: S3ClientProtocol.GetBucketAnalyticsConfigurationAsyncType?
+    let getBucketAnalyticsConfigurationSyncOverride: S3ClientProtocol.GetBucketAnalyticsConfigurationSyncType?
+    let getBucketCorsAsyncOverride: S3ClientProtocol.GetBucketCorsAsyncType?
+    let getBucketCorsSyncOverride: S3ClientProtocol.GetBucketCorsSyncType?
+    let getBucketEncryptionAsyncOverride: S3ClientProtocol.GetBucketEncryptionAsyncType?
+    let getBucketEncryptionSyncOverride: S3ClientProtocol.GetBucketEncryptionSyncType?
+    let getBucketInventoryConfigurationAsyncOverride: S3ClientProtocol.GetBucketInventoryConfigurationAsyncType?
+    let getBucketInventoryConfigurationSyncOverride: S3ClientProtocol.GetBucketInventoryConfigurationSyncType?
+    let getBucketLifecycleAsyncOverride: S3ClientProtocol.GetBucketLifecycleAsyncType?
+    let getBucketLifecycleSyncOverride: S3ClientProtocol.GetBucketLifecycleSyncType?
+    let getBucketLifecycleConfigurationAsyncOverride: S3ClientProtocol.GetBucketLifecycleConfigurationAsyncType?
+    let getBucketLifecycleConfigurationSyncOverride: S3ClientProtocol.GetBucketLifecycleConfigurationSyncType?
+    let getBucketLocationAsyncOverride: S3ClientProtocol.GetBucketLocationAsyncType?
+    let getBucketLocationSyncOverride: S3ClientProtocol.GetBucketLocationSyncType?
+    let getBucketLoggingAsyncOverride: S3ClientProtocol.GetBucketLoggingAsyncType?
+    let getBucketLoggingSyncOverride: S3ClientProtocol.GetBucketLoggingSyncType?
+    let getBucketMetricsConfigurationAsyncOverride: S3ClientProtocol.GetBucketMetricsConfigurationAsyncType?
+    let getBucketMetricsConfigurationSyncOverride: S3ClientProtocol.GetBucketMetricsConfigurationSyncType?
+    let getBucketNotificationAsyncOverride: S3ClientProtocol.GetBucketNotificationAsyncType?
+    let getBucketNotificationSyncOverride: S3ClientProtocol.GetBucketNotificationSyncType?
+    let getBucketNotificationConfigurationAsyncOverride: S3ClientProtocol.GetBucketNotificationConfigurationAsyncType?
+    let getBucketNotificationConfigurationSyncOverride: S3ClientProtocol.GetBucketNotificationConfigurationSyncType?
+    let getBucketPolicyAsyncOverride: S3ClientProtocol.GetBucketPolicyAsyncType?
+    let getBucketPolicySyncOverride: S3ClientProtocol.GetBucketPolicySyncType?
+    let getBucketPolicyStatusAsyncOverride: S3ClientProtocol.GetBucketPolicyStatusAsyncType?
+    let getBucketPolicyStatusSyncOverride: S3ClientProtocol.GetBucketPolicyStatusSyncType?
+    let getBucketReplicationAsyncOverride: S3ClientProtocol.GetBucketReplicationAsyncType?
+    let getBucketReplicationSyncOverride: S3ClientProtocol.GetBucketReplicationSyncType?
+    let getBucketRequestPaymentAsyncOverride: S3ClientProtocol.GetBucketRequestPaymentAsyncType?
+    let getBucketRequestPaymentSyncOverride: S3ClientProtocol.GetBucketRequestPaymentSyncType?
+    let getBucketTaggingAsyncOverride: S3ClientProtocol.GetBucketTaggingAsyncType?
+    let getBucketTaggingSyncOverride: S3ClientProtocol.GetBucketTaggingSyncType?
+    let getBucketVersioningAsyncOverride: S3ClientProtocol.GetBucketVersioningAsyncType?
+    let getBucketVersioningSyncOverride: S3ClientProtocol.GetBucketVersioningSyncType?
+    let getBucketWebsiteAsyncOverride: S3ClientProtocol.GetBucketWebsiteAsyncType?
+    let getBucketWebsiteSyncOverride: S3ClientProtocol.GetBucketWebsiteSyncType?
+    let getObjectAsyncOverride: S3ClientProtocol.GetObjectAsyncType?
+    let getObjectSyncOverride: S3ClientProtocol.GetObjectSyncType?
+    let getObjectAclAsyncOverride: S3ClientProtocol.GetObjectAclAsyncType?
+    let getObjectAclSyncOverride: S3ClientProtocol.GetObjectAclSyncType?
+    let getObjectTaggingAsyncOverride: S3ClientProtocol.GetObjectTaggingAsyncType?
+    let getObjectTaggingSyncOverride: S3ClientProtocol.GetObjectTaggingSyncType?
+    let getObjectTorrentAsyncOverride: S3ClientProtocol.GetObjectTorrentAsyncType?
+    let getObjectTorrentSyncOverride: S3ClientProtocol.GetObjectTorrentSyncType?
+    let getPublicAccessBlockAsyncOverride: S3ClientProtocol.GetPublicAccessBlockAsyncType?
+    let getPublicAccessBlockSyncOverride: S3ClientProtocol.GetPublicAccessBlockSyncType?
+    let headBucketAsyncOverride: S3ClientProtocol.HeadBucketAsyncType?
+    let headBucketSyncOverride: S3ClientProtocol.HeadBucketSyncType?
+    let headObjectAsyncOverride: S3ClientProtocol.HeadObjectAsyncType?
+    let headObjectSyncOverride: S3ClientProtocol.HeadObjectSyncType?
+    let listBucketAnalyticsConfigurationsAsyncOverride: S3ClientProtocol.ListBucketAnalyticsConfigurationsAsyncType?
+    let listBucketAnalyticsConfigurationsSyncOverride: S3ClientProtocol.ListBucketAnalyticsConfigurationsSyncType?
+    let listBucketInventoryConfigurationsAsyncOverride: S3ClientProtocol.ListBucketInventoryConfigurationsAsyncType?
+    let listBucketInventoryConfigurationsSyncOverride: S3ClientProtocol.ListBucketInventoryConfigurationsSyncType?
+    let listBucketMetricsConfigurationsAsyncOverride: S3ClientProtocol.ListBucketMetricsConfigurationsAsyncType?
+    let listBucketMetricsConfigurationsSyncOverride: S3ClientProtocol.ListBucketMetricsConfigurationsSyncType?
+    let listBucketsAsyncOverride: S3ClientProtocol.ListBucketsAsyncType?
+    let listBucketsSyncOverride: S3ClientProtocol.ListBucketsSyncType?
+    let listMultipartUploadsAsyncOverride: S3ClientProtocol.ListMultipartUploadsAsyncType?
+    let listMultipartUploadsSyncOverride: S3ClientProtocol.ListMultipartUploadsSyncType?
+    let listObjectVersionsAsyncOverride: S3ClientProtocol.ListObjectVersionsAsyncType?
+    let listObjectVersionsSyncOverride: S3ClientProtocol.ListObjectVersionsSyncType?
+    let listObjectsAsyncOverride: S3ClientProtocol.ListObjectsAsyncType?
+    let listObjectsSyncOverride: S3ClientProtocol.ListObjectsSyncType?
+    let listObjectsV2AsyncOverride: S3ClientProtocol.ListObjectsV2AsyncType?
+    let listObjectsV2SyncOverride: S3ClientProtocol.ListObjectsV2SyncType?
+    let listPartsAsyncOverride: S3ClientProtocol.ListPartsAsyncType?
+    let listPartsSyncOverride: S3ClientProtocol.ListPartsSyncType?
+    let putBucketAccelerateConfigurationAsyncOverride: S3ClientProtocol.PutBucketAccelerateConfigurationAsyncType?
+    let putBucketAccelerateConfigurationSyncOverride: S3ClientProtocol.PutBucketAccelerateConfigurationSyncType?
+    let putBucketAclAsyncOverride: S3ClientProtocol.PutBucketAclAsyncType?
+    let putBucketAclSyncOverride: S3ClientProtocol.PutBucketAclSyncType?
+    let putBucketAnalyticsConfigurationAsyncOverride: S3ClientProtocol.PutBucketAnalyticsConfigurationAsyncType?
+    let putBucketAnalyticsConfigurationSyncOverride: S3ClientProtocol.PutBucketAnalyticsConfigurationSyncType?
+    let putBucketCorsAsyncOverride: S3ClientProtocol.PutBucketCorsAsyncType?
+    let putBucketCorsSyncOverride: S3ClientProtocol.PutBucketCorsSyncType?
+    let putBucketEncryptionAsyncOverride: S3ClientProtocol.PutBucketEncryptionAsyncType?
+    let putBucketEncryptionSyncOverride: S3ClientProtocol.PutBucketEncryptionSyncType?
+    let putBucketInventoryConfigurationAsyncOverride: S3ClientProtocol.PutBucketInventoryConfigurationAsyncType?
+    let putBucketInventoryConfigurationSyncOverride: S3ClientProtocol.PutBucketInventoryConfigurationSyncType?
+    let putBucketLifecycleAsyncOverride: S3ClientProtocol.PutBucketLifecycleAsyncType?
+    let putBucketLifecycleSyncOverride: S3ClientProtocol.PutBucketLifecycleSyncType?
+    let putBucketLifecycleConfigurationAsyncOverride: S3ClientProtocol.PutBucketLifecycleConfigurationAsyncType?
+    let putBucketLifecycleConfigurationSyncOverride: S3ClientProtocol.PutBucketLifecycleConfigurationSyncType?
+    let putBucketLoggingAsyncOverride: S3ClientProtocol.PutBucketLoggingAsyncType?
+    let putBucketLoggingSyncOverride: S3ClientProtocol.PutBucketLoggingSyncType?
+    let putBucketMetricsConfigurationAsyncOverride: S3ClientProtocol.PutBucketMetricsConfigurationAsyncType?
+    let putBucketMetricsConfigurationSyncOverride: S3ClientProtocol.PutBucketMetricsConfigurationSyncType?
+    let putBucketNotificationAsyncOverride: S3ClientProtocol.PutBucketNotificationAsyncType?
+    let putBucketNotificationSyncOverride: S3ClientProtocol.PutBucketNotificationSyncType?
+    let putBucketNotificationConfigurationAsyncOverride: S3ClientProtocol.PutBucketNotificationConfigurationAsyncType?
+    let putBucketNotificationConfigurationSyncOverride: S3ClientProtocol.PutBucketNotificationConfigurationSyncType?
+    let putBucketPolicyAsyncOverride: S3ClientProtocol.PutBucketPolicyAsyncType?
+    let putBucketPolicySyncOverride: S3ClientProtocol.PutBucketPolicySyncType?
+    let putBucketReplicationAsyncOverride: S3ClientProtocol.PutBucketReplicationAsyncType?
+    let putBucketReplicationSyncOverride: S3ClientProtocol.PutBucketReplicationSyncType?
+    let putBucketRequestPaymentAsyncOverride: S3ClientProtocol.PutBucketRequestPaymentAsyncType?
+    let putBucketRequestPaymentSyncOverride: S3ClientProtocol.PutBucketRequestPaymentSyncType?
+    let putBucketTaggingAsyncOverride: S3ClientProtocol.PutBucketTaggingAsyncType?
+    let putBucketTaggingSyncOverride: S3ClientProtocol.PutBucketTaggingSyncType?
+    let putBucketVersioningAsyncOverride: S3ClientProtocol.PutBucketVersioningAsyncType?
+    let putBucketVersioningSyncOverride: S3ClientProtocol.PutBucketVersioningSyncType?
+    let putBucketWebsiteAsyncOverride: S3ClientProtocol.PutBucketWebsiteAsyncType?
+    let putBucketWebsiteSyncOverride: S3ClientProtocol.PutBucketWebsiteSyncType?
+    let putObjectAsyncOverride: S3ClientProtocol.PutObjectAsyncType?
+    let putObjectSyncOverride: S3ClientProtocol.PutObjectSyncType?
+    let putObjectAclAsyncOverride: S3ClientProtocol.PutObjectAclAsyncType?
+    let putObjectAclSyncOverride: S3ClientProtocol.PutObjectAclSyncType?
+    let putObjectTaggingAsyncOverride: S3ClientProtocol.PutObjectTaggingAsyncType?
+    let putObjectTaggingSyncOverride: S3ClientProtocol.PutObjectTaggingSyncType?
+    let putPublicAccessBlockAsyncOverride: S3ClientProtocol.PutPublicAccessBlockAsyncType?
+    let putPublicAccessBlockSyncOverride: S3ClientProtocol.PutPublicAccessBlockSyncType?
+    let restoreObjectAsyncOverride: S3ClientProtocol.RestoreObjectAsyncType?
+    let restoreObjectSyncOverride: S3ClientProtocol.RestoreObjectSyncType?
+    let selectObjectContentAsyncOverride: S3ClientProtocol.SelectObjectContentAsyncType?
+    let selectObjectContentSyncOverride: S3ClientProtocol.SelectObjectContentSyncType?
+    let uploadPartAsyncOverride: S3ClientProtocol.UploadPartAsyncType?
+    let uploadPartSyncOverride: S3ClientProtocol.UploadPartSyncType?
+    let uploadPartCopyAsyncOverride: S3ClientProtocol.UploadPartCopyAsyncType?
+    let uploadPartCopySyncOverride: S3ClientProtocol.UploadPartCopySyncType?
+
+    /**
+     Initializer that creates an instance of this clients. The behavior of individual
+     functions can be overridden by passing them to this initializer.
+     */
+    public init(error: Swift.Error,
+            abortMultipartUploadAsync: S3ClientProtocol.AbortMultipartUploadAsyncType? = nil,
+            abortMultipartUploadSync: S3ClientProtocol.AbortMultipartUploadSyncType? = nil,
+            completeMultipartUploadAsync: S3ClientProtocol.CompleteMultipartUploadAsyncType? = nil,
+            completeMultipartUploadSync: S3ClientProtocol.CompleteMultipartUploadSyncType? = nil,
+            copyObjectAsync: S3ClientProtocol.CopyObjectAsyncType? = nil,
+            copyObjectSync: S3ClientProtocol.CopyObjectSyncType? = nil,
+            createBucketAsync: S3ClientProtocol.CreateBucketAsyncType? = nil,
+            createBucketSync: S3ClientProtocol.CreateBucketSyncType? = nil,
+            createMultipartUploadAsync: S3ClientProtocol.CreateMultipartUploadAsyncType? = nil,
+            createMultipartUploadSync: S3ClientProtocol.CreateMultipartUploadSyncType? = nil,
+            deleteBucketAsync: S3ClientProtocol.DeleteBucketAsyncType? = nil,
+            deleteBucketSync: S3ClientProtocol.DeleteBucketSyncType? = nil,
+            deleteBucketAnalyticsConfigurationAsync: S3ClientProtocol.DeleteBucketAnalyticsConfigurationAsyncType? = nil,
+            deleteBucketAnalyticsConfigurationSync: S3ClientProtocol.DeleteBucketAnalyticsConfigurationSyncType? = nil,
+            deleteBucketCorsAsync: S3ClientProtocol.DeleteBucketCorsAsyncType? = nil,
+            deleteBucketCorsSync: S3ClientProtocol.DeleteBucketCorsSyncType? = nil,
+            deleteBucketEncryptionAsync: S3ClientProtocol.DeleteBucketEncryptionAsyncType? = nil,
+            deleteBucketEncryptionSync: S3ClientProtocol.DeleteBucketEncryptionSyncType? = nil,
+            deleteBucketInventoryConfigurationAsync: S3ClientProtocol.DeleteBucketInventoryConfigurationAsyncType? = nil,
+            deleteBucketInventoryConfigurationSync: S3ClientProtocol.DeleteBucketInventoryConfigurationSyncType? = nil,
+            deleteBucketLifecycleAsync: S3ClientProtocol.DeleteBucketLifecycleAsyncType? = nil,
+            deleteBucketLifecycleSync: S3ClientProtocol.DeleteBucketLifecycleSyncType? = nil,
+            deleteBucketMetricsConfigurationAsync: S3ClientProtocol.DeleteBucketMetricsConfigurationAsyncType? = nil,
+            deleteBucketMetricsConfigurationSync: S3ClientProtocol.DeleteBucketMetricsConfigurationSyncType? = nil,
+            deleteBucketPolicyAsync: S3ClientProtocol.DeleteBucketPolicyAsyncType? = nil,
+            deleteBucketPolicySync: S3ClientProtocol.DeleteBucketPolicySyncType? = nil,
+            deleteBucketReplicationAsync: S3ClientProtocol.DeleteBucketReplicationAsyncType? = nil,
+            deleteBucketReplicationSync: S3ClientProtocol.DeleteBucketReplicationSyncType? = nil,
+            deleteBucketTaggingAsync: S3ClientProtocol.DeleteBucketTaggingAsyncType? = nil,
+            deleteBucketTaggingSync: S3ClientProtocol.DeleteBucketTaggingSyncType? = nil,
+            deleteBucketWebsiteAsync: S3ClientProtocol.DeleteBucketWebsiteAsyncType? = nil,
+            deleteBucketWebsiteSync: S3ClientProtocol.DeleteBucketWebsiteSyncType? = nil,
+            deleteObjectAsync: S3ClientProtocol.DeleteObjectAsyncType? = nil,
+            deleteObjectSync: S3ClientProtocol.DeleteObjectSyncType? = nil,
+            deleteObjectTaggingAsync: S3ClientProtocol.DeleteObjectTaggingAsyncType? = nil,
+            deleteObjectTaggingSync: S3ClientProtocol.DeleteObjectTaggingSyncType? = nil,
+            deleteObjectsAsync: S3ClientProtocol.DeleteObjectsAsyncType? = nil,
+            deleteObjectsSync: S3ClientProtocol.DeleteObjectsSyncType? = nil,
+            deletePublicAccessBlockAsync: S3ClientProtocol.DeletePublicAccessBlockAsyncType? = nil,
+            deletePublicAccessBlockSync: S3ClientProtocol.DeletePublicAccessBlockSyncType? = nil,
+            getBucketAccelerateConfigurationAsync: S3ClientProtocol.GetBucketAccelerateConfigurationAsyncType? = nil,
+            getBucketAccelerateConfigurationSync: S3ClientProtocol.GetBucketAccelerateConfigurationSyncType? = nil,
+            getBucketAclAsync: S3ClientProtocol.GetBucketAclAsyncType? = nil,
+            getBucketAclSync: S3ClientProtocol.GetBucketAclSyncType? = nil,
+            getBucketAnalyticsConfigurationAsync: S3ClientProtocol.GetBucketAnalyticsConfigurationAsyncType? = nil,
+            getBucketAnalyticsConfigurationSync: S3ClientProtocol.GetBucketAnalyticsConfigurationSyncType? = nil,
+            getBucketCorsAsync: S3ClientProtocol.GetBucketCorsAsyncType? = nil,
+            getBucketCorsSync: S3ClientProtocol.GetBucketCorsSyncType? = nil,
+            getBucketEncryptionAsync: S3ClientProtocol.GetBucketEncryptionAsyncType? = nil,
+            getBucketEncryptionSync: S3ClientProtocol.GetBucketEncryptionSyncType? = nil,
+            getBucketInventoryConfigurationAsync: S3ClientProtocol.GetBucketInventoryConfigurationAsyncType? = nil,
+            getBucketInventoryConfigurationSync: S3ClientProtocol.GetBucketInventoryConfigurationSyncType? = nil,
+            getBucketLifecycleAsync: S3ClientProtocol.GetBucketLifecycleAsyncType? = nil,
+            getBucketLifecycleSync: S3ClientProtocol.GetBucketLifecycleSyncType? = nil,
+            getBucketLifecycleConfigurationAsync: S3ClientProtocol.GetBucketLifecycleConfigurationAsyncType? = nil,
+            getBucketLifecycleConfigurationSync: S3ClientProtocol.GetBucketLifecycleConfigurationSyncType? = nil,
+            getBucketLocationAsync: S3ClientProtocol.GetBucketLocationAsyncType? = nil,
+            getBucketLocationSync: S3ClientProtocol.GetBucketLocationSyncType? = nil,
+            getBucketLoggingAsync: S3ClientProtocol.GetBucketLoggingAsyncType? = nil,
+            getBucketLoggingSync: S3ClientProtocol.GetBucketLoggingSyncType? = nil,
+            getBucketMetricsConfigurationAsync: S3ClientProtocol.GetBucketMetricsConfigurationAsyncType? = nil,
+            getBucketMetricsConfigurationSync: S3ClientProtocol.GetBucketMetricsConfigurationSyncType? = nil,
+            getBucketNotificationAsync: S3ClientProtocol.GetBucketNotificationAsyncType? = nil,
+            getBucketNotificationSync: S3ClientProtocol.GetBucketNotificationSyncType? = nil,
+            getBucketNotificationConfigurationAsync: S3ClientProtocol.GetBucketNotificationConfigurationAsyncType? = nil,
+            getBucketNotificationConfigurationSync: S3ClientProtocol.GetBucketNotificationConfigurationSyncType? = nil,
+            getBucketPolicyAsync: S3ClientProtocol.GetBucketPolicyAsyncType? = nil,
+            getBucketPolicySync: S3ClientProtocol.GetBucketPolicySyncType? = nil,
+            getBucketPolicyStatusAsync: S3ClientProtocol.GetBucketPolicyStatusAsyncType? = nil,
+            getBucketPolicyStatusSync: S3ClientProtocol.GetBucketPolicyStatusSyncType? = nil,
+            getBucketReplicationAsync: S3ClientProtocol.GetBucketReplicationAsyncType? = nil,
+            getBucketReplicationSync: S3ClientProtocol.GetBucketReplicationSyncType? = nil,
+            getBucketRequestPaymentAsync: S3ClientProtocol.GetBucketRequestPaymentAsyncType? = nil,
+            getBucketRequestPaymentSync: S3ClientProtocol.GetBucketRequestPaymentSyncType? = nil,
+            getBucketTaggingAsync: S3ClientProtocol.GetBucketTaggingAsyncType? = nil,
+            getBucketTaggingSync: S3ClientProtocol.GetBucketTaggingSyncType? = nil,
+            getBucketVersioningAsync: S3ClientProtocol.GetBucketVersioningAsyncType? = nil,
+            getBucketVersioningSync: S3ClientProtocol.GetBucketVersioningSyncType? = nil,
+            getBucketWebsiteAsync: S3ClientProtocol.GetBucketWebsiteAsyncType? = nil,
+            getBucketWebsiteSync: S3ClientProtocol.GetBucketWebsiteSyncType? = nil,
+            getObjectAsync: S3ClientProtocol.GetObjectAsyncType? = nil,
+            getObjectSync: S3ClientProtocol.GetObjectSyncType? = nil,
+            getObjectAclAsync: S3ClientProtocol.GetObjectAclAsyncType? = nil,
+            getObjectAclSync: S3ClientProtocol.GetObjectAclSyncType? = nil,
+            getObjectTaggingAsync: S3ClientProtocol.GetObjectTaggingAsyncType? = nil,
+            getObjectTaggingSync: S3ClientProtocol.GetObjectTaggingSyncType? = nil,
+            getObjectTorrentAsync: S3ClientProtocol.GetObjectTorrentAsyncType? = nil,
+            getObjectTorrentSync: S3ClientProtocol.GetObjectTorrentSyncType? = nil,
+            getPublicAccessBlockAsync: S3ClientProtocol.GetPublicAccessBlockAsyncType? = nil,
+            getPublicAccessBlockSync: S3ClientProtocol.GetPublicAccessBlockSyncType? = nil,
+            headBucketAsync: S3ClientProtocol.HeadBucketAsyncType? = nil,
+            headBucketSync: S3ClientProtocol.HeadBucketSyncType? = nil,
+            headObjectAsync: S3ClientProtocol.HeadObjectAsyncType? = nil,
+            headObjectSync: S3ClientProtocol.HeadObjectSyncType? = nil,
+            listBucketAnalyticsConfigurationsAsync: S3ClientProtocol.ListBucketAnalyticsConfigurationsAsyncType? = nil,
+            listBucketAnalyticsConfigurationsSync: S3ClientProtocol.ListBucketAnalyticsConfigurationsSyncType? = nil,
+            listBucketInventoryConfigurationsAsync: S3ClientProtocol.ListBucketInventoryConfigurationsAsyncType? = nil,
+            listBucketInventoryConfigurationsSync: S3ClientProtocol.ListBucketInventoryConfigurationsSyncType? = nil,
+            listBucketMetricsConfigurationsAsync: S3ClientProtocol.ListBucketMetricsConfigurationsAsyncType? = nil,
+            listBucketMetricsConfigurationsSync: S3ClientProtocol.ListBucketMetricsConfigurationsSyncType? = nil,
+            listBucketsAsync: S3ClientProtocol.ListBucketsAsyncType? = nil,
+            listBucketsSync: S3ClientProtocol.ListBucketsSyncType? = nil,
+            listMultipartUploadsAsync: S3ClientProtocol.ListMultipartUploadsAsyncType? = nil,
+            listMultipartUploadsSync: S3ClientProtocol.ListMultipartUploadsSyncType? = nil,
+            listObjectVersionsAsync: S3ClientProtocol.ListObjectVersionsAsyncType? = nil,
+            listObjectVersionsSync: S3ClientProtocol.ListObjectVersionsSyncType? = nil,
+            listObjectsAsync: S3ClientProtocol.ListObjectsAsyncType? = nil,
+            listObjectsSync: S3ClientProtocol.ListObjectsSyncType? = nil,
+            listObjectsV2Async: S3ClientProtocol.ListObjectsV2AsyncType? = nil,
+            listObjectsV2Sync: S3ClientProtocol.ListObjectsV2SyncType? = nil,
+            listPartsAsync: S3ClientProtocol.ListPartsAsyncType? = nil,
+            listPartsSync: S3ClientProtocol.ListPartsSyncType? = nil,
+            putBucketAccelerateConfigurationAsync: S3ClientProtocol.PutBucketAccelerateConfigurationAsyncType? = nil,
+            putBucketAccelerateConfigurationSync: S3ClientProtocol.PutBucketAccelerateConfigurationSyncType? = nil,
+            putBucketAclAsync: S3ClientProtocol.PutBucketAclAsyncType? = nil,
+            putBucketAclSync: S3ClientProtocol.PutBucketAclSyncType? = nil,
+            putBucketAnalyticsConfigurationAsync: S3ClientProtocol.PutBucketAnalyticsConfigurationAsyncType? = nil,
+            putBucketAnalyticsConfigurationSync: S3ClientProtocol.PutBucketAnalyticsConfigurationSyncType? = nil,
+            putBucketCorsAsync: S3ClientProtocol.PutBucketCorsAsyncType? = nil,
+            putBucketCorsSync: S3ClientProtocol.PutBucketCorsSyncType? = nil,
+            putBucketEncryptionAsync: S3ClientProtocol.PutBucketEncryptionAsyncType? = nil,
+            putBucketEncryptionSync: S3ClientProtocol.PutBucketEncryptionSyncType? = nil,
+            putBucketInventoryConfigurationAsync: S3ClientProtocol.PutBucketInventoryConfigurationAsyncType? = nil,
+            putBucketInventoryConfigurationSync: S3ClientProtocol.PutBucketInventoryConfigurationSyncType? = nil,
+            putBucketLifecycleAsync: S3ClientProtocol.PutBucketLifecycleAsyncType? = nil,
+            putBucketLifecycleSync: S3ClientProtocol.PutBucketLifecycleSyncType? = nil,
+            putBucketLifecycleConfigurationAsync: S3ClientProtocol.PutBucketLifecycleConfigurationAsyncType? = nil,
+            putBucketLifecycleConfigurationSync: S3ClientProtocol.PutBucketLifecycleConfigurationSyncType? = nil,
+            putBucketLoggingAsync: S3ClientProtocol.PutBucketLoggingAsyncType? = nil,
+            putBucketLoggingSync: S3ClientProtocol.PutBucketLoggingSyncType? = nil,
+            putBucketMetricsConfigurationAsync: S3ClientProtocol.PutBucketMetricsConfigurationAsyncType? = nil,
+            putBucketMetricsConfigurationSync: S3ClientProtocol.PutBucketMetricsConfigurationSyncType? = nil,
+            putBucketNotificationAsync: S3ClientProtocol.PutBucketNotificationAsyncType? = nil,
+            putBucketNotificationSync: S3ClientProtocol.PutBucketNotificationSyncType? = nil,
+            putBucketNotificationConfigurationAsync: S3ClientProtocol.PutBucketNotificationConfigurationAsyncType? = nil,
+            putBucketNotificationConfigurationSync: S3ClientProtocol.PutBucketNotificationConfigurationSyncType? = nil,
+            putBucketPolicyAsync: S3ClientProtocol.PutBucketPolicyAsyncType? = nil,
+            putBucketPolicySync: S3ClientProtocol.PutBucketPolicySyncType? = nil,
+            putBucketReplicationAsync: S3ClientProtocol.PutBucketReplicationAsyncType? = nil,
+            putBucketReplicationSync: S3ClientProtocol.PutBucketReplicationSyncType? = nil,
+            putBucketRequestPaymentAsync: S3ClientProtocol.PutBucketRequestPaymentAsyncType? = nil,
+            putBucketRequestPaymentSync: S3ClientProtocol.PutBucketRequestPaymentSyncType? = nil,
+            putBucketTaggingAsync: S3ClientProtocol.PutBucketTaggingAsyncType? = nil,
+            putBucketTaggingSync: S3ClientProtocol.PutBucketTaggingSyncType? = nil,
+            putBucketVersioningAsync: S3ClientProtocol.PutBucketVersioningAsyncType? = nil,
+            putBucketVersioningSync: S3ClientProtocol.PutBucketVersioningSyncType? = nil,
+            putBucketWebsiteAsync: S3ClientProtocol.PutBucketWebsiteAsyncType? = nil,
+            putBucketWebsiteSync: S3ClientProtocol.PutBucketWebsiteSyncType? = nil,
+            putObjectAsync: S3ClientProtocol.PutObjectAsyncType? = nil,
+            putObjectSync: S3ClientProtocol.PutObjectSyncType? = nil,
+            putObjectAclAsync: S3ClientProtocol.PutObjectAclAsyncType? = nil,
+            putObjectAclSync: S3ClientProtocol.PutObjectAclSyncType? = nil,
+            putObjectTaggingAsync: S3ClientProtocol.PutObjectTaggingAsyncType? = nil,
+            putObjectTaggingSync: S3ClientProtocol.PutObjectTaggingSyncType? = nil,
+            putPublicAccessBlockAsync: S3ClientProtocol.PutPublicAccessBlockAsyncType? = nil,
+            putPublicAccessBlockSync: S3ClientProtocol.PutPublicAccessBlockSyncType? = nil,
+            restoreObjectAsync: S3ClientProtocol.RestoreObjectAsyncType? = nil,
+            restoreObjectSync: S3ClientProtocol.RestoreObjectSyncType? = nil,
+            selectObjectContentAsync: S3ClientProtocol.SelectObjectContentAsyncType? = nil,
+            selectObjectContentSync: S3ClientProtocol.SelectObjectContentSyncType? = nil,
+            uploadPartAsync: S3ClientProtocol.UploadPartAsyncType? = nil,
+            uploadPartSync: S3ClientProtocol.UploadPartSyncType? = nil,
+            uploadPartCopyAsync: S3ClientProtocol.UploadPartCopyAsyncType? = nil,
+            uploadPartCopySync: S3ClientProtocol.UploadPartCopySyncType? = nil) {
+        self.error = error
+        self.abortMultipartUploadAsyncOverride = abortMultipartUploadAsync
+        self.abortMultipartUploadSyncOverride = abortMultipartUploadSync
+        self.completeMultipartUploadAsyncOverride = completeMultipartUploadAsync
+        self.completeMultipartUploadSyncOverride = completeMultipartUploadSync
+        self.copyObjectAsyncOverride = copyObjectAsync
+        self.copyObjectSyncOverride = copyObjectSync
+        self.createBucketAsyncOverride = createBucketAsync
+        self.createBucketSyncOverride = createBucketSync
+        self.createMultipartUploadAsyncOverride = createMultipartUploadAsync
+        self.createMultipartUploadSyncOverride = createMultipartUploadSync
+        self.deleteBucketAsyncOverride = deleteBucketAsync
+        self.deleteBucketSyncOverride = deleteBucketSync
+        self.deleteBucketAnalyticsConfigurationAsyncOverride = deleteBucketAnalyticsConfigurationAsync
+        self.deleteBucketAnalyticsConfigurationSyncOverride = deleteBucketAnalyticsConfigurationSync
+        self.deleteBucketCorsAsyncOverride = deleteBucketCorsAsync
+        self.deleteBucketCorsSyncOverride = deleteBucketCorsSync
+        self.deleteBucketEncryptionAsyncOverride = deleteBucketEncryptionAsync
+        self.deleteBucketEncryptionSyncOverride = deleteBucketEncryptionSync
+        self.deleteBucketInventoryConfigurationAsyncOverride = deleteBucketInventoryConfigurationAsync
+        self.deleteBucketInventoryConfigurationSyncOverride = deleteBucketInventoryConfigurationSync
+        self.deleteBucketLifecycleAsyncOverride = deleteBucketLifecycleAsync
+        self.deleteBucketLifecycleSyncOverride = deleteBucketLifecycleSync
+        self.deleteBucketMetricsConfigurationAsyncOverride = deleteBucketMetricsConfigurationAsync
+        self.deleteBucketMetricsConfigurationSyncOverride = deleteBucketMetricsConfigurationSync
+        self.deleteBucketPolicyAsyncOverride = deleteBucketPolicyAsync
+        self.deleteBucketPolicySyncOverride = deleteBucketPolicySync
+        self.deleteBucketReplicationAsyncOverride = deleteBucketReplicationAsync
+        self.deleteBucketReplicationSyncOverride = deleteBucketReplicationSync
+        self.deleteBucketTaggingAsyncOverride = deleteBucketTaggingAsync
+        self.deleteBucketTaggingSyncOverride = deleteBucketTaggingSync
+        self.deleteBucketWebsiteAsyncOverride = deleteBucketWebsiteAsync
+        self.deleteBucketWebsiteSyncOverride = deleteBucketWebsiteSync
+        self.deleteObjectAsyncOverride = deleteObjectAsync
+        self.deleteObjectSyncOverride = deleteObjectSync
+        self.deleteObjectTaggingAsyncOverride = deleteObjectTaggingAsync
+        self.deleteObjectTaggingSyncOverride = deleteObjectTaggingSync
+        self.deleteObjectsAsyncOverride = deleteObjectsAsync
+        self.deleteObjectsSyncOverride = deleteObjectsSync
+        self.deletePublicAccessBlockAsyncOverride = deletePublicAccessBlockAsync
+        self.deletePublicAccessBlockSyncOverride = deletePublicAccessBlockSync
+        self.getBucketAccelerateConfigurationAsyncOverride = getBucketAccelerateConfigurationAsync
+        self.getBucketAccelerateConfigurationSyncOverride = getBucketAccelerateConfigurationSync
+        self.getBucketAclAsyncOverride = getBucketAclAsync
+        self.getBucketAclSyncOverride = getBucketAclSync
+        self.getBucketAnalyticsConfigurationAsyncOverride = getBucketAnalyticsConfigurationAsync
+        self.getBucketAnalyticsConfigurationSyncOverride = getBucketAnalyticsConfigurationSync
+        self.getBucketCorsAsyncOverride = getBucketCorsAsync
+        self.getBucketCorsSyncOverride = getBucketCorsSync
+        self.getBucketEncryptionAsyncOverride = getBucketEncryptionAsync
+        self.getBucketEncryptionSyncOverride = getBucketEncryptionSync
+        self.getBucketInventoryConfigurationAsyncOverride = getBucketInventoryConfigurationAsync
+        self.getBucketInventoryConfigurationSyncOverride = getBucketInventoryConfigurationSync
+        self.getBucketLifecycleAsyncOverride = getBucketLifecycleAsync
+        self.getBucketLifecycleSyncOverride = getBucketLifecycleSync
+        self.getBucketLifecycleConfigurationAsyncOverride = getBucketLifecycleConfigurationAsync
+        self.getBucketLifecycleConfigurationSyncOverride = getBucketLifecycleConfigurationSync
+        self.getBucketLocationAsyncOverride = getBucketLocationAsync
+        self.getBucketLocationSyncOverride = getBucketLocationSync
+        self.getBucketLoggingAsyncOverride = getBucketLoggingAsync
+        self.getBucketLoggingSyncOverride = getBucketLoggingSync
+        self.getBucketMetricsConfigurationAsyncOverride = getBucketMetricsConfigurationAsync
+        self.getBucketMetricsConfigurationSyncOverride = getBucketMetricsConfigurationSync
+        self.getBucketNotificationAsyncOverride = getBucketNotificationAsync
+        self.getBucketNotificationSyncOverride = getBucketNotificationSync
+        self.getBucketNotificationConfigurationAsyncOverride = getBucketNotificationConfigurationAsync
+        self.getBucketNotificationConfigurationSyncOverride = getBucketNotificationConfigurationSync
+        self.getBucketPolicyAsyncOverride = getBucketPolicyAsync
+        self.getBucketPolicySyncOverride = getBucketPolicySync
+        self.getBucketPolicyStatusAsyncOverride = getBucketPolicyStatusAsync
+        self.getBucketPolicyStatusSyncOverride = getBucketPolicyStatusSync
+        self.getBucketReplicationAsyncOverride = getBucketReplicationAsync
+        self.getBucketReplicationSyncOverride = getBucketReplicationSync
+        self.getBucketRequestPaymentAsyncOverride = getBucketRequestPaymentAsync
+        self.getBucketRequestPaymentSyncOverride = getBucketRequestPaymentSync
+        self.getBucketTaggingAsyncOverride = getBucketTaggingAsync
+        self.getBucketTaggingSyncOverride = getBucketTaggingSync
+        self.getBucketVersioningAsyncOverride = getBucketVersioningAsync
+        self.getBucketVersioningSyncOverride = getBucketVersioningSync
+        self.getBucketWebsiteAsyncOverride = getBucketWebsiteAsync
+        self.getBucketWebsiteSyncOverride = getBucketWebsiteSync
+        self.getObjectAsyncOverride = getObjectAsync
+        self.getObjectSyncOverride = getObjectSync
+        self.getObjectAclAsyncOverride = getObjectAclAsync
+        self.getObjectAclSyncOverride = getObjectAclSync
+        self.getObjectTaggingAsyncOverride = getObjectTaggingAsync
+        self.getObjectTaggingSyncOverride = getObjectTaggingSync
+        self.getObjectTorrentAsyncOverride = getObjectTorrentAsync
+        self.getObjectTorrentSyncOverride = getObjectTorrentSync
+        self.getPublicAccessBlockAsyncOverride = getPublicAccessBlockAsync
+        self.getPublicAccessBlockSyncOverride = getPublicAccessBlockSync
+        self.headBucketAsyncOverride = headBucketAsync
+        self.headBucketSyncOverride = headBucketSync
+        self.headObjectAsyncOverride = headObjectAsync
+        self.headObjectSyncOverride = headObjectSync
+        self.listBucketAnalyticsConfigurationsAsyncOverride = listBucketAnalyticsConfigurationsAsync
+        self.listBucketAnalyticsConfigurationsSyncOverride = listBucketAnalyticsConfigurationsSync
+        self.listBucketInventoryConfigurationsAsyncOverride = listBucketInventoryConfigurationsAsync
+        self.listBucketInventoryConfigurationsSyncOverride = listBucketInventoryConfigurationsSync
+        self.listBucketMetricsConfigurationsAsyncOverride = listBucketMetricsConfigurationsAsync
+        self.listBucketMetricsConfigurationsSyncOverride = listBucketMetricsConfigurationsSync
+        self.listBucketsAsyncOverride = listBucketsAsync
+        self.listBucketsSyncOverride = listBucketsSync
+        self.listMultipartUploadsAsyncOverride = listMultipartUploadsAsync
+        self.listMultipartUploadsSyncOverride = listMultipartUploadsSync
+        self.listObjectVersionsAsyncOverride = listObjectVersionsAsync
+        self.listObjectVersionsSyncOverride = listObjectVersionsSync
+        self.listObjectsAsyncOverride = listObjectsAsync
+        self.listObjectsSyncOverride = listObjectsSync
+        self.listObjectsV2AsyncOverride = listObjectsV2Async
+        self.listObjectsV2SyncOverride = listObjectsV2Sync
+        self.listPartsAsyncOverride = listPartsAsync
+        self.listPartsSyncOverride = listPartsSync
+        self.putBucketAccelerateConfigurationAsyncOverride = putBucketAccelerateConfigurationAsync
+        self.putBucketAccelerateConfigurationSyncOverride = putBucketAccelerateConfigurationSync
+        self.putBucketAclAsyncOverride = putBucketAclAsync
+        self.putBucketAclSyncOverride = putBucketAclSync
+        self.putBucketAnalyticsConfigurationAsyncOverride = putBucketAnalyticsConfigurationAsync
+        self.putBucketAnalyticsConfigurationSyncOverride = putBucketAnalyticsConfigurationSync
+        self.putBucketCorsAsyncOverride = putBucketCorsAsync
+        self.putBucketCorsSyncOverride = putBucketCorsSync
+        self.putBucketEncryptionAsyncOverride = putBucketEncryptionAsync
+        self.putBucketEncryptionSyncOverride = putBucketEncryptionSync
+        self.putBucketInventoryConfigurationAsyncOverride = putBucketInventoryConfigurationAsync
+        self.putBucketInventoryConfigurationSyncOverride = putBucketInventoryConfigurationSync
+        self.putBucketLifecycleAsyncOverride = putBucketLifecycleAsync
+        self.putBucketLifecycleSyncOverride = putBucketLifecycleSync
+        self.putBucketLifecycleConfigurationAsyncOverride = putBucketLifecycleConfigurationAsync
+        self.putBucketLifecycleConfigurationSyncOverride = putBucketLifecycleConfigurationSync
+        self.putBucketLoggingAsyncOverride = putBucketLoggingAsync
+        self.putBucketLoggingSyncOverride = putBucketLoggingSync
+        self.putBucketMetricsConfigurationAsyncOverride = putBucketMetricsConfigurationAsync
+        self.putBucketMetricsConfigurationSyncOverride = putBucketMetricsConfigurationSync
+        self.putBucketNotificationAsyncOverride = putBucketNotificationAsync
+        self.putBucketNotificationSyncOverride = putBucketNotificationSync
+        self.putBucketNotificationConfigurationAsyncOverride = putBucketNotificationConfigurationAsync
+        self.putBucketNotificationConfigurationSyncOverride = putBucketNotificationConfigurationSync
+        self.putBucketPolicyAsyncOverride = putBucketPolicyAsync
+        self.putBucketPolicySyncOverride = putBucketPolicySync
+        self.putBucketReplicationAsyncOverride = putBucketReplicationAsync
+        self.putBucketReplicationSyncOverride = putBucketReplicationSync
+        self.putBucketRequestPaymentAsyncOverride = putBucketRequestPaymentAsync
+        self.putBucketRequestPaymentSyncOverride = putBucketRequestPaymentSync
+        self.putBucketTaggingAsyncOverride = putBucketTaggingAsync
+        self.putBucketTaggingSyncOverride = putBucketTaggingSync
+        self.putBucketVersioningAsyncOverride = putBucketVersioningAsync
+        self.putBucketVersioningSyncOverride = putBucketVersioningSync
+        self.putBucketWebsiteAsyncOverride = putBucketWebsiteAsync
+        self.putBucketWebsiteSyncOverride = putBucketWebsiteSync
+        self.putObjectAsyncOverride = putObjectAsync
+        self.putObjectSyncOverride = putObjectSync
+        self.putObjectAclAsyncOverride = putObjectAclAsync
+        self.putObjectAclSyncOverride = putObjectAclSync
+        self.putObjectTaggingAsyncOverride = putObjectTaggingAsync
+        self.putObjectTaggingSyncOverride = putObjectTaggingSync
+        self.putPublicAccessBlockAsyncOverride = putPublicAccessBlockAsync
+        self.putPublicAccessBlockSyncOverride = putPublicAccessBlockSync
+        self.restoreObjectAsyncOverride = restoreObjectAsync
+        self.restoreObjectSyncOverride = restoreObjectSync
+        self.selectObjectContentAsyncOverride = selectObjectContentAsync
+        self.selectObjectContentSyncOverride = selectObjectContentSync
+        self.uploadPartAsyncOverride = uploadPartAsync
+        self.uploadPartSyncOverride = uploadPartSync
+        self.uploadPartCopyAsyncOverride = uploadPartCopyAsync
+        self.uploadPartCopySyncOverride = uploadPartCopySync
+    }
+
+    /**
+     Invokes the AbortMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated AbortMultipartUploadRequest object being passed to this operation.
+         - completion: The AbortMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The AbortMultipartUploadOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchUpload.
+     */
+    public func abortMultipartUploadAsync(input: S3Model.AbortMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.AbortMultipartUploadOutput>) -> ()) throws {
+        if let abortMultipartUploadAsyncOverride = abortMultipartUploadAsyncOverride {
+            return try abortMultipartUploadAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the AbortMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated AbortMultipartUploadRequest object being passed to this operation.
+     - Returns: The AbortMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchUpload.
+     */
+    public func abortMultipartUploadSync(input: S3Model.AbortMultipartUploadRequest) throws -> S3Model.AbortMultipartUploadOutput {
+        if let abortMultipartUploadSyncOverride = abortMultipartUploadSyncOverride {
+            return try abortMultipartUploadSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the CompleteMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CompleteMultipartUploadRequest object being passed to this operation.
+         - completion: The CompleteMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The CompleteMultipartUploadOutput
+           object will be validated before being returned to caller.
+     */
+    public func completeMultipartUploadAsync(input: S3Model.CompleteMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.CompleteMultipartUploadOutput>) -> ()) throws {
+        if let completeMultipartUploadAsyncOverride = completeMultipartUploadAsyncOverride {
+            return try completeMultipartUploadAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the CompleteMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CompleteMultipartUploadRequest object being passed to this operation.
+     - Returns: The CompleteMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func completeMultipartUploadSync(input: S3Model.CompleteMultipartUploadRequest) throws -> S3Model.CompleteMultipartUploadOutput {
+        if let completeMultipartUploadSyncOverride = completeMultipartUploadSyncOverride {
+            return try completeMultipartUploadSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the CopyObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CopyObjectRequest object being passed to this operation.
+         - completion: The CopyObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The CopyObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: objectNotInActiveTier.
+     */
+    public func copyObjectAsync(input: S3Model.CopyObjectRequest, completion: @escaping (HTTPResult<S3Model.CopyObjectOutput>) -> ()) throws {
+        if let copyObjectAsyncOverride = copyObjectAsyncOverride {
+            return try copyObjectAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the CopyObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CopyObjectRequest object being passed to this operation.
+     - Returns: The CopyObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: objectNotInActiveTier.
+     */
+    public func copyObjectSync(input: S3Model.CopyObjectRequest) throws -> S3Model.CopyObjectOutput {
+        if let copyObjectSyncOverride = copyObjectSyncOverride {
+            return try copyObjectSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the CreateBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CreateBucketRequest object being passed to this operation.
+         - completion: The CreateBucketOutput object or an error will be passed to this 
+           callback when the operation is complete. The CreateBucketOutput
+           object will be validated before being returned to caller.
+           The possible errors are: bucketAlreadyExists, bucketAlreadyOwnedByYou.
+     */
+    public func createBucketAsync(input: S3Model.CreateBucketRequest, completion: @escaping (HTTPResult<S3Model.CreateBucketOutput>) -> ()) throws {
+        if let createBucketAsyncOverride = createBucketAsyncOverride {
+            return try createBucketAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the CreateBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CreateBucketRequest object being passed to this operation.
+     - Returns: The CreateBucketOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: bucketAlreadyExists, bucketAlreadyOwnedByYou.
+     */
+    public func createBucketSync(input: S3Model.CreateBucketRequest) throws -> S3Model.CreateBucketOutput {
+        if let createBucketSyncOverride = createBucketSyncOverride {
+            return try createBucketSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the CreateMultipartUpload operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated CreateMultipartUploadRequest object being passed to this operation.
+         - completion: The CreateMultipartUploadOutput object or an error will be passed to this 
+           callback when the operation is complete. The CreateMultipartUploadOutput
+           object will be validated before being returned to caller.
+     */
+    public func createMultipartUploadAsync(input: S3Model.CreateMultipartUploadRequest, completion: @escaping (HTTPResult<S3Model.CreateMultipartUploadOutput>) -> ()) throws {
+        if let createMultipartUploadAsyncOverride = createMultipartUploadAsyncOverride {
+            return try createMultipartUploadAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the CreateMultipartUpload operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated CreateMultipartUploadRequest object being passed to this operation.
+     - Returns: The CreateMultipartUploadOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func createMultipartUploadSync(input: S3Model.CreateMultipartUploadRequest) throws -> S3Model.CreateMultipartUploadOutput {
+        if let createMultipartUploadSyncOverride = createMultipartUploadSyncOverride {
+            return try createMultipartUploadSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketAsync(input: S3Model.DeleteBucketRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketAsyncOverride = deleteBucketAsyncOverride {
+            return try deleteBucketAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketRequest object being passed to this operation.
+     */
+    public func deleteBucketSync(input: S3Model.DeleteBucketRequest) throws {
+        if let deleteBucketSyncOverride = deleteBucketSyncOverride {
+            return try deleteBucketSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketAnalyticsConfigurationAsync(input: S3Model.DeleteBucketAnalyticsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketAnalyticsConfigurationAsyncOverride = deleteBucketAnalyticsConfigurationAsyncOverride {
+            return try deleteBucketAnalyticsConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketAnalyticsConfigurationRequest object being passed to this operation.
+     */
+    public func deleteBucketAnalyticsConfigurationSync(input: S3Model.DeleteBucketAnalyticsConfigurationRequest) throws {
+        if let deleteBucketAnalyticsConfigurationSyncOverride = deleteBucketAnalyticsConfigurationSyncOverride {
+            return try deleteBucketAnalyticsConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketCorsRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketCorsAsync(input: S3Model.DeleteBucketCorsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketCorsAsyncOverride = deleteBucketCorsAsyncOverride {
+            return try deleteBucketCorsAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketCorsRequest object being passed to this operation.
+     */
+    public func deleteBucketCorsSync(input: S3Model.DeleteBucketCorsRequest) throws {
+        if let deleteBucketCorsSyncOverride = deleteBucketCorsSyncOverride {
+            return try deleteBucketCorsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketEncryptionRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketEncryptionAsync(input: S3Model.DeleteBucketEncryptionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketEncryptionAsyncOverride = deleteBucketEncryptionAsyncOverride {
+            return try deleteBucketEncryptionAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketEncryptionRequest object being passed to this operation.
+     */
+    public func deleteBucketEncryptionSync(input: S3Model.DeleteBucketEncryptionRequest) throws {
+        if let deleteBucketEncryptionSyncOverride = deleteBucketEncryptionSyncOverride {
+            return try deleteBucketEncryptionSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketInventoryConfigurationAsync(input: S3Model.DeleteBucketInventoryConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketInventoryConfigurationAsyncOverride = deleteBucketInventoryConfigurationAsyncOverride {
+            return try deleteBucketInventoryConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketInventoryConfigurationRequest object being passed to this operation.
+     */
+    public func deleteBucketInventoryConfigurationSync(input: S3Model.DeleteBucketInventoryConfigurationRequest) throws {
+        if let deleteBucketInventoryConfigurationSyncOverride = deleteBucketInventoryConfigurationSyncOverride {
+            return try deleteBucketInventoryConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketLifecycleRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketLifecycleAsync(input: S3Model.DeleteBucketLifecycleRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketLifecycleAsyncOverride = deleteBucketLifecycleAsyncOverride {
+            return try deleteBucketLifecycleAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketLifecycleRequest object being passed to this operation.
+     */
+    public func deleteBucketLifecycleSync(input: S3Model.DeleteBucketLifecycleRequest) throws {
+        if let deleteBucketLifecycleSyncOverride = deleteBucketLifecycleSyncOverride {
+            return try deleteBucketLifecycleSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketMetricsConfigurationAsync(input: S3Model.DeleteBucketMetricsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketMetricsConfigurationAsyncOverride = deleteBucketMetricsConfigurationAsyncOverride {
+            return try deleteBucketMetricsConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketMetricsConfigurationRequest object being passed to this operation.
+     */
+    public func deleteBucketMetricsConfigurationSync(input: S3Model.DeleteBucketMetricsConfigurationRequest) throws {
+        if let deleteBucketMetricsConfigurationSyncOverride = deleteBucketMetricsConfigurationSyncOverride {
+            return try deleteBucketMetricsConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketPolicyRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketPolicyAsync(input: S3Model.DeleteBucketPolicyRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketPolicyAsyncOverride = deleteBucketPolicyAsyncOverride {
+            return try deleteBucketPolicyAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketPolicyRequest object being passed to this operation.
+     */
+    public func deleteBucketPolicySync(input: S3Model.DeleteBucketPolicyRequest) throws {
+        if let deleteBucketPolicySyncOverride = deleteBucketPolicySyncOverride {
+            return try deleteBucketPolicySyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketReplicationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketReplicationAsync(input: S3Model.DeleteBucketReplicationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketReplicationAsyncOverride = deleteBucketReplicationAsyncOverride {
+            return try deleteBucketReplicationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketReplicationRequest object being passed to this operation.
+     */
+    public func deleteBucketReplicationSync(input: S3Model.DeleteBucketReplicationRequest) throws {
+        if let deleteBucketReplicationSyncOverride = deleteBucketReplicationSyncOverride {
+            return try deleteBucketReplicationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketTaggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketTaggingAsync(input: S3Model.DeleteBucketTaggingRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketTaggingAsyncOverride = deleteBucketTaggingAsyncOverride {
+            return try deleteBucketTaggingAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketTaggingRequest object being passed to this operation.
+     */
+    public func deleteBucketTaggingSync(input: S3Model.DeleteBucketTaggingRequest) throws {
+        if let deleteBucketTaggingSyncOverride = deleteBucketTaggingSyncOverride {
+            return try deleteBucketTaggingSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteBucketWebsiteRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deleteBucketWebsiteAsync(input: S3Model.DeleteBucketWebsiteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deleteBucketWebsiteAsyncOverride = deleteBucketWebsiteAsyncOverride {
+            return try deleteBucketWebsiteAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeleteBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteBucketWebsiteRequest object being passed to this operation.
+     */
+    public func deleteBucketWebsiteSync(input: S3Model.DeleteBucketWebsiteRequest) throws {
+        if let deleteBucketWebsiteSyncOverride = deleteBucketWebsiteSyncOverride {
+            return try deleteBucketWebsiteSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectRequest object being passed to this operation.
+         - completion: The DeleteObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectOutput
+           object will be validated before being returned to caller.
+     */
+    public func deleteObjectAsync(input: S3Model.DeleteObjectRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectOutput>) -> ()) throws {
+        if let deleteObjectAsyncOverride = deleteObjectAsyncOverride {
+            return try deleteObjectAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the DeleteObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectRequest object being passed to this operation.
+     - Returns: The DeleteObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func deleteObjectSync(input: S3Model.DeleteObjectRequest) throws -> S3Model.DeleteObjectOutput {
+        if let deleteObjectSyncOverride = deleteObjectSyncOverride {
+            return try deleteObjectSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectTaggingRequest object being passed to this operation.
+         - completion: The DeleteObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func deleteObjectTaggingAsync(input: S3Model.DeleteObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectTaggingOutput>) -> ()) throws {
+        if let deleteObjectTaggingAsyncOverride = deleteObjectTaggingAsyncOverride {
+            return try deleteObjectTaggingAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the DeleteObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectTaggingRequest object being passed to this operation.
+     - Returns: The DeleteObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func deleteObjectTaggingSync(input: S3Model.DeleteObjectTaggingRequest) throws -> S3Model.DeleteObjectTaggingOutput {
+        if let deleteObjectTaggingSyncOverride = deleteObjectTaggingSyncOverride {
+            return try deleteObjectTaggingSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeleteObjects operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeleteObjectsRequest object being passed to this operation.
+         - completion: The DeleteObjectsOutput object or an error will be passed to this 
+           callback when the operation is complete. The DeleteObjectsOutput
+           object will be validated before being returned to caller.
+     */
+    public func deleteObjectsAsync(input: S3Model.DeleteObjectsRequest, completion: @escaping (HTTPResult<S3Model.DeleteObjectsOutput>) -> ()) throws {
+        if let deleteObjectsAsyncOverride = deleteObjectsAsyncOverride {
+            return try deleteObjectsAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the DeleteObjects operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeleteObjectsRequest object being passed to this operation.
+     - Returns: The DeleteObjectsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func deleteObjectsSync(input: S3Model.DeleteObjectsRequest) throws -> S3Model.DeleteObjectsOutput {
+        if let deleteObjectsSyncOverride = deleteObjectsSyncOverride {
+            return try deleteObjectsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the DeletePublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated DeletePublicAccessBlockRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func deletePublicAccessBlockAsync(input: S3Model.DeletePublicAccessBlockRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let deletePublicAccessBlockAsyncOverride = deletePublicAccessBlockAsyncOverride {
+            return try deletePublicAccessBlockAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the DeletePublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated DeletePublicAccessBlockRequest object being passed to this operation.
+     */
+    public func deletePublicAccessBlockSync(input: S3Model.DeletePublicAccessBlockRequest) throws {
+        if let deletePublicAccessBlockSyncOverride = deletePublicAccessBlockSyncOverride {
+            return try deletePublicAccessBlockSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketAccelerateConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAccelerateConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketAccelerateConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAccelerateConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketAccelerateConfigurationAsync(input: S3Model.GetBucketAccelerateConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAccelerateConfigurationOutput>) -> ()) throws {
+        if let getBucketAccelerateConfigurationAsyncOverride = getBucketAccelerateConfigurationAsyncOverride {
+            return try getBucketAccelerateConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketAccelerateConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAccelerateConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketAccelerateConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketAccelerateConfigurationSync(input: S3Model.GetBucketAccelerateConfigurationRequest) throws -> S3Model.GetBucketAccelerateConfigurationOutput {
+        if let getBucketAccelerateConfigurationSyncOverride = getBucketAccelerateConfigurationSyncOverride {
+            return try getBucketAccelerateConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAclRequest object being passed to this operation.
+         - completion: The GetBucketAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAclOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketAclAsync(input: S3Model.GetBucketAclRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAclOutput>) -> ()) throws {
+        if let getBucketAclAsyncOverride = getBucketAclAsyncOverride {
+            return try getBucketAclAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAclRequest object being passed to this operation.
+     - Returns: The GetBucketAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketAclSync(input: S3Model.GetBucketAclRequest) throws -> S3Model.GetBucketAclOutput {
+        if let getBucketAclSyncOverride = getBucketAclSyncOverride {
+            return try getBucketAclSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketAnalyticsConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketAnalyticsConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketAnalyticsConfigurationAsync(input: S3Model.GetBucketAnalyticsConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketAnalyticsConfigurationOutput>) -> ()) throws {
+        if let getBucketAnalyticsConfigurationAsyncOverride = getBucketAnalyticsConfigurationAsyncOverride {
+            return try getBucketAnalyticsConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketAnalyticsConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketAnalyticsConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketAnalyticsConfigurationSync(input: S3Model.GetBucketAnalyticsConfigurationRequest) throws -> S3Model.GetBucketAnalyticsConfigurationOutput {
+        if let getBucketAnalyticsConfigurationSyncOverride = getBucketAnalyticsConfigurationSyncOverride {
+            return try getBucketAnalyticsConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketCorsRequest object being passed to this operation.
+         - completion: The GetBucketCorsOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketCorsOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketCorsAsync(input: S3Model.GetBucketCorsRequest, completion: @escaping (HTTPResult<S3Model.GetBucketCorsOutput>) -> ()) throws {
+        if let getBucketCorsAsyncOverride = getBucketCorsAsyncOverride {
+            return try getBucketCorsAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketCorsRequest object being passed to this operation.
+     - Returns: The GetBucketCorsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketCorsSync(input: S3Model.GetBucketCorsRequest) throws -> S3Model.GetBucketCorsOutput {
+        if let getBucketCorsSyncOverride = getBucketCorsSyncOverride {
+            return try getBucketCorsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketEncryptionRequest object being passed to this operation.
+         - completion: The GetBucketEncryptionOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketEncryptionOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketEncryptionAsync(input: S3Model.GetBucketEncryptionRequest, completion: @escaping (HTTPResult<S3Model.GetBucketEncryptionOutput>) -> ()) throws {
+        if let getBucketEncryptionAsyncOverride = getBucketEncryptionAsyncOverride {
+            return try getBucketEncryptionAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketEncryptionRequest object being passed to this operation.
+     - Returns: The GetBucketEncryptionOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketEncryptionSync(input: S3Model.GetBucketEncryptionRequest) throws -> S3Model.GetBucketEncryptionOutput {
+        if let getBucketEncryptionSyncOverride = getBucketEncryptionSyncOverride {
+            return try getBucketEncryptionSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketInventoryConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketInventoryConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketInventoryConfigurationAsync(input: S3Model.GetBucketInventoryConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketInventoryConfigurationOutput>) -> ()) throws {
+        if let getBucketInventoryConfigurationAsyncOverride = getBucketInventoryConfigurationAsyncOverride {
+            return try getBucketInventoryConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketInventoryConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketInventoryConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketInventoryConfigurationSync(input: S3Model.GetBucketInventoryConfigurationRequest) throws -> S3Model.GetBucketInventoryConfigurationOutput {
+        if let getBucketInventoryConfigurationSyncOverride = getBucketInventoryConfigurationSyncOverride {
+            return try getBucketInventoryConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleRequest object being passed to this operation.
+         - completion: The GetBucketLifecycleOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLifecycleOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleAsync(input: S3Model.GetBucketLifecycleRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLifecycleOutput>) -> ()) throws {
+        if let getBucketLifecycleAsyncOverride = getBucketLifecycleAsyncOverride {
+            return try getBucketLifecycleAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleRequest object being passed to this operation.
+     - Returns: The GetBucketLifecycleOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleSync(input: S3Model.GetBucketLifecycleRequest) throws -> S3Model.GetBucketLifecycleOutput {
+        if let getBucketLifecycleSyncOverride = getBucketLifecycleSyncOverride {
+            return try getBucketLifecycleSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketLifecycleConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketLifecycleConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLifecycleConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleConfigurationAsync(input: S3Model.GetBucketLifecycleConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLifecycleConfigurationOutput>) -> ()) throws {
+        if let getBucketLifecycleConfigurationAsyncOverride = getBucketLifecycleConfigurationAsyncOverride {
+            return try getBucketLifecycleConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketLifecycleConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLifecycleConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketLifecycleConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLifecycleConfigurationSync(input: S3Model.GetBucketLifecycleConfigurationRequest) throws -> S3Model.GetBucketLifecycleConfigurationOutput {
+        if let getBucketLifecycleConfigurationSyncOverride = getBucketLifecycleConfigurationSyncOverride {
+            return try getBucketLifecycleConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketLocation operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLocationRequest object being passed to this operation.
+         - completion: The GetBucketLocationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLocationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLocationAsync(input: S3Model.GetBucketLocationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLocationOutput>) -> ()) throws {
+        if let getBucketLocationAsyncOverride = getBucketLocationAsyncOverride {
+            return try getBucketLocationAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketLocation operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLocationRequest object being passed to this operation.
+     - Returns: The GetBucketLocationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLocationSync(input: S3Model.GetBucketLocationRequest) throws -> S3Model.GetBucketLocationOutput {
+        if let getBucketLocationSyncOverride = getBucketLocationSyncOverride {
+            return try getBucketLocationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketLogging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketLoggingRequest object being passed to this operation.
+         - completion: The GetBucketLoggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketLoggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketLoggingAsync(input: S3Model.GetBucketLoggingRequest, completion: @escaping (HTTPResult<S3Model.GetBucketLoggingOutput>) -> ()) throws {
+        if let getBucketLoggingAsyncOverride = getBucketLoggingAsyncOverride {
+            return try getBucketLoggingAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketLogging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketLoggingRequest object being passed to this operation.
+     - Returns: The GetBucketLoggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketLoggingSync(input: S3Model.GetBucketLoggingRequest) throws -> S3Model.GetBucketLoggingOutput {
+        if let getBucketLoggingSyncOverride = getBucketLoggingSyncOverride {
+            return try getBucketLoggingSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: The GetBucketMetricsConfigurationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketMetricsConfigurationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketMetricsConfigurationAsync(input: S3Model.GetBucketMetricsConfigurationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketMetricsConfigurationOutput>) -> ()) throws {
+        if let getBucketMetricsConfigurationAsyncOverride = getBucketMetricsConfigurationAsyncOverride {
+            return try getBucketMetricsConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketMetricsConfigurationRequest object being passed to this operation.
+     - Returns: The GetBucketMetricsConfigurationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketMetricsConfigurationSync(input: S3Model.GetBucketMetricsConfigurationRequest) throws -> S3Model.GetBucketMetricsConfigurationOutput {
+        if let getBucketMetricsConfigurationSyncOverride = getBucketMetricsConfigurationSyncOverride {
+            return try getBucketMetricsConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketNotification operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: The NotificationConfigurationDeprecated object or an error will be passed to this 
+           callback when the operation is complete. The NotificationConfigurationDeprecated
+           object will be validated before being returned to caller.
+     */
+    public func getBucketNotificationAsync(input: S3Model.GetBucketNotificationConfigurationRequest, completion: @escaping (HTTPResult<S3Model.NotificationConfigurationDeprecated>) -> ()) throws {
+        if let getBucketNotificationAsyncOverride = getBucketNotificationAsyncOverride {
+            return try getBucketNotificationAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketNotification operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+     - Returns: The NotificationConfigurationDeprecated object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketNotificationSync(input: S3Model.GetBucketNotificationConfigurationRequest) throws -> S3Model.NotificationConfigurationDeprecated {
+        if let getBucketNotificationSyncOverride = getBucketNotificationSyncOverride {
+            return try getBucketNotificationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketNotificationConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: The NotificationConfiguration object or an error will be passed to this 
+           callback when the operation is complete. The NotificationConfiguration
+           object will be validated before being returned to caller.
+     */
+    public func getBucketNotificationConfigurationAsync(input: S3Model.GetBucketNotificationConfigurationRequest, completion: @escaping (HTTPResult<S3Model.NotificationConfiguration>) -> ()) throws {
+        if let getBucketNotificationConfigurationAsyncOverride = getBucketNotificationConfigurationAsyncOverride {
+            return try getBucketNotificationConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketNotificationConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketNotificationConfigurationRequest object being passed to this operation.
+     - Returns: The NotificationConfiguration object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketNotificationConfigurationSync(input: S3Model.GetBucketNotificationConfigurationRequest) throws -> S3Model.NotificationConfiguration {
+        if let getBucketNotificationConfigurationSyncOverride = getBucketNotificationConfigurationSyncOverride {
+            return try getBucketNotificationConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyRequest object being passed to this operation.
+         - completion: The GetBucketPolicyOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketPolicyOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketPolicyAsync(input: S3Model.GetBucketPolicyRequest, completion: @escaping (HTTPResult<S3Model.GetBucketPolicyOutput>) -> ()) throws {
+        if let getBucketPolicyAsyncOverride = getBucketPolicyAsyncOverride {
+            return try getBucketPolicyAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyRequest object being passed to this operation.
+     - Returns: The GetBucketPolicyOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketPolicySync(input: S3Model.GetBucketPolicyRequest) throws -> S3Model.GetBucketPolicyOutput {
+        if let getBucketPolicySyncOverride = getBucketPolicySyncOverride {
+            return try getBucketPolicySyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketPolicyStatus operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyStatusRequest object being passed to this operation.
+         - completion: The GetBucketPolicyStatusOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketPolicyStatusOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketPolicyStatusAsync(input: S3Model.GetBucketPolicyStatusRequest, completion: @escaping (HTTPResult<S3Model.GetBucketPolicyStatusOutput>) -> ()) throws {
+        if let getBucketPolicyStatusAsyncOverride = getBucketPolicyStatusAsyncOverride {
+            return try getBucketPolicyStatusAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketPolicyStatus operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketPolicyStatusRequest object being passed to this operation.
+     - Returns: The GetBucketPolicyStatusOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketPolicyStatusSync(input: S3Model.GetBucketPolicyStatusRequest) throws -> S3Model.GetBucketPolicyStatusOutput {
+        if let getBucketPolicyStatusSyncOverride = getBucketPolicyStatusSyncOverride {
+            return try getBucketPolicyStatusSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketReplicationRequest object being passed to this operation.
+         - completion: The GetBucketReplicationOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketReplicationOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketReplicationAsync(input: S3Model.GetBucketReplicationRequest, completion: @escaping (HTTPResult<S3Model.GetBucketReplicationOutput>) -> ()) throws {
+        if let getBucketReplicationAsyncOverride = getBucketReplicationAsyncOverride {
+            return try getBucketReplicationAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketReplicationRequest object being passed to this operation.
+     - Returns: The GetBucketReplicationOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketReplicationSync(input: S3Model.GetBucketReplicationRequest) throws -> S3Model.GetBucketReplicationOutput {
+        if let getBucketReplicationSyncOverride = getBucketReplicationSyncOverride {
+            return try getBucketReplicationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketRequestPayment operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketRequestPaymentRequest object being passed to this operation.
+         - completion: The GetBucketRequestPaymentOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketRequestPaymentOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketRequestPaymentAsync(input: S3Model.GetBucketRequestPaymentRequest, completion: @escaping (HTTPResult<S3Model.GetBucketRequestPaymentOutput>) -> ()) throws {
+        if let getBucketRequestPaymentAsyncOverride = getBucketRequestPaymentAsyncOverride {
+            return try getBucketRequestPaymentAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketRequestPayment operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketRequestPaymentRequest object being passed to this operation.
+     - Returns: The GetBucketRequestPaymentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketRequestPaymentSync(input: S3Model.GetBucketRequestPaymentRequest) throws -> S3Model.GetBucketRequestPaymentOutput {
+        if let getBucketRequestPaymentSyncOverride = getBucketRequestPaymentSyncOverride {
+            return try getBucketRequestPaymentSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketTaggingRequest object being passed to this operation.
+         - completion: The GetBucketTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketTaggingAsync(input: S3Model.GetBucketTaggingRequest, completion: @escaping (HTTPResult<S3Model.GetBucketTaggingOutput>) -> ()) throws {
+        if let getBucketTaggingAsyncOverride = getBucketTaggingAsyncOverride {
+            return try getBucketTaggingAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketTaggingRequest object being passed to this operation.
+     - Returns: The GetBucketTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketTaggingSync(input: S3Model.GetBucketTaggingRequest) throws -> S3Model.GetBucketTaggingOutput {
+        if let getBucketTaggingSyncOverride = getBucketTaggingSyncOverride {
+            return try getBucketTaggingSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketVersioning operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketVersioningRequest object being passed to this operation.
+         - completion: The GetBucketVersioningOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketVersioningOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketVersioningAsync(input: S3Model.GetBucketVersioningRequest, completion: @escaping (HTTPResult<S3Model.GetBucketVersioningOutput>) -> ()) throws {
+        if let getBucketVersioningAsyncOverride = getBucketVersioningAsyncOverride {
+            return try getBucketVersioningAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketVersioning operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketVersioningRequest object being passed to this operation.
+     - Returns: The GetBucketVersioningOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketVersioningSync(input: S3Model.GetBucketVersioningRequest) throws -> S3Model.GetBucketVersioningOutput {
+        if let getBucketVersioningSyncOverride = getBucketVersioningSyncOverride {
+            return try getBucketVersioningSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetBucketWebsiteRequest object being passed to this operation.
+         - completion: The GetBucketWebsiteOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetBucketWebsiteOutput
+           object will be validated before being returned to caller.
+     */
+    public func getBucketWebsiteAsync(input: S3Model.GetBucketWebsiteRequest, completion: @escaping (HTTPResult<S3Model.GetBucketWebsiteOutput>) -> ()) throws {
+        if let getBucketWebsiteAsyncOverride = getBucketWebsiteAsyncOverride {
+            return try getBucketWebsiteAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetBucketWebsiteRequest object being passed to this operation.
+     - Returns: The GetBucketWebsiteOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getBucketWebsiteSync(input: S3Model.GetBucketWebsiteRequest) throws -> S3Model.GetBucketWebsiteOutput {
+        if let getBucketWebsiteSyncOverride = getBucketWebsiteSyncOverride {
+            return try getBucketWebsiteSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectRequest object being passed to this operation.
+         - completion: The GetObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func getObjectAsync(input: S3Model.GetObjectRequest, completion: @escaping (HTTPResult<S3Model.GetObjectOutput>) -> ()) throws {
+        if let getObjectAsyncOverride = getObjectAsyncOverride {
+            return try getObjectAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectRequest object being passed to this operation.
+     - Returns: The GetObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func getObjectSync(input: S3Model.GetObjectRequest) throws -> S3Model.GetObjectOutput {
+        if let getObjectSyncOverride = getObjectSyncOverride {
+            return try getObjectSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetObjectAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectAclRequest object being passed to this operation.
+         - completion: The GetObjectAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectAclOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func getObjectAclAsync(input: S3Model.GetObjectAclRequest, completion: @escaping (HTTPResult<S3Model.GetObjectAclOutput>) -> ()) throws {
+        if let getObjectAclAsyncOverride = getObjectAclAsyncOverride {
+            return try getObjectAclAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetObjectAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectAclRequest object being passed to this operation.
+     - Returns: The GetObjectAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func getObjectAclSync(input: S3Model.GetObjectAclRequest) throws -> S3Model.GetObjectAclOutput {
+        if let getObjectAclSyncOverride = getObjectAclSyncOverride {
+            return try getObjectAclSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectTaggingRequest object being passed to this operation.
+         - completion: The GetObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func getObjectTaggingAsync(input: S3Model.GetObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.GetObjectTaggingOutput>) -> ()) throws {
+        if let getObjectTaggingAsyncOverride = getObjectTaggingAsyncOverride {
+            return try getObjectTaggingAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectTaggingRequest object being passed to this operation.
+     - Returns: The GetObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getObjectTaggingSync(input: S3Model.GetObjectTaggingRequest) throws -> S3Model.GetObjectTaggingOutput {
+        if let getObjectTaggingSyncOverride = getObjectTaggingSyncOverride {
+            return try getObjectTaggingSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetObjectTorrent operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetObjectTorrentRequest object being passed to this operation.
+         - completion: The GetObjectTorrentOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetObjectTorrentOutput
+           object will be validated before being returned to caller.
+     */
+    public func getObjectTorrentAsync(input: S3Model.GetObjectTorrentRequest, completion: @escaping (HTTPResult<S3Model.GetObjectTorrentOutput>) -> ()) throws {
+        if let getObjectTorrentAsyncOverride = getObjectTorrentAsyncOverride {
+            return try getObjectTorrentAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetObjectTorrent operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetObjectTorrentRequest object being passed to this operation.
+     - Returns: The GetObjectTorrentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getObjectTorrentSync(input: S3Model.GetObjectTorrentRequest) throws -> S3Model.GetObjectTorrentOutput {
+        if let getObjectTorrentSyncOverride = getObjectTorrentSyncOverride {
+            return try getObjectTorrentSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the GetPublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated GetPublicAccessBlockRequest object being passed to this operation.
+         - completion: The GetPublicAccessBlockOutput object or an error will be passed to this 
+           callback when the operation is complete. The GetPublicAccessBlockOutput
+           object will be validated before being returned to caller.
+     */
+    public func getPublicAccessBlockAsync(input: S3Model.GetPublicAccessBlockRequest, completion: @escaping (HTTPResult<S3Model.GetPublicAccessBlockOutput>) -> ()) throws {
+        if let getPublicAccessBlockAsyncOverride = getPublicAccessBlockAsyncOverride {
+            return try getPublicAccessBlockAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the GetPublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated GetPublicAccessBlockRequest object being passed to this operation.
+     - Returns: The GetPublicAccessBlockOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func getPublicAccessBlockSync(input: S3Model.GetPublicAccessBlockRequest) throws -> S3Model.GetPublicAccessBlockOutput {
+        if let getPublicAccessBlockSyncOverride = getPublicAccessBlockSyncOverride {
+            return try getPublicAccessBlockSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the HeadBucket operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated HeadBucketRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+           The possible errors are: noSuchBucket.
+     */
+    public func headBucketAsync(input: S3Model.HeadBucketRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let headBucketAsyncOverride = headBucketAsyncOverride {
+            return try headBucketAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the HeadBucket operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated HeadBucketRequest object being passed to this operation.
+     - Throws: noSuchBucket.
+     */
+    public func headBucketSync(input: S3Model.HeadBucketRequest) throws {
+        if let headBucketSyncOverride = headBucketSyncOverride {
+            return try headBucketSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the HeadObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated HeadObjectRequest object being passed to this operation.
+         - completion: The HeadObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The HeadObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func headObjectAsync(input: S3Model.HeadObjectRequest, completion: @escaping (HTTPResult<S3Model.HeadObjectOutput>) -> ()) throws {
+        if let headObjectAsyncOverride = headObjectAsyncOverride {
+            return try headObjectAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the HeadObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated HeadObjectRequest object being passed to this operation.
+     - Returns: The HeadObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func headObjectSync(input: S3Model.HeadObjectRequest) throws -> S3Model.HeadObjectOutput {
+        if let headObjectSyncOverride = headObjectSyncOverride {
+            return try headObjectSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the ListBucketAnalyticsConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketAnalyticsConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketAnalyticsConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketAnalyticsConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketAnalyticsConfigurationsAsync(input: S3Model.ListBucketAnalyticsConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketAnalyticsConfigurationsOutput>) -> ()) throws {
+        if let listBucketAnalyticsConfigurationsAsyncOverride = listBucketAnalyticsConfigurationsAsyncOverride {
+            return try listBucketAnalyticsConfigurationsAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the ListBucketAnalyticsConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketAnalyticsConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketAnalyticsConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketAnalyticsConfigurationsSync(input: S3Model.ListBucketAnalyticsConfigurationsRequest) throws -> S3Model.ListBucketAnalyticsConfigurationsOutput {
+        if let listBucketAnalyticsConfigurationsSyncOverride = listBucketAnalyticsConfigurationsSyncOverride {
+            return try listBucketAnalyticsConfigurationsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the ListBucketInventoryConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketInventoryConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketInventoryConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketInventoryConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketInventoryConfigurationsAsync(input: S3Model.ListBucketInventoryConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketInventoryConfigurationsOutput>) -> ()) throws {
+        if let listBucketInventoryConfigurationsAsyncOverride = listBucketInventoryConfigurationsAsyncOverride {
+            return try listBucketInventoryConfigurationsAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the ListBucketInventoryConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketInventoryConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketInventoryConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketInventoryConfigurationsSync(input: S3Model.ListBucketInventoryConfigurationsRequest) throws -> S3Model.ListBucketInventoryConfigurationsOutput {
+        if let listBucketInventoryConfigurationsSyncOverride = listBucketInventoryConfigurationsSyncOverride {
+            return try listBucketInventoryConfigurationsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the ListBucketMetricsConfigurations operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListBucketMetricsConfigurationsRequest object being passed to this operation.
+         - completion: The ListBucketMetricsConfigurationsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketMetricsConfigurationsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketMetricsConfigurationsAsync(input: S3Model.ListBucketMetricsConfigurationsRequest, completion: @escaping (HTTPResult<S3Model.ListBucketMetricsConfigurationsOutput>) -> ()) throws {
+        if let listBucketMetricsConfigurationsAsyncOverride = listBucketMetricsConfigurationsAsyncOverride {
+            return try listBucketMetricsConfigurationsAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the ListBucketMetricsConfigurations operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListBucketMetricsConfigurationsRequest object being passed to this operation.
+     - Returns: The ListBucketMetricsConfigurationsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketMetricsConfigurationsSync(input: S3Model.ListBucketMetricsConfigurationsRequest) throws -> S3Model.ListBucketMetricsConfigurationsOutput {
+        if let listBucketMetricsConfigurationsSyncOverride = listBucketMetricsConfigurationsSyncOverride {
+            return try listBucketMetricsConfigurationsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the ListBuckets operation returning immediately and passing the response to a callback.
+         - completion: The ListBucketsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListBucketsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listBucketsAsync(completion: @escaping (HTTPResult<S3Model.ListBucketsOutput>) -> ()) throws {
+        if let listBucketsAsyncOverride = listBucketsAsyncOverride {
+            return try listBucketsAsyncOverride(completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the ListBuckets operation waiting for the response before returning.
+     - Returns: The ListBucketsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listBucketsSync() throws -> S3Model.ListBucketsOutput {
+        if let listBucketsSyncOverride = listBucketsSyncOverride {
+            return try listBucketsSyncOverride()
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the ListMultipartUploads operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListMultipartUploadsRequest object being passed to this operation.
+         - completion: The ListMultipartUploadsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListMultipartUploadsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listMultipartUploadsAsync(input: S3Model.ListMultipartUploadsRequest, completion: @escaping (HTTPResult<S3Model.ListMultipartUploadsOutput>) -> ()) throws {
+        if let listMultipartUploadsAsyncOverride = listMultipartUploadsAsyncOverride {
+            return try listMultipartUploadsAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the ListMultipartUploads operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListMultipartUploadsRequest object being passed to this operation.
+     - Returns: The ListMultipartUploadsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listMultipartUploadsSync(input: S3Model.ListMultipartUploadsRequest) throws -> S3Model.ListMultipartUploadsOutput {
+        if let listMultipartUploadsSyncOverride = listMultipartUploadsSyncOverride {
+            return try listMultipartUploadsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the ListObjectVersions operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectVersionsRequest object being passed to this operation.
+         - completion: The ListObjectVersionsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectVersionsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listObjectVersionsAsync(input: S3Model.ListObjectVersionsRequest, completion: @escaping (HTTPResult<S3Model.ListObjectVersionsOutput>) -> ()) throws {
+        if let listObjectVersionsAsyncOverride = listObjectVersionsAsyncOverride {
+            return try listObjectVersionsAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the ListObjectVersions operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectVersionsRequest object being passed to this operation.
+     - Returns: The ListObjectVersionsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listObjectVersionsSync(input: S3Model.ListObjectVersionsRequest) throws -> S3Model.ListObjectVersionsOutput {
+        if let listObjectVersionsSyncOverride = listObjectVersionsSyncOverride {
+            return try listObjectVersionsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the ListObjects operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectsRequest object being passed to this operation.
+         - completion: The ListObjectsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectsOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchBucket.
+     */
+    public func listObjectsAsync(input: S3Model.ListObjectsRequest, completion: @escaping (HTTPResult<S3Model.ListObjectsOutput>) -> ()) throws {
+        if let listObjectsAsyncOverride = listObjectsAsyncOverride {
+            return try listObjectsAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the ListObjects operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectsRequest object being passed to this operation.
+     - Returns: The ListObjectsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchBucket.
+     */
+    public func listObjectsSync(input: S3Model.ListObjectsRequest) throws -> S3Model.ListObjectsOutput {
+        if let listObjectsSyncOverride = listObjectsSyncOverride {
+            return try listObjectsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the ListObjectsV2 operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListObjectsV2Request object being passed to this operation.
+         - completion: The ListObjectsV2Output object or an error will be passed to this 
+           callback when the operation is complete. The ListObjectsV2Output
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchBucket.
+     */
+    public func listObjectsV2Async(input: S3Model.ListObjectsV2Request, completion: @escaping (HTTPResult<S3Model.ListObjectsV2Output>) -> ()) throws {
+        if let listObjectsV2AsyncOverride = listObjectsV2AsyncOverride {
+            return try listObjectsV2AsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the ListObjectsV2 operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListObjectsV2Request object being passed to this operation.
+     - Returns: The ListObjectsV2Output object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchBucket.
+     */
+    public func listObjectsV2Sync(input: S3Model.ListObjectsV2Request) throws -> S3Model.ListObjectsV2Output {
+        if let listObjectsV2SyncOverride = listObjectsV2SyncOverride {
+            return try listObjectsV2SyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the ListParts operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated ListPartsRequest object being passed to this operation.
+         - completion: The ListPartsOutput object or an error will be passed to this 
+           callback when the operation is complete. The ListPartsOutput
+           object will be validated before being returned to caller.
+     */
+    public func listPartsAsync(input: S3Model.ListPartsRequest, completion: @escaping (HTTPResult<S3Model.ListPartsOutput>) -> ()) throws {
+        if let listPartsAsyncOverride = listPartsAsyncOverride {
+            return try listPartsAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the ListParts operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated ListPartsRequest object being passed to this operation.
+     - Returns: The ListPartsOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func listPartsSync(input: S3Model.ListPartsRequest) throws -> S3Model.ListPartsOutput {
+        if let listPartsSyncOverride = listPartsSyncOverride {
+            return try listPartsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketAccelerateConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAccelerateConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketAccelerateConfigurationAsync(input: S3Model.PutBucketAccelerateConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketAccelerateConfigurationAsyncOverride = putBucketAccelerateConfigurationAsyncOverride {
+            return try putBucketAccelerateConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketAccelerateConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAccelerateConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketAccelerateConfigurationSync(input: S3Model.PutBucketAccelerateConfigurationRequest) throws {
+        if let putBucketAccelerateConfigurationSyncOverride = putBucketAccelerateConfigurationSyncOverride {
+            return try putBucketAccelerateConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAclRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketAclAsync(input: S3Model.PutBucketAclRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketAclAsyncOverride = putBucketAclAsyncOverride {
+            return try putBucketAclAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAclRequest object being passed to this operation.
+     */
+    public func putBucketAclSync(input: S3Model.PutBucketAclRequest) throws {
+        if let putBucketAclSyncOverride = putBucketAclSyncOverride {
+            return try putBucketAclSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketAnalyticsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketAnalyticsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketAnalyticsConfigurationAsync(input: S3Model.PutBucketAnalyticsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketAnalyticsConfigurationAsyncOverride = putBucketAnalyticsConfigurationAsyncOverride {
+            return try putBucketAnalyticsConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketAnalyticsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketAnalyticsConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketAnalyticsConfigurationSync(input: S3Model.PutBucketAnalyticsConfigurationRequest) throws {
+        if let putBucketAnalyticsConfigurationSyncOverride = putBucketAnalyticsConfigurationSyncOverride {
+            return try putBucketAnalyticsConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketCors operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketCorsRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketCorsAsync(input: S3Model.PutBucketCorsRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketCorsAsyncOverride = putBucketCorsAsyncOverride {
+            return try putBucketCorsAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketCors operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketCorsRequest object being passed to this operation.
+     */
+    public func putBucketCorsSync(input: S3Model.PutBucketCorsRequest) throws {
+        if let putBucketCorsSyncOverride = putBucketCorsSyncOverride {
+            return try putBucketCorsSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketEncryption operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketEncryptionRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketEncryptionAsync(input: S3Model.PutBucketEncryptionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketEncryptionAsyncOverride = putBucketEncryptionAsyncOverride {
+            return try putBucketEncryptionAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketEncryption operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketEncryptionRequest object being passed to this operation.
+     */
+    public func putBucketEncryptionSync(input: S3Model.PutBucketEncryptionRequest) throws {
+        if let putBucketEncryptionSyncOverride = putBucketEncryptionSyncOverride {
+            return try putBucketEncryptionSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketInventoryConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketInventoryConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketInventoryConfigurationAsync(input: S3Model.PutBucketInventoryConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketInventoryConfigurationAsyncOverride = putBucketInventoryConfigurationAsyncOverride {
+            return try putBucketInventoryConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketInventoryConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketInventoryConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketInventoryConfigurationSync(input: S3Model.PutBucketInventoryConfigurationRequest) throws {
+        if let putBucketInventoryConfigurationSyncOverride = putBucketInventoryConfigurationSyncOverride {
+            return try putBucketInventoryConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketLifecycle operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketLifecycleAsync(input: S3Model.PutBucketLifecycleRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketLifecycleAsyncOverride = putBucketLifecycleAsyncOverride {
+            return try putBucketLifecycleAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketLifecycle operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleRequest object being passed to this operation.
+     */
+    public func putBucketLifecycleSync(input: S3Model.PutBucketLifecycleRequest) throws {
+        if let putBucketLifecycleSyncOverride = putBucketLifecycleSyncOverride {
+            return try putBucketLifecycleSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketLifecycleConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketLifecycleConfigurationAsync(input: S3Model.PutBucketLifecycleConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketLifecycleConfigurationAsyncOverride = putBucketLifecycleConfigurationAsyncOverride {
+            return try putBucketLifecycleConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketLifecycleConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLifecycleConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketLifecycleConfigurationSync(input: S3Model.PutBucketLifecycleConfigurationRequest) throws {
+        if let putBucketLifecycleConfigurationSyncOverride = putBucketLifecycleConfigurationSyncOverride {
+            return try putBucketLifecycleConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketLogging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketLoggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketLoggingAsync(input: S3Model.PutBucketLoggingRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketLoggingAsyncOverride = putBucketLoggingAsyncOverride {
+            return try putBucketLoggingAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketLogging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketLoggingRequest object being passed to this operation.
+     */
+    public func putBucketLoggingSync(input: S3Model.PutBucketLoggingRequest) throws {
+        if let putBucketLoggingSyncOverride = putBucketLoggingSyncOverride {
+            return try putBucketLoggingSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketMetricsConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketMetricsConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketMetricsConfigurationAsync(input: S3Model.PutBucketMetricsConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketMetricsConfigurationAsyncOverride = putBucketMetricsConfigurationAsyncOverride {
+            return try putBucketMetricsConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketMetricsConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketMetricsConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketMetricsConfigurationSync(input: S3Model.PutBucketMetricsConfigurationRequest) throws {
+        if let putBucketMetricsConfigurationSyncOverride = putBucketMetricsConfigurationSyncOverride {
+            return try putBucketMetricsConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketNotification operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketNotificationAsync(input: S3Model.PutBucketNotificationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketNotificationAsyncOverride = putBucketNotificationAsyncOverride {
+            return try putBucketNotificationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketNotification operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationRequest object being passed to this operation.
+     */
+    public func putBucketNotificationSync(input: S3Model.PutBucketNotificationRequest) throws {
+        if let putBucketNotificationSyncOverride = putBucketNotificationSyncOverride {
+            return try putBucketNotificationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketNotificationConfiguration operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationConfigurationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketNotificationConfigurationAsync(input: S3Model.PutBucketNotificationConfigurationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketNotificationConfigurationAsyncOverride = putBucketNotificationConfigurationAsyncOverride {
+            return try putBucketNotificationConfigurationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketNotificationConfiguration operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketNotificationConfigurationRequest object being passed to this operation.
+     */
+    public func putBucketNotificationConfigurationSync(input: S3Model.PutBucketNotificationConfigurationRequest) throws {
+        if let putBucketNotificationConfigurationSyncOverride = putBucketNotificationConfigurationSyncOverride {
+            return try putBucketNotificationConfigurationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketPolicy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketPolicyRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketPolicyAsync(input: S3Model.PutBucketPolicyRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketPolicyAsyncOverride = putBucketPolicyAsyncOverride {
+            return try putBucketPolicyAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketPolicy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketPolicyRequest object being passed to this operation.
+     */
+    public func putBucketPolicySync(input: S3Model.PutBucketPolicyRequest) throws {
+        if let putBucketPolicySyncOverride = putBucketPolicySyncOverride {
+            return try putBucketPolicySyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketReplication operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketReplicationRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketReplicationAsync(input: S3Model.PutBucketReplicationRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketReplicationAsyncOverride = putBucketReplicationAsyncOverride {
+            return try putBucketReplicationAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketReplication operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketReplicationRequest object being passed to this operation.
+     */
+    public func putBucketReplicationSync(input: S3Model.PutBucketReplicationRequest) throws {
+        if let putBucketReplicationSyncOverride = putBucketReplicationSyncOverride {
+            return try putBucketReplicationSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketRequestPayment operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketRequestPaymentRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketRequestPaymentAsync(input: S3Model.PutBucketRequestPaymentRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketRequestPaymentAsyncOverride = putBucketRequestPaymentAsyncOverride {
+            return try putBucketRequestPaymentAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketRequestPayment operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketRequestPaymentRequest object being passed to this operation.
+     */
+    public func putBucketRequestPaymentSync(input: S3Model.PutBucketRequestPaymentRequest) throws {
+        if let putBucketRequestPaymentSyncOverride = putBucketRequestPaymentSyncOverride {
+            return try putBucketRequestPaymentSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketTaggingRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketTaggingAsync(input: S3Model.PutBucketTaggingRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketTaggingAsyncOverride = putBucketTaggingAsyncOverride {
+            return try putBucketTaggingAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketTaggingRequest object being passed to this operation.
+     */
+    public func putBucketTaggingSync(input: S3Model.PutBucketTaggingRequest) throws {
+        if let putBucketTaggingSyncOverride = putBucketTaggingSyncOverride {
+            return try putBucketTaggingSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketVersioning operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketVersioningRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketVersioningAsync(input: S3Model.PutBucketVersioningRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketVersioningAsyncOverride = putBucketVersioningAsyncOverride {
+            return try putBucketVersioningAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketVersioning operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketVersioningRequest object being passed to this operation.
+     */
+    public func putBucketVersioningSync(input: S3Model.PutBucketVersioningRequest) throws {
+        if let putBucketVersioningSyncOverride = putBucketVersioningSyncOverride {
+            return try putBucketVersioningSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutBucketWebsite operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutBucketWebsiteRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putBucketWebsiteAsync(input: S3Model.PutBucketWebsiteRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putBucketWebsiteAsyncOverride = putBucketWebsiteAsyncOverride {
+            return try putBucketWebsiteAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutBucketWebsite operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutBucketWebsiteRequest object being passed to this operation.
+     */
+    public func putBucketWebsiteSync(input: S3Model.PutBucketWebsiteRequest) throws {
+        if let putBucketWebsiteSyncOverride = putBucketWebsiteSyncOverride {
+            return try putBucketWebsiteSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectRequest object being passed to this operation.
+         - completion: The PutObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectOutput
+           object will be validated before being returned to caller.
+     */
+    public func putObjectAsync(input: S3Model.PutObjectRequest, completion: @escaping (HTTPResult<S3Model.PutObjectOutput>) -> ()) throws {
+        if let putObjectAsyncOverride = putObjectAsyncOverride {
+            return try putObjectAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the PutObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectRequest object being passed to this operation.
+     - Returns: The PutObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func putObjectSync(input: S3Model.PutObjectRequest) throws -> S3Model.PutObjectOutput {
+        if let putObjectSyncOverride = putObjectSyncOverride {
+            return try putObjectSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutObjectAcl operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectAclRequest object being passed to this operation.
+         - completion: The PutObjectAclOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectAclOutput
+           object will be validated before being returned to caller.
+           The possible errors are: noSuchKey.
+     */
+    public func putObjectAclAsync(input: S3Model.PutObjectAclRequest, completion: @escaping (HTTPResult<S3Model.PutObjectAclOutput>) -> ()) throws {
+        if let putObjectAclAsyncOverride = putObjectAclAsyncOverride {
+            return try putObjectAclAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the PutObjectAcl operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectAclRequest object being passed to this operation.
+     - Returns: The PutObjectAclOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: noSuchKey.
+     */
+    public func putObjectAclSync(input: S3Model.PutObjectAclRequest) throws -> S3Model.PutObjectAclOutput {
+        if let putObjectAclSyncOverride = putObjectAclSyncOverride {
+            return try putObjectAclSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutObjectTagging operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutObjectTaggingRequest object being passed to this operation.
+         - completion: The PutObjectTaggingOutput object or an error will be passed to this 
+           callback when the operation is complete. The PutObjectTaggingOutput
+           object will be validated before being returned to caller.
+     */
+    public func putObjectTaggingAsync(input: S3Model.PutObjectTaggingRequest, completion: @escaping (HTTPResult<S3Model.PutObjectTaggingOutput>) -> ()) throws {
+        if let putObjectTaggingAsyncOverride = putObjectTaggingAsyncOverride {
+            return try putObjectTaggingAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the PutObjectTagging operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutObjectTaggingRequest object being passed to this operation.
+     - Returns: The PutObjectTaggingOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func putObjectTaggingSync(input: S3Model.PutObjectTaggingRequest) throws -> S3Model.PutObjectTaggingOutput {
+        if let putObjectTaggingSyncOverride = putObjectTaggingSyncOverride {
+            return try putObjectTaggingSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the PutPublicAccessBlock operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated PutPublicAccessBlockRequest object being passed to this operation.
+         - completion: Nil or an error will be passed to this callback when the operation
+           is complete.
+     */
+    public func putPublicAccessBlockAsync(input: S3Model.PutPublicAccessBlockRequest, completion: @escaping (Swift.Error?) -> ()) throws {
+        if let putPublicAccessBlockAsyncOverride = putPublicAccessBlockAsyncOverride {
+            return try putPublicAccessBlockAsyncOverride(input, completion)
+        }
+
+        completion(error)
+    }
+
+    /**
+     Invokes the PutPublicAccessBlock operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated PutPublicAccessBlockRequest object being passed to this operation.
+     */
+    public func putPublicAccessBlockSync(input: S3Model.PutPublicAccessBlockRequest) throws {
+        if let putPublicAccessBlockSyncOverride = putPublicAccessBlockSyncOverride {
+            return try putPublicAccessBlockSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the RestoreObject operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated RestoreObjectRequest object being passed to this operation.
+         - completion: The RestoreObjectOutput object or an error will be passed to this 
+           callback when the operation is complete. The RestoreObjectOutput
+           object will be validated before being returned to caller.
+           The possible errors are: objectAlreadyInActiveTier.
+     */
+    public func restoreObjectAsync(input: S3Model.RestoreObjectRequest, completion: @escaping (HTTPResult<S3Model.RestoreObjectOutput>) -> ()) throws {
+        if let restoreObjectAsyncOverride = restoreObjectAsyncOverride {
+            return try restoreObjectAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the RestoreObject operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated RestoreObjectRequest object being passed to this operation.
+     - Returns: The RestoreObjectOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     - Throws: objectAlreadyInActiveTier.
+     */
+    public func restoreObjectSync(input: S3Model.RestoreObjectRequest) throws -> S3Model.RestoreObjectOutput {
+        if let restoreObjectSyncOverride = restoreObjectSyncOverride {
+            return try restoreObjectSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the SelectObjectContent operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated SelectObjectContentRequest object being passed to this operation.
+         - completion: The SelectObjectContentOutput object or an error will be passed to this 
+           callback when the operation is complete. The SelectObjectContentOutput
+           object will be validated before being returned to caller.
+     */
+    public func selectObjectContentAsync(input: S3Model.SelectObjectContentRequest, completion: @escaping (HTTPResult<S3Model.SelectObjectContentOutput>) -> ()) throws {
+        if let selectObjectContentAsyncOverride = selectObjectContentAsyncOverride {
+            return try selectObjectContentAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the SelectObjectContent operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated SelectObjectContentRequest object being passed to this operation.
+     - Returns: The SelectObjectContentOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func selectObjectContentSync(input: S3Model.SelectObjectContentRequest) throws -> S3Model.SelectObjectContentOutput {
+        if let selectObjectContentSyncOverride = selectObjectContentSyncOverride {
+            return try selectObjectContentSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the UploadPart operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated UploadPartRequest object being passed to this operation.
+         - completion: The UploadPartOutput object or an error will be passed to this 
+           callback when the operation is complete. The UploadPartOutput
+           object will be validated before being returned to caller.
+     */
+    public func uploadPartAsync(input: S3Model.UploadPartRequest, completion: @escaping (HTTPResult<S3Model.UploadPartOutput>) -> ()) throws {
+        if let uploadPartAsyncOverride = uploadPartAsyncOverride {
+            return try uploadPartAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the UploadPart operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated UploadPartRequest object being passed to this operation.
+     - Returns: The UploadPartOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func uploadPartSync(input: S3Model.UploadPartRequest) throws -> S3Model.UploadPartOutput {
+        if let uploadPartSyncOverride = uploadPartSyncOverride {
+            return try uploadPartSyncOverride(input)
+        }
+
+        throw error
+    }
+
+    /**
+     Invokes the UploadPartCopy operation returning immediately and passing the response to a callback.
+
+     - Parameters:
+         - input: The validated UploadPartCopyRequest object being passed to this operation.
+         - completion: The UploadPartCopyOutput object or an error will be passed to this 
+           callback when the operation is complete. The UploadPartCopyOutput
+           object will be validated before being returned to caller.
+     */
+    public func uploadPartCopyAsync(input: S3Model.UploadPartCopyRequest, completion: @escaping (HTTPResult<S3Model.UploadPartCopyOutput>) -> ()) throws {
+        if let uploadPartCopyAsyncOverride = uploadPartCopyAsyncOverride {
+            return try uploadPartCopyAsyncOverride(input, completion)
+        }
+
+        completion(.error(error))
+    }
+
+    /**
+     Invokes the UploadPartCopy operation waiting for the response before returning.
+
+     - Parameters:
+         - input: The validated UploadPartCopyRequest object being passed to this operation.
+     - Returns: The UploadPartCopyOutput object to be passed back from the caller of this operation.
+         Will be validated before being returned to caller.
+     */
+    public func uploadPartCopySync(input: S3Model.UploadPartCopyRequest) throws -> S3Model.UploadPartCopyOutput {
+        if let uploadPartCopySyncOverride = uploadPartCopySyncOverride {
+            return try uploadPartCopySyncOverride(input)
+        }
+
+        throw error
+    }
+}

--- a/Sources/S3Model/S3ModelDefaultInstances.swift
+++ b/Sources/S3Model/S3ModelDefaultInstances.swift
@@ -1,0 +1,3662 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// S3ModelDefaultInstances.swift
+// S3Model
+//
+
+import Foundation
+
+public extension AbortIncompleteMultipartUpload {
+    /**
+     Default instance of the AbortIncompleteMultipartUpload structure.
+     */
+    public static let __default: S3Model.AbortIncompleteMultipartUpload = {
+        let defaultInstance = S3Model.AbortIncompleteMultipartUpload(
+            daysAfterInitiation: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension AbortMultipartUploadOutput {
+    /**
+     Default instance of the AbortMultipartUploadOutput structure.
+     */
+    public static let __default: S3Model.AbortMultipartUploadOutput = {
+        let defaultInstance = S3Model.AbortMultipartUploadOutput(
+            requestCharged: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension AbortMultipartUploadRequest {
+    /**
+     Default instance of the AbortMultipartUploadRequest structure.
+     */
+    public static let __default: S3Model.AbortMultipartUploadRequest = {
+        let defaultInstance = S3Model.AbortMultipartUploadRequest(
+            bucket: "value",
+            key: "0",
+            requestPayer: nil,
+            uploadId: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension AccelerateConfiguration {
+    /**
+     Default instance of the AccelerateConfiguration structure.
+     */
+    public static let __default: S3Model.AccelerateConfiguration = {
+        let defaultInstance = S3Model.AccelerateConfiguration(
+            status: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension AccessControlPolicy {
+    /**
+     Default instance of the AccessControlPolicy structure.
+     */
+    public static let __default: S3Model.AccessControlPolicy = {
+        let defaultInstance = S3Model.AccessControlPolicy(
+            grants: nil,
+            owner: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension AccessControlTranslation {
+    /**
+     Default instance of the AccessControlTranslation structure.
+     */
+    public static let __default: S3Model.AccessControlTranslation = {
+        let defaultInstance = S3Model.AccessControlTranslation(
+            owner: .__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension AnalyticsAndOperator {
+    /**
+     Default instance of the AnalyticsAndOperator structure.
+     */
+    public static let __default: S3Model.AnalyticsAndOperator = {
+        let defaultInstance = S3Model.AnalyticsAndOperator(
+            prefix: nil,
+            tags: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension AnalyticsConfiguration {
+    /**
+     Default instance of the AnalyticsConfiguration structure.
+     */
+    public static let __default: S3Model.AnalyticsConfiguration = {
+        let defaultInstance = S3Model.AnalyticsConfiguration(
+            filter: nil,
+            id: "value",
+            storageClassAnalysis: StorageClassAnalysis.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension AnalyticsExportDestination {
+    /**
+     Default instance of the AnalyticsExportDestination structure.
+     */
+    public static let __default: S3Model.AnalyticsExportDestination = {
+        let defaultInstance = S3Model.AnalyticsExportDestination(
+            s3BucketDestination: AnalyticsS3BucketDestination.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension AnalyticsFilter {
+    /**
+     Default instance of the AnalyticsFilter structure.
+     */
+    public static let __default: S3Model.AnalyticsFilter = {
+        let defaultInstance = S3Model.AnalyticsFilter(
+            and: nil,
+            prefix: nil,
+            tag: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension AnalyticsS3BucketDestination {
+    /**
+     Default instance of the AnalyticsS3BucketDestination structure.
+     */
+    public static let __default: S3Model.AnalyticsS3BucketDestination = {
+        let defaultInstance = S3Model.AnalyticsS3BucketDestination(
+            bucket: "value",
+            bucketAccountId: nil,
+            format: .__default,
+            prefix: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Bucket {
+    /**
+     Default instance of the Bucket structure.
+     */
+    public static let __default: S3Model.Bucket = {
+        let defaultInstance = S3Model.Bucket(
+            creationDate: nil,
+            name: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension BucketAlreadyExists {
+    /**
+     Default instance of the BucketAlreadyExists structure.
+     */
+    public static let __default: S3Model.BucketAlreadyExists = {
+        let defaultInstance = S3Model.BucketAlreadyExists()
+
+        return defaultInstance
+    }()
+}
+
+public extension BucketAlreadyOwnedByYou {
+    /**
+     Default instance of the BucketAlreadyOwnedByYou structure.
+     */
+    public static let __default: S3Model.BucketAlreadyOwnedByYou = {
+        let defaultInstance = S3Model.BucketAlreadyOwnedByYou()
+
+        return defaultInstance
+    }()
+}
+
+public extension BucketLifecycleConfiguration {
+    /**
+     Default instance of the BucketLifecycleConfiguration structure.
+     */
+    public static let __default: S3Model.BucketLifecycleConfiguration = {
+        let defaultInstance = S3Model.BucketLifecycleConfiguration(
+            rules: [])
+
+        return defaultInstance
+    }()
+}
+
+public extension BucketLoggingStatus {
+    /**
+     Default instance of the BucketLoggingStatus structure.
+     */
+    public static let __default: S3Model.BucketLoggingStatus = {
+        let defaultInstance = S3Model.BucketLoggingStatus(
+            loggingEnabled: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CORSConfiguration {
+    /**
+     Default instance of the CORSConfiguration structure.
+     */
+    public static let __default: S3Model.CORSConfiguration = {
+        let defaultInstance = S3Model.CORSConfiguration(
+            cORSRules: [])
+
+        return defaultInstance
+    }()
+}
+
+public extension CORSRule {
+    /**
+     Default instance of the CORSRule structure.
+     */
+    public static let __default: S3Model.CORSRule = {
+        let defaultInstance = S3Model.CORSRule(
+            allowedHeaders: nil,
+            allowedMethods: [],
+            allowedOrigins: [],
+            exposeHeaders: nil,
+            maxAgeSeconds: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CSVInput {
+    /**
+     Default instance of the CSVInput structure.
+     */
+    public static let __default: S3Model.CSVInput = {
+        let defaultInstance = S3Model.CSVInput(
+            allowQuotedRecordDelimiter: nil,
+            comments: nil,
+            fieldDelimiter: nil,
+            fileHeaderInfo: nil,
+            quoteCharacter: nil,
+            quoteEscapeCharacter: nil,
+            recordDelimiter: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CSVOutput {
+    /**
+     Default instance of the CSVOutput structure.
+     */
+    public static let __default: S3Model.CSVOutput = {
+        let defaultInstance = S3Model.CSVOutput(
+            fieldDelimiter: nil,
+            quoteCharacter: nil,
+            quoteEscapeCharacter: nil,
+            quoteFields: nil,
+            recordDelimiter: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CloudFunctionConfiguration {
+    /**
+     Default instance of the CloudFunctionConfiguration structure.
+     */
+    public static let __default: S3Model.CloudFunctionConfiguration = {
+        let defaultInstance = S3Model.CloudFunctionConfiguration(
+            cloudFunction: nil,
+            events: nil,
+            id: nil,
+            invocationRole: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CommonPrefix {
+    /**
+     Default instance of the CommonPrefix structure.
+     */
+    public static let __default: S3Model.CommonPrefix = {
+        let defaultInstance = S3Model.CommonPrefix(
+            prefix: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CompleteMultipartUploadOutput {
+    /**
+     Default instance of the CompleteMultipartUploadOutput structure.
+     */
+    public static let __default: S3Model.CompleteMultipartUploadOutput = {
+        let defaultInstance = S3Model.CompleteMultipartUploadOutput(
+            bucket: nil,
+            eTag: nil,
+            expiration: nil,
+            key: nil,
+            location: nil,
+            requestCharged: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CompleteMultipartUploadRequest {
+    /**
+     Default instance of the CompleteMultipartUploadRequest structure.
+     */
+    public static let __default: S3Model.CompleteMultipartUploadRequest = {
+        let defaultInstance = S3Model.CompleteMultipartUploadRequest(
+            bucket: "value",
+            key: "0",
+            multipartUpload: nil,
+            requestPayer: nil,
+            uploadId: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension CompletedMultipartUpload {
+    /**
+     Default instance of the CompletedMultipartUpload structure.
+     */
+    public static let __default: S3Model.CompletedMultipartUpload = {
+        let defaultInstance = S3Model.CompletedMultipartUpload(
+            parts: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CompletedPart {
+    /**
+     Default instance of the CompletedPart structure.
+     */
+    public static let __default: S3Model.CompletedPart = {
+        let defaultInstance = S3Model.CompletedPart(
+            eTag: nil,
+            partNumber: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Condition {
+    /**
+     Default instance of the Condition structure.
+     */
+    public static let __default: S3Model.Condition = {
+        let defaultInstance = S3Model.Condition(
+            httpErrorCodeReturnedEquals: nil,
+            keyPrefixEquals: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ContinuationEvent {
+    /**
+     Default instance of the ContinuationEvent structure.
+     */
+    public static let __default: S3Model.ContinuationEvent = {
+        let defaultInstance = S3Model.ContinuationEvent()
+
+        return defaultInstance
+    }()
+}
+
+public extension CopyObjectOutput {
+    /**
+     Default instance of the CopyObjectOutput structure.
+     */
+    public static let __default: S3Model.CopyObjectOutput = {
+        let defaultInstance = S3Model.CopyObjectOutput(
+            copyObjectResult: nil,
+            copySourceVersionId: nil,
+            expiration: nil,
+            requestCharged: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKeyMD5: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CopyObjectRequest {
+    /**
+     Default instance of the CopyObjectRequest structure.
+     */
+    public static let __default: S3Model.CopyObjectRequest = {
+        let defaultInstance = S3Model.CopyObjectRequest(
+            aCL: nil,
+            bucket: "value",
+            cacheControl: nil,
+            contentDisposition: nil,
+            contentEncoding: nil,
+            contentLanguage: nil,
+            contentType: nil,
+            copySource: "",
+            copySourceIfMatch: nil,
+            copySourceIfModifiedSince: nil,
+            copySourceIfNoneMatch: nil,
+            copySourceIfUnmodifiedSince: nil,
+            copySourceSSECustomerAlgorithm: nil,
+            copySourceSSECustomerKey: nil,
+            copySourceSSECustomerKeyMD5: nil,
+            expires: nil,
+            grantFullControl: nil,
+            grantRead: nil,
+            grantReadACP: nil,
+            grantWriteACP: nil,
+            key: "0",
+            metadata: nil,
+            metadataDirective: nil,
+            requestPayer: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKey: nil,
+            sSECustomerKeyMD5: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil,
+            storageClass: nil,
+            tagging: nil,
+            taggingDirective: nil,
+            websiteRedirectLocation: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CopyObjectResult {
+    /**
+     Default instance of the CopyObjectResult structure.
+     */
+    public static let __default: S3Model.CopyObjectResult = {
+        let defaultInstance = S3Model.CopyObjectResult(
+            eTag: nil,
+            lastModified: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CopyPartResult {
+    /**
+     Default instance of the CopyPartResult structure.
+     */
+    public static let __default: S3Model.CopyPartResult = {
+        let defaultInstance = S3Model.CopyPartResult(
+            eTag: nil,
+            lastModified: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CreateBucketConfiguration {
+    /**
+     Default instance of the CreateBucketConfiguration structure.
+     */
+    public static let __default: S3Model.CreateBucketConfiguration = {
+        let defaultInstance = S3Model.CreateBucketConfiguration(
+            locationConstraint: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CreateBucketOutput {
+    /**
+     Default instance of the CreateBucketOutput structure.
+     */
+    public static let __default: S3Model.CreateBucketOutput = {
+        let defaultInstance = S3Model.CreateBucketOutput(
+            location: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CreateBucketRequest {
+    /**
+     Default instance of the CreateBucketRequest structure.
+     */
+    public static let __default: S3Model.CreateBucketRequest = {
+        let defaultInstance = S3Model.CreateBucketRequest(
+            aCL: nil,
+            bucket: "value",
+            createBucketConfiguration: nil,
+            grantFullControl: nil,
+            grantRead: nil,
+            grantReadACP: nil,
+            grantWrite: nil,
+            grantWriteACP: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CreateMultipartUploadOutput {
+    /**
+     Default instance of the CreateMultipartUploadOutput structure.
+     */
+    public static let __default: S3Model.CreateMultipartUploadOutput = {
+        let defaultInstance = S3Model.CreateMultipartUploadOutput(
+            abortDate: nil,
+            abortRuleId: nil,
+            bucket: nil,
+            key: nil,
+            requestCharged: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKeyMD5: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil,
+            uploadId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension CreateMultipartUploadRequest {
+    /**
+     Default instance of the CreateMultipartUploadRequest structure.
+     */
+    public static let __default: S3Model.CreateMultipartUploadRequest = {
+        let defaultInstance = S3Model.CreateMultipartUploadRequest(
+            aCL: nil,
+            bucket: "value",
+            cacheControl: nil,
+            contentDisposition: nil,
+            contentEncoding: nil,
+            contentLanguage: nil,
+            contentType: nil,
+            expires: nil,
+            grantFullControl: nil,
+            grantRead: nil,
+            grantReadACP: nil,
+            grantWriteACP: nil,
+            key: "0",
+            metadata: nil,
+            requestPayer: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKey: nil,
+            sSECustomerKeyMD5: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil,
+            storageClass: nil,
+            tagging: nil,
+            websiteRedirectLocation: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Delete {
+    /**
+     Default instance of the Delete structure.
+     */
+    public static let __default: S3Model.Delete = {
+        let defaultInstance = S3Model.Delete(
+            objects: [],
+            quiet: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketAnalyticsConfigurationRequest {
+    /**
+     Default instance of the DeleteBucketAnalyticsConfigurationRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketAnalyticsConfigurationRequest = {
+        let defaultInstance = S3Model.DeleteBucketAnalyticsConfigurationRequest(
+            bucket: "value",
+            id: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketCorsRequest {
+    /**
+     Default instance of the DeleteBucketCorsRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketCorsRequest = {
+        let defaultInstance = S3Model.DeleteBucketCorsRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketEncryptionRequest {
+    /**
+     Default instance of the DeleteBucketEncryptionRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketEncryptionRequest = {
+        let defaultInstance = S3Model.DeleteBucketEncryptionRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketInventoryConfigurationRequest {
+    /**
+     Default instance of the DeleteBucketInventoryConfigurationRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketInventoryConfigurationRequest = {
+        let defaultInstance = S3Model.DeleteBucketInventoryConfigurationRequest(
+            bucket: "value",
+            id: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketLifecycleRequest {
+    /**
+     Default instance of the DeleteBucketLifecycleRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketLifecycleRequest = {
+        let defaultInstance = S3Model.DeleteBucketLifecycleRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketMetricsConfigurationRequest {
+    /**
+     Default instance of the DeleteBucketMetricsConfigurationRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketMetricsConfigurationRequest = {
+        let defaultInstance = S3Model.DeleteBucketMetricsConfigurationRequest(
+            bucket: "value",
+            id: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketPolicyRequest {
+    /**
+     Default instance of the DeleteBucketPolicyRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketPolicyRequest = {
+        let defaultInstance = S3Model.DeleteBucketPolicyRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketReplicationRequest {
+    /**
+     Default instance of the DeleteBucketReplicationRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketReplicationRequest = {
+        let defaultInstance = S3Model.DeleteBucketReplicationRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketRequest {
+    /**
+     Default instance of the DeleteBucketRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketRequest = {
+        let defaultInstance = S3Model.DeleteBucketRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketTaggingRequest {
+    /**
+     Default instance of the DeleteBucketTaggingRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketTaggingRequest = {
+        let defaultInstance = S3Model.DeleteBucketTaggingRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteBucketWebsiteRequest {
+    /**
+     Default instance of the DeleteBucketWebsiteRequest structure.
+     */
+    public static let __default: S3Model.DeleteBucketWebsiteRequest = {
+        let defaultInstance = S3Model.DeleteBucketWebsiteRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteMarkerEntry {
+    /**
+     Default instance of the DeleteMarkerEntry structure.
+     */
+    public static let __default: S3Model.DeleteMarkerEntry = {
+        let defaultInstance = S3Model.DeleteMarkerEntry(
+            isLatest: nil,
+            key: nil,
+            lastModified: nil,
+            owner: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteMarkerReplication {
+    /**
+     Default instance of the DeleteMarkerReplication structure.
+     */
+    public static let __default: S3Model.DeleteMarkerReplication = {
+        let defaultInstance = S3Model.DeleteMarkerReplication(
+            status: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteObjectOutput {
+    /**
+     Default instance of the DeleteObjectOutput structure.
+     */
+    public static let __default: S3Model.DeleteObjectOutput = {
+        let defaultInstance = S3Model.DeleteObjectOutput(
+            deleteMarker: nil,
+            requestCharged: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteObjectRequest {
+    /**
+     Default instance of the DeleteObjectRequest structure.
+     */
+    public static let __default: S3Model.DeleteObjectRequest = {
+        let defaultInstance = S3Model.DeleteObjectRequest(
+            bucket: "value",
+            key: "0",
+            mFA: nil,
+            requestPayer: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteObjectTaggingOutput {
+    /**
+     Default instance of the DeleteObjectTaggingOutput structure.
+     */
+    public static let __default: S3Model.DeleteObjectTaggingOutput = {
+        let defaultInstance = S3Model.DeleteObjectTaggingOutput(
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteObjectTaggingRequest {
+    /**
+     Default instance of the DeleteObjectTaggingRequest structure.
+     */
+    public static let __default: S3Model.DeleteObjectTaggingRequest = {
+        let defaultInstance = S3Model.DeleteObjectTaggingRequest(
+            bucket: "value",
+            key: "0",
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteObjectsOutput {
+    /**
+     Default instance of the DeleteObjectsOutput structure.
+     */
+    public static let __default: S3Model.DeleteObjectsOutput = {
+        let defaultInstance = S3Model.DeleteObjectsOutput(
+            deleted: nil,
+            errors: nil,
+            requestCharged: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension DeleteObjectsRequest {
+    /**
+     Default instance of the DeleteObjectsRequest structure.
+     */
+    public static let __default: S3Model.DeleteObjectsRequest = {
+        let defaultInstance = S3Model.DeleteObjectsRequest(
+            bucket: "value",
+            delete: Delete.__default,
+            mFA: nil,
+            requestPayer: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension DeletePublicAccessBlockRequest {
+    /**
+     Default instance of the DeletePublicAccessBlockRequest structure.
+     */
+    public static let __default: S3Model.DeletePublicAccessBlockRequest = {
+        let defaultInstance = S3Model.DeletePublicAccessBlockRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension DeletedObject {
+    /**
+     Default instance of the DeletedObject structure.
+     */
+    public static let __default: S3Model.DeletedObject = {
+        let defaultInstance = S3Model.DeletedObject(
+            deleteMarker: nil,
+            deleteMarkerVersionId: nil,
+            key: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Destination {
+    /**
+     Default instance of the Destination structure.
+     */
+    public static let __default: S3Model.Destination = {
+        let defaultInstance = S3Model.Destination(
+            accessControlTranslation: nil,
+            account: nil,
+            bucket: "value",
+            encryptionConfiguration: nil,
+            storageClass: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Encryption {
+    /**
+     Default instance of the Encryption structure.
+     */
+    public static let __default: S3Model.Encryption = {
+        let defaultInstance = S3Model.Encryption(
+            encryptionType: .__default,
+            kMSContext: nil,
+            kMSKeyId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension EncryptionConfiguration {
+    /**
+     Default instance of the EncryptionConfiguration structure.
+     */
+    public static let __default: S3Model.EncryptionConfiguration = {
+        let defaultInstance = S3Model.EncryptionConfiguration(
+            replicaKmsKeyID: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension EndEvent {
+    /**
+     Default instance of the EndEvent structure.
+     */
+    public static let __default: S3Model.EndEvent = {
+        let defaultInstance = S3Model.EndEvent()
+
+        return defaultInstance
+    }()
+}
+
+public extension Error {
+    /**
+     Default instance of the Error structure.
+     */
+    public static let __default: S3Model.Error = {
+        let defaultInstance = S3Model.Error(
+            code: nil,
+            key: nil,
+            message: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ErrorDocument {
+    /**
+     Default instance of the ErrorDocument structure.
+     */
+    public static let __default: S3Model.ErrorDocument = {
+        let defaultInstance = S3Model.ErrorDocument(
+            key: "0")
+
+        return defaultInstance
+    }()
+}
+
+public extension FilterRule {
+    /**
+     Default instance of the FilterRule structure.
+     */
+    public static let __default: S3Model.FilterRule = {
+        let defaultInstance = S3Model.FilterRule(
+            name: nil,
+            value: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketAccelerateConfigurationOutput {
+    /**
+     Default instance of the GetBucketAccelerateConfigurationOutput structure.
+     */
+    public static let __default: S3Model.GetBucketAccelerateConfigurationOutput = {
+        let defaultInstance = S3Model.GetBucketAccelerateConfigurationOutput(
+            status: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketAccelerateConfigurationRequest {
+    /**
+     Default instance of the GetBucketAccelerateConfigurationRequest structure.
+     */
+    public static let __default: S3Model.GetBucketAccelerateConfigurationRequest = {
+        let defaultInstance = S3Model.GetBucketAccelerateConfigurationRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketAclOutput {
+    /**
+     Default instance of the GetBucketAclOutput structure.
+     */
+    public static let __default: S3Model.GetBucketAclOutput = {
+        let defaultInstance = S3Model.GetBucketAclOutput(
+            grants: nil,
+            owner: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketAclRequest {
+    /**
+     Default instance of the GetBucketAclRequest structure.
+     */
+    public static let __default: S3Model.GetBucketAclRequest = {
+        let defaultInstance = S3Model.GetBucketAclRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketAnalyticsConfigurationOutput {
+    /**
+     Default instance of the GetBucketAnalyticsConfigurationOutput structure.
+     */
+    public static let __default: S3Model.GetBucketAnalyticsConfigurationOutput = {
+        let defaultInstance = S3Model.GetBucketAnalyticsConfigurationOutput(
+            analyticsConfiguration: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketAnalyticsConfigurationRequest {
+    /**
+     Default instance of the GetBucketAnalyticsConfigurationRequest structure.
+     */
+    public static let __default: S3Model.GetBucketAnalyticsConfigurationRequest = {
+        let defaultInstance = S3Model.GetBucketAnalyticsConfigurationRequest(
+            bucket: "value",
+            id: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketCorsOutput {
+    /**
+     Default instance of the GetBucketCorsOutput structure.
+     */
+    public static let __default: S3Model.GetBucketCorsOutput = {
+        let defaultInstance = S3Model.GetBucketCorsOutput(
+            cORSRules: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketCorsRequest {
+    /**
+     Default instance of the GetBucketCorsRequest structure.
+     */
+    public static let __default: S3Model.GetBucketCorsRequest = {
+        let defaultInstance = S3Model.GetBucketCorsRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketEncryptionOutput {
+    /**
+     Default instance of the GetBucketEncryptionOutput structure.
+     */
+    public static let __default: S3Model.GetBucketEncryptionOutput = {
+        let defaultInstance = S3Model.GetBucketEncryptionOutput(
+            serverSideEncryptionConfiguration: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketEncryptionRequest {
+    /**
+     Default instance of the GetBucketEncryptionRequest structure.
+     */
+    public static let __default: S3Model.GetBucketEncryptionRequest = {
+        let defaultInstance = S3Model.GetBucketEncryptionRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketInventoryConfigurationOutput {
+    /**
+     Default instance of the GetBucketInventoryConfigurationOutput structure.
+     */
+    public static let __default: S3Model.GetBucketInventoryConfigurationOutput = {
+        let defaultInstance = S3Model.GetBucketInventoryConfigurationOutput(
+            inventoryConfiguration: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketInventoryConfigurationRequest {
+    /**
+     Default instance of the GetBucketInventoryConfigurationRequest structure.
+     */
+    public static let __default: S3Model.GetBucketInventoryConfigurationRequest = {
+        let defaultInstance = S3Model.GetBucketInventoryConfigurationRequest(
+            bucket: "value",
+            id: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketLifecycleConfigurationOutput {
+    /**
+     Default instance of the GetBucketLifecycleConfigurationOutput structure.
+     */
+    public static let __default: S3Model.GetBucketLifecycleConfigurationOutput = {
+        let defaultInstance = S3Model.GetBucketLifecycleConfigurationOutput(
+            rules: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketLifecycleConfigurationRequest {
+    /**
+     Default instance of the GetBucketLifecycleConfigurationRequest structure.
+     */
+    public static let __default: S3Model.GetBucketLifecycleConfigurationRequest = {
+        let defaultInstance = S3Model.GetBucketLifecycleConfigurationRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketLifecycleOutput {
+    /**
+     Default instance of the GetBucketLifecycleOutput structure.
+     */
+    public static let __default: S3Model.GetBucketLifecycleOutput = {
+        let defaultInstance = S3Model.GetBucketLifecycleOutput(
+            rules: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketLifecycleRequest {
+    /**
+     Default instance of the GetBucketLifecycleRequest structure.
+     */
+    public static let __default: S3Model.GetBucketLifecycleRequest = {
+        let defaultInstance = S3Model.GetBucketLifecycleRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketLocationOutput {
+    /**
+     Default instance of the GetBucketLocationOutput structure.
+     */
+    public static let __default: S3Model.GetBucketLocationOutput = {
+        let defaultInstance = S3Model.GetBucketLocationOutput(
+            locationConstraint: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketLocationRequest {
+    /**
+     Default instance of the GetBucketLocationRequest structure.
+     */
+    public static let __default: S3Model.GetBucketLocationRequest = {
+        let defaultInstance = S3Model.GetBucketLocationRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketLoggingOutput {
+    /**
+     Default instance of the GetBucketLoggingOutput structure.
+     */
+    public static let __default: S3Model.GetBucketLoggingOutput = {
+        let defaultInstance = S3Model.GetBucketLoggingOutput(
+            loggingEnabled: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketLoggingRequest {
+    /**
+     Default instance of the GetBucketLoggingRequest structure.
+     */
+    public static let __default: S3Model.GetBucketLoggingRequest = {
+        let defaultInstance = S3Model.GetBucketLoggingRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketMetricsConfigurationOutput {
+    /**
+     Default instance of the GetBucketMetricsConfigurationOutput structure.
+     */
+    public static let __default: S3Model.GetBucketMetricsConfigurationOutput = {
+        let defaultInstance = S3Model.GetBucketMetricsConfigurationOutput(
+            metricsConfiguration: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketMetricsConfigurationRequest {
+    /**
+     Default instance of the GetBucketMetricsConfigurationRequest structure.
+     */
+    public static let __default: S3Model.GetBucketMetricsConfigurationRequest = {
+        let defaultInstance = S3Model.GetBucketMetricsConfigurationRequest(
+            bucket: "value",
+            id: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketNotificationConfigurationRequest {
+    /**
+     Default instance of the GetBucketNotificationConfigurationRequest structure.
+     */
+    public static let __default: S3Model.GetBucketNotificationConfigurationRequest = {
+        let defaultInstance = S3Model.GetBucketNotificationConfigurationRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketPolicyOutput {
+    /**
+     Default instance of the GetBucketPolicyOutput structure.
+     */
+    public static let __default: S3Model.GetBucketPolicyOutput = {
+        let defaultInstance = S3Model.GetBucketPolicyOutput(
+            policy: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketPolicyRequest {
+    /**
+     Default instance of the GetBucketPolicyRequest structure.
+     */
+    public static let __default: S3Model.GetBucketPolicyRequest = {
+        let defaultInstance = S3Model.GetBucketPolicyRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketPolicyStatusOutput {
+    /**
+     Default instance of the GetBucketPolicyStatusOutput structure.
+     */
+    public static let __default: S3Model.GetBucketPolicyStatusOutput = {
+        let defaultInstance = S3Model.GetBucketPolicyStatusOutput(
+            policyStatus: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketPolicyStatusRequest {
+    /**
+     Default instance of the GetBucketPolicyStatusRequest structure.
+     */
+    public static let __default: S3Model.GetBucketPolicyStatusRequest = {
+        let defaultInstance = S3Model.GetBucketPolicyStatusRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketReplicationOutput {
+    /**
+     Default instance of the GetBucketReplicationOutput structure.
+     */
+    public static let __default: S3Model.GetBucketReplicationOutput = {
+        let defaultInstance = S3Model.GetBucketReplicationOutput(
+            replicationConfiguration: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketReplicationRequest {
+    /**
+     Default instance of the GetBucketReplicationRequest structure.
+     */
+    public static let __default: S3Model.GetBucketReplicationRequest = {
+        let defaultInstance = S3Model.GetBucketReplicationRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketRequestPaymentOutput {
+    /**
+     Default instance of the GetBucketRequestPaymentOutput structure.
+     */
+    public static let __default: S3Model.GetBucketRequestPaymentOutput = {
+        let defaultInstance = S3Model.GetBucketRequestPaymentOutput(
+            payer: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketRequestPaymentRequest {
+    /**
+     Default instance of the GetBucketRequestPaymentRequest structure.
+     */
+    public static let __default: S3Model.GetBucketRequestPaymentRequest = {
+        let defaultInstance = S3Model.GetBucketRequestPaymentRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketTaggingOutput {
+    /**
+     Default instance of the GetBucketTaggingOutput structure.
+     */
+    public static let __default: S3Model.GetBucketTaggingOutput = {
+        let defaultInstance = S3Model.GetBucketTaggingOutput(
+            tagSet: [])
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketTaggingRequest {
+    /**
+     Default instance of the GetBucketTaggingRequest structure.
+     */
+    public static let __default: S3Model.GetBucketTaggingRequest = {
+        let defaultInstance = S3Model.GetBucketTaggingRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketVersioningOutput {
+    /**
+     Default instance of the GetBucketVersioningOutput structure.
+     */
+    public static let __default: S3Model.GetBucketVersioningOutput = {
+        let defaultInstance = S3Model.GetBucketVersioningOutput(
+            mFADelete: nil,
+            status: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketVersioningRequest {
+    /**
+     Default instance of the GetBucketVersioningRequest structure.
+     */
+    public static let __default: S3Model.GetBucketVersioningRequest = {
+        let defaultInstance = S3Model.GetBucketVersioningRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketWebsiteOutput {
+    /**
+     Default instance of the GetBucketWebsiteOutput structure.
+     */
+    public static let __default: S3Model.GetBucketWebsiteOutput = {
+        let defaultInstance = S3Model.GetBucketWebsiteOutput(
+            errorDocument: nil,
+            indexDocument: nil,
+            redirectAllRequestsTo: nil,
+            routingRules: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetBucketWebsiteRequest {
+    /**
+     Default instance of the GetBucketWebsiteRequest structure.
+     */
+    public static let __default: S3Model.GetBucketWebsiteRequest = {
+        let defaultInstance = S3Model.GetBucketWebsiteRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GetObjectAclOutput {
+    /**
+     Default instance of the GetObjectAclOutput structure.
+     */
+    public static let __default: S3Model.GetObjectAclOutput = {
+        let defaultInstance = S3Model.GetObjectAclOutput(
+            grants: nil,
+            owner: nil,
+            requestCharged: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetObjectAclRequest {
+    /**
+     Default instance of the GetObjectAclRequest structure.
+     */
+    public static let __default: S3Model.GetObjectAclRequest = {
+        let defaultInstance = S3Model.GetObjectAclRequest(
+            bucket: "value",
+            key: "0",
+            requestPayer: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetObjectOutput {
+    /**
+     Default instance of the GetObjectOutput structure.
+     */
+    public static let __default: S3Model.GetObjectOutput = {
+        let defaultInstance = S3Model.GetObjectOutput(
+            acceptRanges: nil,
+            body: nil,
+            cacheControl: nil,
+            contentDisposition: nil,
+            contentEncoding: nil,
+            contentLanguage: nil,
+            contentLength: nil,
+            contentRange: nil,
+            contentType: nil,
+            deleteMarker: nil,
+            eTag: nil,
+            expiration: nil,
+            expires: nil,
+            lastModified: nil,
+            metadata: nil,
+            missingMeta: nil,
+            partsCount: nil,
+            replicationStatus: nil,
+            requestCharged: nil,
+            restore: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKeyMD5: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil,
+            storageClass: nil,
+            tagCount: nil,
+            versionId: nil,
+            websiteRedirectLocation: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetObjectRequest {
+    /**
+     Default instance of the GetObjectRequest structure.
+     */
+    public static let __default: S3Model.GetObjectRequest = {
+        let defaultInstance = S3Model.GetObjectRequest(
+            bucket: "value",
+            ifMatch: nil,
+            ifModifiedSince: nil,
+            ifNoneMatch: nil,
+            ifUnmodifiedSince: nil,
+            key: "0",
+            partNumber: nil,
+            range: nil,
+            requestPayer: nil,
+            responseCacheControl: nil,
+            responseContentDisposition: nil,
+            responseContentEncoding: nil,
+            responseContentLanguage: nil,
+            responseContentType: nil,
+            responseExpires: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKey: nil,
+            sSECustomerKeyMD5: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetObjectTaggingOutput {
+    /**
+     Default instance of the GetObjectTaggingOutput structure.
+     */
+    public static let __default: S3Model.GetObjectTaggingOutput = {
+        let defaultInstance = S3Model.GetObjectTaggingOutput(
+            tagSet: [],
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetObjectTaggingRequest {
+    /**
+     Default instance of the GetObjectTaggingRequest structure.
+     */
+    public static let __default: S3Model.GetObjectTaggingRequest = {
+        let defaultInstance = S3Model.GetObjectTaggingRequest(
+            bucket: "value",
+            key: "0",
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetObjectTorrentOutput {
+    /**
+     Default instance of the GetObjectTorrentOutput structure.
+     */
+    public static let __default: S3Model.GetObjectTorrentOutput = {
+        let defaultInstance = S3Model.GetObjectTorrentOutput(
+            body: nil,
+            requestCharged: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetObjectTorrentRequest {
+    /**
+     Default instance of the GetObjectTorrentRequest structure.
+     */
+    public static let __default: S3Model.GetObjectTorrentRequest = {
+        let defaultInstance = S3Model.GetObjectTorrentRequest(
+            bucket: "value",
+            key: "0",
+            requestPayer: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetPublicAccessBlockOutput {
+    /**
+     Default instance of the GetPublicAccessBlockOutput structure.
+     */
+    public static let __default: S3Model.GetPublicAccessBlockOutput = {
+        let defaultInstance = S3Model.GetPublicAccessBlockOutput(
+            publicAccessBlockConfiguration: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension GetPublicAccessBlockRequest {
+    /**
+     Default instance of the GetPublicAccessBlockRequest structure.
+     */
+    public static let __default: S3Model.GetPublicAccessBlockRequest = {
+        let defaultInstance = S3Model.GetPublicAccessBlockRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension GlacierJobParameters {
+    /**
+     Default instance of the GlacierJobParameters structure.
+     */
+    public static let __default: S3Model.GlacierJobParameters = {
+        let defaultInstance = S3Model.GlacierJobParameters(
+            tier: .__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension Grant {
+    /**
+     Default instance of the Grant structure.
+     */
+    public static let __default: S3Model.Grant = {
+        let defaultInstance = S3Model.Grant(
+            grantee: nil,
+            permission: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Grantee {
+    /**
+     Default instance of the Grantee structure.
+     */
+    public static let __default: S3Model.Grantee = {
+        let defaultInstance = S3Model.Grantee(
+            displayName: nil,
+            emailAddress: nil,
+            iD: nil,
+            type: .__default,
+            uRI: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension HeadBucketRequest {
+    /**
+     Default instance of the HeadBucketRequest structure.
+     */
+    public static let __default: S3Model.HeadBucketRequest = {
+        let defaultInstance = S3Model.HeadBucketRequest(
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension HeadObjectOutput {
+    /**
+     Default instance of the HeadObjectOutput structure.
+     */
+    public static let __default: S3Model.HeadObjectOutput = {
+        let defaultInstance = S3Model.HeadObjectOutput(
+            acceptRanges: nil,
+            cacheControl: nil,
+            contentDisposition: nil,
+            contentEncoding: nil,
+            contentLanguage: nil,
+            contentLength: nil,
+            contentType: nil,
+            deleteMarker: nil,
+            eTag: nil,
+            expiration: nil,
+            expires: nil,
+            lastModified: nil,
+            metadata: nil,
+            missingMeta: nil,
+            partsCount: nil,
+            replicationStatus: nil,
+            requestCharged: nil,
+            restore: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKeyMD5: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil,
+            storageClass: nil,
+            versionId: nil,
+            websiteRedirectLocation: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension HeadObjectRequest {
+    /**
+     Default instance of the HeadObjectRequest structure.
+     */
+    public static let __default: S3Model.HeadObjectRequest = {
+        let defaultInstance = S3Model.HeadObjectRequest(
+            bucket: "value",
+            ifMatch: nil,
+            ifModifiedSince: nil,
+            ifNoneMatch: nil,
+            ifUnmodifiedSince: nil,
+            key: "0",
+            partNumber: nil,
+            range: nil,
+            requestPayer: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKey: nil,
+            sSECustomerKeyMD5: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension IndexDocument {
+    /**
+     Default instance of the IndexDocument structure.
+     */
+    public static let __default: S3Model.IndexDocument = {
+        let defaultInstance = S3Model.IndexDocument(
+            suffix: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension Initiator {
+    /**
+     Default instance of the Initiator structure.
+     */
+    public static let __default: S3Model.Initiator = {
+        let defaultInstance = S3Model.Initiator(
+            displayName: nil,
+            iD: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension InputSerialization {
+    /**
+     Default instance of the InputSerialization structure.
+     */
+    public static let __default: S3Model.InputSerialization = {
+        let defaultInstance = S3Model.InputSerialization(
+            cSV: nil,
+            compressionType: nil,
+            jSON: nil,
+            parquet: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension InventoryConfiguration {
+    /**
+     Default instance of the InventoryConfiguration structure.
+     */
+    public static let __default: S3Model.InventoryConfiguration = {
+        let defaultInstance = S3Model.InventoryConfiguration(
+            destination: InventoryDestination.__default,
+            filter: nil,
+            id: "value",
+            includedObjectVersions: .__default,
+            isEnabled: false,
+            optionalFields: nil,
+            schedule: InventorySchedule.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension InventoryDestination {
+    /**
+     Default instance of the InventoryDestination structure.
+     */
+    public static let __default: S3Model.InventoryDestination = {
+        let defaultInstance = S3Model.InventoryDestination(
+            s3BucketDestination: InventoryS3BucketDestination.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension InventoryEncryption {
+    /**
+     Default instance of the InventoryEncryption structure.
+     */
+    public static let __default: S3Model.InventoryEncryption = {
+        let defaultInstance = S3Model.InventoryEncryption(
+            sSEKMS: nil,
+            sSES3: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension InventoryFilter {
+    /**
+     Default instance of the InventoryFilter structure.
+     */
+    public static let __default: S3Model.InventoryFilter = {
+        let defaultInstance = S3Model.InventoryFilter(
+            prefix: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension InventoryS3BucketDestination {
+    /**
+     Default instance of the InventoryS3BucketDestination structure.
+     */
+    public static let __default: S3Model.InventoryS3BucketDestination = {
+        let defaultInstance = S3Model.InventoryS3BucketDestination(
+            accountId: nil,
+            bucket: "value",
+            encryption: nil,
+            format: .__default,
+            prefix: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension InventorySchedule {
+    /**
+     Default instance of the InventorySchedule structure.
+     */
+    public static let __default: S3Model.InventorySchedule = {
+        let defaultInstance = S3Model.InventorySchedule(
+            frequency: .__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension JSONInput {
+    /**
+     Default instance of the JSONInput structure.
+     */
+    public static let __default: S3Model.JSONInput = {
+        let defaultInstance = S3Model.JSONInput(
+            type: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension JSONOutput {
+    /**
+     Default instance of the JSONOutput structure.
+     */
+    public static let __default: S3Model.JSONOutput = {
+        let defaultInstance = S3Model.JSONOutput(
+            recordDelimiter: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension LambdaFunctionConfiguration {
+    /**
+     Default instance of the LambdaFunctionConfiguration structure.
+     */
+    public static let __default: S3Model.LambdaFunctionConfiguration = {
+        let defaultInstance = S3Model.LambdaFunctionConfiguration(
+            events: [],
+            filter: nil,
+            id: nil,
+            lambdaFunctionArn: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension LifecycleConfiguration {
+    /**
+     Default instance of the LifecycleConfiguration structure.
+     */
+    public static let __default: S3Model.LifecycleConfiguration = {
+        let defaultInstance = S3Model.LifecycleConfiguration(
+            rules: [])
+
+        return defaultInstance
+    }()
+}
+
+public extension LifecycleExpiration {
+    /**
+     Default instance of the LifecycleExpiration structure.
+     */
+    public static let __default: S3Model.LifecycleExpiration = {
+        let defaultInstance = S3Model.LifecycleExpiration(
+            date: nil,
+            days: nil,
+            expiredObjectDeleteMarker: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension LifecycleRule {
+    /**
+     Default instance of the LifecycleRule structure.
+     */
+    public static let __default: S3Model.LifecycleRule = {
+        let defaultInstance = S3Model.LifecycleRule(
+            abortIncompleteMultipartUpload: nil,
+            expiration: nil,
+            filter: nil,
+            iD: nil,
+            noncurrentVersionExpiration: nil,
+            noncurrentVersionTransitions: nil,
+            status: .__default,
+            transitions: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension LifecycleRuleAndOperator {
+    /**
+     Default instance of the LifecycleRuleAndOperator structure.
+     */
+    public static let __default: S3Model.LifecycleRuleAndOperator = {
+        let defaultInstance = S3Model.LifecycleRuleAndOperator(
+            prefix: nil,
+            tags: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension LifecycleRuleFilter {
+    /**
+     Default instance of the LifecycleRuleFilter structure.
+     */
+    public static let __default: S3Model.LifecycleRuleFilter = {
+        let defaultInstance = S3Model.LifecycleRuleFilter(
+            and: nil,
+            prefix: nil,
+            tag: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListBucketAnalyticsConfigurationsOutput {
+    /**
+     Default instance of the ListBucketAnalyticsConfigurationsOutput structure.
+     */
+    public static let __default: S3Model.ListBucketAnalyticsConfigurationsOutput = {
+        let defaultInstance = S3Model.ListBucketAnalyticsConfigurationsOutput(
+            analyticsConfigurationList: nil,
+            continuationToken: nil,
+            isTruncated: nil,
+            nextContinuationToken: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListBucketAnalyticsConfigurationsRequest {
+    /**
+     Default instance of the ListBucketAnalyticsConfigurationsRequest structure.
+     */
+    public static let __default: S3Model.ListBucketAnalyticsConfigurationsRequest = {
+        let defaultInstance = S3Model.ListBucketAnalyticsConfigurationsRequest(
+            bucket: "value",
+            continuationToken: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListBucketInventoryConfigurationsOutput {
+    /**
+     Default instance of the ListBucketInventoryConfigurationsOutput structure.
+     */
+    public static let __default: S3Model.ListBucketInventoryConfigurationsOutput = {
+        let defaultInstance = S3Model.ListBucketInventoryConfigurationsOutput(
+            continuationToken: nil,
+            inventoryConfigurationList: nil,
+            isTruncated: nil,
+            nextContinuationToken: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListBucketInventoryConfigurationsRequest {
+    /**
+     Default instance of the ListBucketInventoryConfigurationsRequest structure.
+     */
+    public static let __default: S3Model.ListBucketInventoryConfigurationsRequest = {
+        let defaultInstance = S3Model.ListBucketInventoryConfigurationsRequest(
+            bucket: "value",
+            continuationToken: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListBucketMetricsConfigurationsOutput {
+    /**
+     Default instance of the ListBucketMetricsConfigurationsOutput structure.
+     */
+    public static let __default: S3Model.ListBucketMetricsConfigurationsOutput = {
+        let defaultInstance = S3Model.ListBucketMetricsConfigurationsOutput(
+            continuationToken: nil,
+            isTruncated: nil,
+            metricsConfigurationList: nil,
+            nextContinuationToken: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListBucketMetricsConfigurationsRequest {
+    /**
+     Default instance of the ListBucketMetricsConfigurationsRequest structure.
+     */
+    public static let __default: S3Model.ListBucketMetricsConfigurationsRequest = {
+        let defaultInstance = S3Model.ListBucketMetricsConfigurationsRequest(
+            bucket: "value",
+            continuationToken: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListBucketsOutput {
+    /**
+     Default instance of the ListBucketsOutput structure.
+     */
+    public static let __default: S3Model.ListBucketsOutput = {
+        let defaultInstance = S3Model.ListBucketsOutput(
+            buckets: nil,
+            owner: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListMultipartUploadsOutput {
+    /**
+     Default instance of the ListMultipartUploadsOutput structure.
+     */
+    public static let __default: S3Model.ListMultipartUploadsOutput = {
+        let defaultInstance = S3Model.ListMultipartUploadsOutput(
+            bucket: nil,
+            commonPrefixes: nil,
+            delimiter: nil,
+            encodingType: nil,
+            isTruncated: nil,
+            keyMarker: nil,
+            maxUploads: nil,
+            nextKeyMarker: nil,
+            nextUploadIdMarker: nil,
+            prefix: nil,
+            uploadIdMarker: nil,
+            uploads: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListMultipartUploadsRequest {
+    /**
+     Default instance of the ListMultipartUploadsRequest structure.
+     */
+    public static let __default: S3Model.ListMultipartUploadsRequest = {
+        let defaultInstance = S3Model.ListMultipartUploadsRequest(
+            bucket: "value",
+            delimiter: nil,
+            encodingType: nil,
+            keyMarker: nil,
+            maxUploads: nil,
+            prefix: nil,
+            uploadIdMarker: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListObjectVersionsOutput {
+    /**
+     Default instance of the ListObjectVersionsOutput structure.
+     */
+    public static let __default: S3Model.ListObjectVersionsOutput = {
+        let defaultInstance = S3Model.ListObjectVersionsOutput(
+            commonPrefixes: nil,
+            deleteMarkers: nil,
+            delimiter: nil,
+            encodingType: nil,
+            isTruncated: nil,
+            keyMarker: nil,
+            maxKeys: nil,
+            name: nil,
+            nextKeyMarker: nil,
+            nextVersionIdMarker: nil,
+            prefix: nil,
+            versionIdMarker: nil,
+            versions: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListObjectVersionsRequest {
+    /**
+     Default instance of the ListObjectVersionsRequest structure.
+     */
+    public static let __default: S3Model.ListObjectVersionsRequest = {
+        let defaultInstance = S3Model.ListObjectVersionsRequest(
+            bucket: "value",
+            delimiter: nil,
+            encodingType: nil,
+            keyMarker: nil,
+            maxKeys: nil,
+            prefix: nil,
+            versionIdMarker: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListObjectsOutput {
+    /**
+     Default instance of the ListObjectsOutput structure.
+     */
+    public static let __default: S3Model.ListObjectsOutput = {
+        let defaultInstance = S3Model.ListObjectsOutput(
+            commonPrefixes: nil,
+            contents: nil,
+            delimiter: nil,
+            encodingType: nil,
+            isTruncated: nil,
+            marker: nil,
+            maxKeys: nil,
+            name: nil,
+            nextMarker: nil,
+            prefix: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListObjectsRequest {
+    /**
+     Default instance of the ListObjectsRequest structure.
+     */
+    public static let __default: S3Model.ListObjectsRequest = {
+        let defaultInstance = S3Model.ListObjectsRequest(
+            bucket: "value",
+            delimiter: nil,
+            encodingType: nil,
+            marker: nil,
+            maxKeys: nil,
+            prefix: nil,
+            requestPayer: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListObjectsV2Output {
+    /**
+     Default instance of the ListObjectsV2Output structure.
+     */
+    public static let __default: S3Model.ListObjectsV2Output = {
+        let defaultInstance = S3Model.ListObjectsV2Output(
+            commonPrefixes: nil,
+            contents: nil,
+            continuationToken: nil,
+            delimiter: nil,
+            encodingType: nil,
+            isTruncated: nil,
+            keyCount: nil,
+            maxKeys: nil,
+            name: nil,
+            nextContinuationToken: nil,
+            prefix: nil,
+            startAfter: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListObjectsV2Request {
+    /**
+     Default instance of the ListObjectsV2Request structure.
+     */
+    public static let __default: S3Model.ListObjectsV2Request = {
+        let defaultInstance = S3Model.ListObjectsV2Request(
+            bucket: "value",
+            continuationToken: nil,
+            delimiter: nil,
+            encodingType: nil,
+            fetchOwner: nil,
+            maxKeys: nil,
+            prefix: nil,
+            requestPayer: nil,
+            startAfter: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListPartsOutput {
+    /**
+     Default instance of the ListPartsOutput structure.
+     */
+    public static let __default: S3Model.ListPartsOutput = {
+        let defaultInstance = S3Model.ListPartsOutput(
+            abortDate: nil,
+            abortRuleId: nil,
+            bucket: nil,
+            initiator: nil,
+            isTruncated: nil,
+            key: nil,
+            maxParts: nil,
+            nextPartNumberMarker: nil,
+            owner: nil,
+            partNumberMarker: nil,
+            parts: nil,
+            requestCharged: nil,
+            storageClass: nil,
+            uploadId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ListPartsRequest {
+    /**
+     Default instance of the ListPartsRequest structure.
+     */
+    public static let __default: S3Model.ListPartsRequest = {
+        let defaultInstance = S3Model.ListPartsRequest(
+            bucket: "value",
+            key: "0",
+            maxParts: nil,
+            partNumberMarker: nil,
+            requestPayer: nil,
+            uploadId: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension LoggingEnabled {
+    /**
+     Default instance of the LoggingEnabled structure.
+     */
+    public static let __default: S3Model.LoggingEnabled = {
+        let defaultInstance = S3Model.LoggingEnabled(
+            targetBucket: "value",
+            targetGrants: nil,
+            targetPrefix: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension MetadataEntry {
+    /**
+     Default instance of the MetadataEntry structure.
+     */
+    public static let __default: S3Model.MetadataEntry = {
+        let defaultInstance = S3Model.MetadataEntry(
+            name: nil,
+            value: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension MetricsAndOperator {
+    /**
+     Default instance of the MetricsAndOperator structure.
+     */
+    public static let __default: S3Model.MetricsAndOperator = {
+        let defaultInstance = S3Model.MetricsAndOperator(
+            prefix: nil,
+            tags: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension MetricsConfiguration {
+    /**
+     Default instance of the MetricsConfiguration structure.
+     */
+    public static let __default: S3Model.MetricsConfiguration = {
+        let defaultInstance = S3Model.MetricsConfiguration(
+            filter: nil,
+            id: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension MetricsFilter {
+    /**
+     Default instance of the MetricsFilter structure.
+     */
+    public static let __default: S3Model.MetricsFilter = {
+        let defaultInstance = S3Model.MetricsFilter(
+            and: nil,
+            prefix: nil,
+            tag: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension MultipartUpload {
+    /**
+     Default instance of the MultipartUpload structure.
+     */
+    public static let __default: S3Model.MultipartUpload = {
+        let defaultInstance = S3Model.MultipartUpload(
+            initiated: nil,
+            initiator: nil,
+            key: nil,
+            owner: nil,
+            storageClass: nil,
+            uploadId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension NoSuchBucket {
+    /**
+     Default instance of the NoSuchBucket structure.
+     */
+    public static let __default: S3Model.NoSuchBucket = {
+        let defaultInstance = S3Model.NoSuchBucket()
+
+        return defaultInstance
+    }()
+}
+
+public extension NoSuchKey {
+    /**
+     Default instance of the NoSuchKey structure.
+     */
+    public static let __default: S3Model.NoSuchKey = {
+        let defaultInstance = S3Model.NoSuchKey()
+
+        return defaultInstance
+    }()
+}
+
+public extension NoSuchUpload {
+    /**
+     Default instance of the NoSuchUpload structure.
+     */
+    public static let __default: S3Model.NoSuchUpload = {
+        let defaultInstance = S3Model.NoSuchUpload()
+
+        return defaultInstance
+    }()
+}
+
+public extension NoncurrentVersionExpiration {
+    /**
+     Default instance of the NoncurrentVersionExpiration structure.
+     */
+    public static let __default: S3Model.NoncurrentVersionExpiration = {
+        let defaultInstance = S3Model.NoncurrentVersionExpiration(
+            noncurrentDays: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension NoncurrentVersionTransition {
+    /**
+     Default instance of the NoncurrentVersionTransition structure.
+     */
+    public static let __default: S3Model.NoncurrentVersionTransition = {
+        let defaultInstance = S3Model.NoncurrentVersionTransition(
+            noncurrentDays: nil,
+            storageClass: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension NotificationConfiguration {
+    /**
+     Default instance of the NotificationConfiguration structure.
+     */
+    public static let __default: S3Model.NotificationConfiguration = {
+        let defaultInstance = S3Model.NotificationConfiguration(
+            lambdaFunctionConfigurations: nil,
+            queueConfigurations: nil,
+            topicConfigurations: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension NotificationConfigurationDeprecated {
+    /**
+     Default instance of the NotificationConfigurationDeprecated structure.
+     */
+    public static let __default: S3Model.NotificationConfigurationDeprecated = {
+        let defaultInstance = S3Model.NotificationConfigurationDeprecated(
+            cloudFunctionConfiguration: nil,
+            queueConfiguration: nil,
+            topicConfiguration: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension NotificationConfigurationFilter {
+    /**
+     Default instance of the NotificationConfigurationFilter structure.
+     */
+    public static let __default: S3Model.NotificationConfigurationFilter = {
+        let defaultInstance = S3Model.NotificationConfigurationFilter(
+            key: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Object {
+    /**
+     Default instance of the Object structure.
+     */
+    public static let __default: S3Model.Object = {
+        let defaultInstance = S3Model.Object(
+            eTag: nil,
+            key: nil,
+            lastModified: nil,
+            owner: nil,
+            size: nil,
+            storageClass: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ObjectAlreadyInActiveTierError {
+    /**
+     Default instance of the ObjectAlreadyInActiveTierError structure.
+     */
+    public static let __default: S3Model.ObjectAlreadyInActiveTierError = {
+        let defaultInstance = S3Model.ObjectAlreadyInActiveTierError()
+
+        return defaultInstance
+    }()
+}
+
+public extension ObjectIdentifier {
+    /**
+     Default instance of the ObjectIdentifier structure.
+     */
+    public static let __default: S3Model.ObjectIdentifier = {
+        let defaultInstance = S3Model.ObjectIdentifier(
+            key: "0",
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ObjectNotInActiveTierError {
+    /**
+     Default instance of the ObjectNotInActiveTierError structure.
+     */
+    public static let __default: S3Model.ObjectNotInActiveTierError = {
+        let defaultInstance = S3Model.ObjectNotInActiveTierError()
+
+        return defaultInstance
+    }()
+}
+
+public extension ObjectVersion {
+    /**
+     Default instance of the ObjectVersion structure.
+     */
+    public static let __default: S3Model.ObjectVersion = {
+        let defaultInstance = S3Model.ObjectVersion(
+            eTag: nil,
+            isLatest: nil,
+            key: nil,
+            lastModified: nil,
+            owner: nil,
+            size: nil,
+            storageClass: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension OutputLocation {
+    /**
+     Default instance of the OutputLocation structure.
+     */
+    public static let __default: S3Model.OutputLocation = {
+        let defaultInstance = S3Model.OutputLocation(
+            s3: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension OutputSerialization {
+    /**
+     Default instance of the OutputSerialization structure.
+     */
+    public static let __default: S3Model.OutputSerialization = {
+        let defaultInstance = S3Model.OutputSerialization(
+            cSV: nil,
+            jSON: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Owner {
+    /**
+     Default instance of the Owner structure.
+     */
+    public static let __default: S3Model.Owner = {
+        let defaultInstance = S3Model.Owner(
+            displayName: nil,
+            iD: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ParquetInput {
+    /**
+     Default instance of the ParquetInput structure.
+     */
+    public static let __default: S3Model.ParquetInput = {
+        let defaultInstance = S3Model.ParquetInput()
+
+        return defaultInstance
+    }()
+}
+
+public extension Part {
+    /**
+     Default instance of the Part structure.
+     */
+    public static let __default: S3Model.Part = {
+        let defaultInstance = S3Model.Part(
+            eTag: nil,
+            lastModified: nil,
+            partNumber: nil,
+            size: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PolicyStatus {
+    /**
+     Default instance of the PolicyStatus structure.
+     */
+    public static let __default: S3Model.PolicyStatus = {
+        let defaultInstance = S3Model.PolicyStatus(
+            isPublic: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Progress {
+    /**
+     Default instance of the Progress structure.
+     */
+    public static let __default: S3Model.Progress = {
+        let defaultInstance = S3Model.Progress(
+            bytesProcessed: nil,
+            bytesReturned: nil,
+            bytesScanned: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ProgressEvent {
+    /**
+     Default instance of the ProgressEvent structure.
+     */
+    public static let __default: S3Model.ProgressEvent = {
+        let defaultInstance = S3Model.ProgressEvent(
+            details: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PublicAccessBlockConfiguration {
+    /**
+     Default instance of the PublicAccessBlockConfiguration structure.
+     */
+    public static let __default: S3Model.PublicAccessBlockConfiguration = {
+        let defaultInstance = S3Model.PublicAccessBlockConfiguration(
+            blockPublicAcls: nil,
+            blockPublicPolicy: nil,
+            ignorePublicAcls: nil,
+            restrictPublicBuckets: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketAccelerateConfigurationRequest {
+    /**
+     Default instance of the PutBucketAccelerateConfigurationRequest structure.
+     */
+    public static let __default: S3Model.PutBucketAccelerateConfigurationRequest = {
+        let defaultInstance = S3Model.PutBucketAccelerateConfigurationRequest(
+            accelerateConfiguration: AccelerateConfiguration.__default,
+            bucket: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketAclRequest {
+    /**
+     Default instance of the PutBucketAclRequest structure.
+     */
+    public static let __default: S3Model.PutBucketAclRequest = {
+        let defaultInstance = S3Model.PutBucketAclRequest(
+            aCL: nil,
+            accessControlPolicy: nil,
+            bucket: "value",
+            contentMD5: nil,
+            grantFullControl: nil,
+            grantRead: nil,
+            grantReadACP: nil,
+            grantWrite: nil,
+            grantWriteACP: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketAnalyticsConfigurationRequest {
+    /**
+     Default instance of the PutBucketAnalyticsConfigurationRequest structure.
+     */
+    public static let __default: S3Model.PutBucketAnalyticsConfigurationRequest = {
+        let defaultInstance = S3Model.PutBucketAnalyticsConfigurationRequest(
+            analyticsConfiguration: AnalyticsConfiguration.__default,
+            bucket: "value",
+            id: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketCorsRequest {
+    /**
+     Default instance of the PutBucketCorsRequest structure.
+     */
+    public static let __default: S3Model.PutBucketCorsRequest = {
+        let defaultInstance = S3Model.PutBucketCorsRequest(
+            bucket: "value",
+            cORSConfiguration: CORSConfiguration.__default,
+            contentMD5: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketEncryptionRequest {
+    /**
+     Default instance of the PutBucketEncryptionRequest structure.
+     */
+    public static let __default: S3Model.PutBucketEncryptionRequest = {
+        let defaultInstance = S3Model.PutBucketEncryptionRequest(
+            bucket: "value",
+            contentMD5: nil,
+            serverSideEncryptionConfiguration: ServerSideEncryptionConfiguration.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketInventoryConfigurationRequest {
+    /**
+     Default instance of the PutBucketInventoryConfigurationRequest structure.
+     */
+    public static let __default: S3Model.PutBucketInventoryConfigurationRequest = {
+        let defaultInstance = S3Model.PutBucketInventoryConfigurationRequest(
+            bucket: "value",
+            id: "value",
+            inventoryConfiguration: InventoryConfiguration.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketLifecycleConfigurationRequest {
+    /**
+     Default instance of the PutBucketLifecycleConfigurationRequest structure.
+     */
+    public static let __default: S3Model.PutBucketLifecycleConfigurationRequest = {
+        let defaultInstance = S3Model.PutBucketLifecycleConfigurationRequest(
+            bucket: "value",
+            lifecycleConfiguration: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketLifecycleRequest {
+    /**
+     Default instance of the PutBucketLifecycleRequest structure.
+     */
+    public static let __default: S3Model.PutBucketLifecycleRequest = {
+        let defaultInstance = S3Model.PutBucketLifecycleRequest(
+            bucket: "value",
+            contentMD5: nil,
+            lifecycleConfiguration: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketLoggingRequest {
+    /**
+     Default instance of the PutBucketLoggingRequest structure.
+     */
+    public static let __default: S3Model.PutBucketLoggingRequest = {
+        let defaultInstance = S3Model.PutBucketLoggingRequest(
+            bucket: "value",
+            bucketLoggingStatus: BucketLoggingStatus.__default,
+            contentMD5: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketMetricsConfigurationRequest {
+    /**
+     Default instance of the PutBucketMetricsConfigurationRequest structure.
+     */
+    public static let __default: S3Model.PutBucketMetricsConfigurationRequest = {
+        let defaultInstance = S3Model.PutBucketMetricsConfigurationRequest(
+            bucket: "value",
+            id: "value",
+            metricsConfiguration: MetricsConfiguration.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketNotificationConfigurationRequest {
+    /**
+     Default instance of the PutBucketNotificationConfigurationRequest structure.
+     */
+    public static let __default: S3Model.PutBucketNotificationConfigurationRequest = {
+        let defaultInstance = S3Model.PutBucketNotificationConfigurationRequest(
+            bucket: "value",
+            notificationConfiguration: NotificationConfiguration.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketNotificationRequest {
+    /**
+     Default instance of the PutBucketNotificationRequest structure.
+     */
+    public static let __default: S3Model.PutBucketNotificationRequest = {
+        let defaultInstance = S3Model.PutBucketNotificationRequest(
+            bucket: "value",
+            contentMD5: nil,
+            notificationConfiguration: NotificationConfigurationDeprecated.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketPolicyRequest {
+    /**
+     Default instance of the PutBucketPolicyRequest structure.
+     */
+    public static let __default: S3Model.PutBucketPolicyRequest = {
+        let defaultInstance = S3Model.PutBucketPolicyRequest(
+            bucket: "value",
+            confirmRemoveSelfBucketAccess: nil,
+            contentMD5: nil,
+            policy: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketReplicationRequest {
+    /**
+     Default instance of the PutBucketReplicationRequest structure.
+     */
+    public static let __default: S3Model.PutBucketReplicationRequest = {
+        let defaultInstance = S3Model.PutBucketReplicationRequest(
+            bucket: "value",
+            contentMD5: nil,
+            replicationConfiguration: ReplicationConfiguration.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketRequestPaymentRequest {
+    /**
+     Default instance of the PutBucketRequestPaymentRequest structure.
+     */
+    public static let __default: S3Model.PutBucketRequestPaymentRequest = {
+        let defaultInstance = S3Model.PutBucketRequestPaymentRequest(
+            bucket: "value",
+            contentMD5: nil,
+            requestPaymentConfiguration: RequestPaymentConfiguration.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketTaggingRequest {
+    /**
+     Default instance of the PutBucketTaggingRequest structure.
+     */
+    public static let __default: S3Model.PutBucketTaggingRequest = {
+        let defaultInstance = S3Model.PutBucketTaggingRequest(
+            bucket: "value",
+            contentMD5: nil,
+            tagging: Tagging.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketVersioningRequest {
+    /**
+     Default instance of the PutBucketVersioningRequest structure.
+     */
+    public static let __default: S3Model.PutBucketVersioningRequest = {
+        let defaultInstance = S3Model.PutBucketVersioningRequest(
+            bucket: "value",
+            contentMD5: nil,
+            mFA: nil,
+            versioningConfiguration: VersioningConfiguration.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutBucketWebsiteRequest {
+    /**
+     Default instance of the PutBucketWebsiteRequest structure.
+     */
+    public static let __default: S3Model.PutBucketWebsiteRequest = {
+        let defaultInstance = S3Model.PutBucketWebsiteRequest(
+            bucket: "value",
+            contentMD5: nil,
+            websiteConfiguration: WebsiteConfiguration.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutObjectAclOutput {
+    /**
+     Default instance of the PutObjectAclOutput structure.
+     */
+    public static let __default: S3Model.PutObjectAclOutput = {
+        let defaultInstance = S3Model.PutObjectAclOutput(
+            requestCharged: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutObjectAclRequest {
+    /**
+     Default instance of the PutObjectAclRequest structure.
+     */
+    public static let __default: S3Model.PutObjectAclRequest = {
+        let defaultInstance = S3Model.PutObjectAclRequest(
+            aCL: nil,
+            accessControlPolicy: nil,
+            bucket: "value",
+            contentMD5: nil,
+            grantFullControl: nil,
+            grantRead: nil,
+            grantReadACP: nil,
+            grantWrite: nil,
+            grantWriteACP: nil,
+            key: "0",
+            requestPayer: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutObjectOutput {
+    /**
+     Default instance of the PutObjectOutput structure.
+     */
+    public static let __default: S3Model.PutObjectOutput = {
+        let defaultInstance = S3Model.PutObjectOutput(
+            eTag: nil,
+            expiration: nil,
+            requestCharged: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKeyMD5: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutObjectRequest {
+    /**
+     Default instance of the PutObjectRequest structure.
+     */
+    public static let __default: S3Model.PutObjectRequest = {
+        let defaultInstance = S3Model.PutObjectRequest(
+            aCL: nil,
+            body: nil,
+            bucket: "value",
+            cacheControl: nil,
+            contentDisposition: nil,
+            contentEncoding: nil,
+            contentLanguage: nil,
+            contentLength: nil,
+            contentMD5: nil,
+            contentType: nil,
+            expires: nil,
+            grantFullControl: nil,
+            grantRead: nil,
+            grantReadACP: nil,
+            grantWriteACP: nil,
+            key: "0",
+            metadata: nil,
+            requestPayer: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKey: nil,
+            sSECustomerKeyMD5: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil,
+            storageClass: nil,
+            tagging: nil,
+            websiteRedirectLocation: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutObjectTaggingOutput {
+    /**
+     Default instance of the PutObjectTaggingOutput structure.
+     */
+    public static let __default: S3Model.PutObjectTaggingOutput = {
+        let defaultInstance = S3Model.PutObjectTaggingOutput(
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutObjectTaggingRequest {
+    /**
+     Default instance of the PutObjectTaggingRequest structure.
+     */
+    public static let __default: S3Model.PutObjectTaggingRequest = {
+        let defaultInstance = S3Model.PutObjectTaggingRequest(
+            bucket: "value",
+            contentMD5: nil,
+            key: "0",
+            tagging: Tagging.__default,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension PutPublicAccessBlockRequest {
+    /**
+     Default instance of the PutPublicAccessBlockRequest structure.
+     */
+    public static let __default: S3Model.PutPublicAccessBlockRequest = {
+        let defaultInstance = S3Model.PutPublicAccessBlockRequest(
+            bucket: "value",
+            contentMD5: nil,
+            publicAccessBlockConfiguration: PublicAccessBlockConfiguration.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension QueueConfiguration {
+    /**
+     Default instance of the QueueConfiguration structure.
+     */
+    public static let __default: S3Model.QueueConfiguration = {
+        let defaultInstance = S3Model.QueueConfiguration(
+            events: [],
+            filter: nil,
+            id: nil,
+            queueArn: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension QueueConfigurationDeprecated {
+    /**
+     Default instance of the QueueConfigurationDeprecated structure.
+     */
+    public static let __default: S3Model.QueueConfigurationDeprecated = {
+        let defaultInstance = S3Model.QueueConfigurationDeprecated(
+            events: nil,
+            id: nil,
+            queue: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension RecordsEvent {
+    /**
+     Default instance of the RecordsEvent structure.
+     */
+    public static let __default: S3Model.RecordsEvent = {
+        let defaultInstance = S3Model.RecordsEvent(
+            payload: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Redirect {
+    /**
+     Default instance of the Redirect structure.
+     */
+    public static let __default: S3Model.Redirect = {
+        let defaultInstance = S3Model.Redirect(
+            hostName: nil,
+            httpRedirectCode: nil,
+            protocol: nil,
+            replaceKeyPrefixWith: nil,
+            replaceKeyWith: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension RedirectAllRequestsTo {
+    /**
+     Default instance of the RedirectAllRequestsTo structure.
+     */
+    public static let __default: S3Model.RedirectAllRequestsTo = {
+        let defaultInstance = S3Model.RedirectAllRequestsTo(
+            hostName: "value",
+            protocol: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ReplicationConfiguration {
+    /**
+     Default instance of the ReplicationConfiguration structure.
+     */
+    public static let __default: S3Model.ReplicationConfiguration = {
+        let defaultInstance = S3Model.ReplicationConfiguration(
+            role: "value",
+            rules: [])
+
+        return defaultInstance
+    }()
+}
+
+public extension ReplicationRule {
+    /**
+     Default instance of the ReplicationRule structure.
+     */
+    public static let __default: S3Model.ReplicationRule = {
+        let defaultInstance = S3Model.ReplicationRule(
+            deleteMarkerReplication: nil,
+            destination: Destination.__default,
+            filter: nil,
+            iD: nil,
+            priority: nil,
+            sourceSelectionCriteria: nil,
+            status: .__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension ReplicationRuleAndOperator {
+    /**
+     Default instance of the ReplicationRuleAndOperator structure.
+     */
+    public static let __default: S3Model.ReplicationRuleAndOperator = {
+        let defaultInstance = S3Model.ReplicationRuleAndOperator(
+            prefix: nil,
+            tags: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ReplicationRuleFilter {
+    /**
+     Default instance of the ReplicationRuleFilter structure.
+     */
+    public static let __default: S3Model.ReplicationRuleFilter = {
+        let defaultInstance = S3Model.ReplicationRuleFilter(
+            and: nil,
+            prefix: nil,
+            tag: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension RequestPaymentConfiguration {
+    /**
+     Default instance of the RequestPaymentConfiguration structure.
+     */
+    public static let __default: S3Model.RequestPaymentConfiguration = {
+        let defaultInstance = S3Model.RequestPaymentConfiguration(
+            payer: .__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension RequestProgress {
+    /**
+     Default instance of the RequestProgress structure.
+     */
+    public static let __default: S3Model.RequestProgress = {
+        let defaultInstance = S3Model.RequestProgress(
+            enabled: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension RestoreObjectOutput {
+    /**
+     Default instance of the RestoreObjectOutput structure.
+     */
+    public static let __default: S3Model.RestoreObjectOutput = {
+        let defaultInstance = S3Model.RestoreObjectOutput(
+            requestCharged: nil,
+            restoreOutputPath: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension RestoreObjectRequest {
+    /**
+     Default instance of the RestoreObjectRequest structure.
+     */
+    public static let __default: S3Model.RestoreObjectRequest = {
+        let defaultInstance = S3Model.RestoreObjectRequest(
+            bucket: "value",
+            key: "0",
+            requestPayer: nil,
+            restoreRequest: nil,
+            versionId: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension RestoreRequest {
+    /**
+     Default instance of the RestoreRequest structure.
+     */
+    public static let __default: S3Model.RestoreRequest = {
+        let defaultInstance = S3Model.RestoreRequest(
+            days: nil,
+            description: nil,
+            glacierJobParameters: nil,
+            outputLocation: nil,
+            selectParameters: nil,
+            tier: nil,
+            type: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension RoutingRule {
+    /**
+     Default instance of the RoutingRule structure.
+     */
+    public static let __default: S3Model.RoutingRule = {
+        let defaultInstance = S3Model.RoutingRule(
+            condition: nil,
+            redirect: Redirect.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension Rule {
+    /**
+     Default instance of the Rule structure.
+     */
+    public static let __default: S3Model.Rule = {
+        let defaultInstance = S3Model.Rule(
+            abortIncompleteMultipartUpload: nil,
+            expiration: nil,
+            iD: nil,
+            noncurrentVersionExpiration: nil,
+            noncurrentVersionTransition: nil,
+            prefix: "value",
+            status: .__default,
+            transition: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension S3KeyFilter {
+    /**
+     Default instance of the S3KeyFilter structure.
+     */
+    public static let __default: S3Model.S3KeyFilter = {
+        let defaultInstance = S3Model.S3KeyFilter(
+            filterRules: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension S3Location {
+    /**
+     Default instance of the S3Location structure.
+     */
+    public static let __default: S3Model.S3Location = {
+        let defaultInstance = S3Model.S3Location(
+            accessControlList: nil,
+            bucketName: "value",
+            cannedACL: nil,
+            encryption: nil,
+            prefix: "value",
+            storageClass: nil,
+            tagging: nil,
+            userMetadata: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension SSEKMS {
+    /**
+     Default instance of the SSEKMS structure.
+     */
+    public static let __default: S3Model.SSEKMS = {
+        let defaultInstance = S3Model.SSEKMS(
+            keyId: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension SSES3 {
+    /**
+     Default instance of the SSES3 structure.
+     */
+    public static let __default: S3Model.SSES3 = {
+        let defaultInstance = S3Model.SSES3()
+
+        return defaultInstance
+    }()
+}
+
+public extension SelectObjectContentEventStream {
+    /**
+     Default instance of the SelectObjectContentEventStream structure.
+     */
+    public static let __default: S3Model.SelectObjectContentEventStream = {
+        let defaultInstance = S3Model.SelectObjectContentEventStream(
+            cont: nil,
+            end: nil,
+            progress: nil,
+            records: nil,
+            stats: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension SelectObjectContentOutput {
+    /**
+     Default instance of the SelectObjectContentOutput structure.
+     */
+    public static let __default: S3Model.SelectObjectContentOutput = {
+        let defaultInstance = S3Model.SelectObjectContentOutput(
+            payload: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension SelectObjectContentRequest {
+    /**
+     Default instance of the SelectObjectContentRequest structure.
+     */
+    public static let __default: S3Model.SelectObjectContentRequest = {
+        let defaultInstance = S3Model.SelectObjectContentRequest(
+            bucket: "value",
+            expression: "value",
+            expressionType: .__default,
+            inputSerialization: InputSerialization.__default,
+            key: "0",
+            outputSerialization: OutputSerialization.__default,
+            requestProgress: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKey: nil,
+            sSECustomerKeyMD5: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension SelectParameters {
+    /**
+     Default instance of the SelectParameters structure.
+     */
+    public static let __default: S3Model.SelectParameters = {
+        let defaultInstance = S3Model.SelectParameters(
+            expression: "value",
+            expressionType: .__default,
+            inputSerialization: InputSerialization.__default,
+            outputSerialization: OutputSerialization.__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension ServerSideEncryptionByDefault {
+    /**
+     Default instance of the ServerSideEncryptionByDefault structure.
+     */
+    public static let __default: S3Model.ServerSideEncryptionByDefault = {
+        let defaultInstance = S3Model.ServerSideEncryptionByDefault(
+            kMSMasterKeyID: nil,
+            sSEAlgorithm: .__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension ServerSideEncryptionConfiguration {
+    /**
+     Default instance of the ServerSideEncryptionConfiguration structure.
+     */
+    public static let __default: S3Model.ServerSideEncryptionConfiguration = {
+        let defaultInstance = S3Model.ServerSideEncryptionConfiguration(
+            rules: [])
+
+        return defaultInstance
+    }()
+}
+
+public extension ServerSideEncryptionRule {
+    /**
+     Default instance of the ServerSideEncryptionRule structure.
+     */
+    public static let __default: S3Model.ServerSideEncryptionRule = {
+        let defaultInstance = S3Model.ServerSideEncryptionRule(
+            applyServerSideEncryptionByDefault: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension SourceSelectionCriteria {
+    /**
+     Default instance of the SourceSelectionCriteria structure.
+     */
+    public static let __default: S3Model.SourceSelectionCriteria = {
+        let defaultInstance = S3Model.SourceSelectionCriteria(
+            sseKmsEncryptedObjects: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension SseKmsEncryptedObjects {
+    /**
+     Default instance of the SseKmsEncryptedObjects structure.
+     */
+    public static let __default: S3Model.SseKmsEncryptedObjects = {
+        let defaultInstance = S3Model.SseKmsEncryptedObjects(
+            status: .__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension Stats {
+    /**
+     Default instance of the Stats structure.
+     */
+    public static let __default: S3Model.Stats = {
+        let defaultInstance = S3Model.Stats(
+            bytesProcessed: nil,
+            bytesReturned: nil,
+            bytesScanned: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension StatsEvent {
+    /**
+     Default instance of the StatsEvent structure.
+     */
+    public static let __default: S3Model.StatsEvent = {
+        let defaultInstance = S3Model.StatsEvent(
+            details: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension StorageClassAnalysis {
+    /**
+     Default instance of the StorageClassAnalysis structure.
+     */
+    public static let __default: S3Model.StorageClassAnalysis = {
+        let defaultInstance = S3Model.StorageClassAnalysis(
+            dataExport: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension StorageClassAnalysisDataExport {
+    /**
+     Default instance of the StorageClassAnalysisDataExport structure.
+     */
+    public static let __default: S3Model.StorageClassAnalysisDataExport = {
+        let defaultInstance = S3Model.StorageClassAnalysisDataExport(
+            destination: AnalyticsExportDestination.__default,
+            outputSchemaVersion: .__default)
+
+        return defaultInstance
+    }()
+}
+
+public extension Tag {
+    /**
+     Default instance of the Tag structure.
+     */
+    public static let __default: S3Model.Tag = {
+        let defaultInstance = S3Model.Tag(
+            key: "0",
+            value: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension Tagging {
+    /**
+     Default instance of the Tagging structure.
+     */
+    public static let __default: S3Model.Tagging = {
+        let defaultInstance = S3Model.Tagging(
+            tagSet: [])
+
+        return defaultInstance
+    }()
+}
+
+public extension TargetGrant {
+    /**
+     Default instance of the TargetGrant structure.
+     */
+    public static let __default: S3Model.TargetGrant = {
+        let defaultInstance = S3Model.TargetGrant(
+            grantee: nil,
+            permission: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension TopicConfiguration {
+    /**
+     Default instance of the TopicConfiguration structure.
+     */
+    public static let __default: S3Model.TopicConfiguration = {
+        let defaultInstance = S3Model.TopicConfiguration(
+            events: [],
+            filter: nil,
+            id: nil,
+            topicArn: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension TopicConfigurationDeprecated {
+    /**
+     Default instance of the TopicConfigurationDeprecated structure.
+     */
+    public static let __default: S3Model.TopicConfigurationDeprecated = {
+        let defaultInstance = S3Model.TopicConfigurationDeprecated(
+            events: nil,
+            id: nil,
+            topic: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension Transition {
+    /**
+     Default instance of the Transition structure.
+     */
+    public static let __default: S3Model.Transition = {
+        let defaultInstance = S3Model.Transition(
+            date: nil,
+            days: nil,
+            storageClass: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension UploadPartCopyOutput {
+    /**
+     Default instance of the UploadPartCopyOutput structure.
+     */
+    public static let __default: S3Model.UploadPartCopyOutput = {
+        let defaultInstance = S3Model.UploadPartCopyOutput(
+            copyPartResult: nil,
+            copySourceVersionId: nil,
+            requestCharged: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKeyMD5: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension UploadPartCopyRequest {
+    /**
+     Default instance of the UploadPartCopyRequest structure.
+     */
+    public static let __default: S3Model.UploadPartCopyRequest = {
+        let defaultInstance = S3Model.UploadPartCopyRequest(
+            bucket: "value",
+            copySource: "",
+            copySourceIfMatch: nil,
+            copySourceIfModifiedSince: nil,
+            copySourceIfNoneMatch: nil,
+            copySourceIfUnmodifiedSince: nil,
+            copySourceRange: nil,
+            copySourceSSECustomerAlgorithm: nil,
+            copySourceSSECustomerKey: nil,
+            copySourceSSECustomerKeyMD5: nil,
+            key: "0",
+            partNumber: 0,
+            requestPayer: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKey: nil,
+            sSECustomerKeyMD5: nil,
+            uploadId: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension UploadPartOutput {
+    /**
+     Default instance of the UploadPartOutput structure.
+     */
+    public static let __default: S3Model.UploadPartOutput = {
+        let defaultInstance = S3Model.UploadPartOutput(
+            eTag: nil,
+            requestCharged: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKeyMD5: nil,
+            sSEKMSKeyId: nil,
+            serverSideEncryption: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension UploadPartRequest {
+    /**
+     Default instance of the UploadPartRequest structure.
+     */
+    public static let __default: S3Model.UploadPartRequest = {
+        let defaultInstance = S3Model.UploadPartRequest(
+            body: nil,
+            bucket: "value",
+            contentLength: nil,
+            contentMD5: nil,
+            key: "0",
+            partNumber: 0,
+            requestPayer: nil,
+            sSECustomerAlgorithm: nil,
+            sSECustomerKey: nil,
+            sSECustomerKeyMD5: nil,
+            uploadId: "value")
+
+        return defaultInstance
+    }()
+}
+
+public extension VersioningConfiguration {
+    /**
+     Default instance of the VersioningConfiguration structure.
+     */
+    public static let __default: S3Model.VersioningConfiguration = {
+        let defaultInstance = S3Model.VersioningConfiguration(
+            mFADelete: nil,
+            status: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension WebsiteConfiguration {
+    /**
+     Default instance of the WebsiteConfiguration structure.
+     */
+    public static let __default: S3Model.WebsiteConfiguration = {
+        let defaultInstance = S3Model.WebsiteConfiguration(
+            errorDocument: nil,
+            indexDocument: nil,
+            redirectAllRequestsTo: nil,
+            routingRules: nil)
+
+        return defaultInstance
+    }()
+}

--- a/Sources/S3Model/S3ModelErrors.swift
+++ b/Sources/S3Model/S3ModelErrors.swift
@@ -1,0 +1,90 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// S3ModelErrors.swift
+// S3Model
+//
+
+import Foundation
+import LoggerAPI
+
+private let bucketAlreadyExistsIdentity = "BucketAlreadyExists"
+private let bucketAlreadyOwnedByYouIdentity = "BucketAlreadyOwnedByYou"
+private let noSuchBucketIdentity = "NoSuchBucket"
+private let noSuchKeyIdentity = "NoSuchKey"
+private let noSuchUploadIdentity = "NoSuchUpload"
+private let objectAlreadyInActiveTierIdentity = "ObjectAlreadyInActiveTierError"
+private let objectNotInActiveTierIdentity = "ObjectNotInActiveTierError"
+
+public enum S3CodingError: Swift.Error {
+    case unknownError
+    case validationError(reason: String)
+    case unrecognizedError(String, String?)
+}
+
+public enum S3Error: Swift.Error, Decodable {
+    case bucketAlreadyExists(BucketAlreadyExists)
+    case bucketAlreadyOwnedByYou(BucketAlreadyOwnedByYou)
+    case noSuchBucket(NoSuchBucket)
+    case noSuchKey(NoSuchKey)
+    case noSuchUpload(NoSuchUpload)
+    case objectAlreadyInActiveTier(ObjectAlreadyInActiveTierError)
+    case objectNotInActiveTier(ObjectNotInActiveTierError)
+    
+    enum CodingKeys: String, CodingKey {
+        case type = "Code"
+        case message = "Message"
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        var errorReason = try values.decode(String.self, forKey: .type)
+        let errorMessage = try values.decodeIfPresent(String.self, forKey: .message)
+    
+        if let index = errorReason.index(of: "#") {
+            errorReason = String(errorReason[errorReason.index(index, offsetBy: 1)...])
+        }
+    
+        switch errorReason {
+        case bucketAlreadyExistsIdentity:
+            let errorPayload = try BucketAlreadyExists(from: decoder)
+            self = S3Error.bucketAlreadyExists(errorPayload)
+        case bucketAlreadyOwnedByYouIdentity:
+            let errorPayload = try BucketAlreadyOwnedByYou(from: decoder)
+            self = S3Error.bucketAlreadyOwnedByYou(errorPayload)
+        case noSuchBucketIdentity:
+            let errorPayload = try NoSuchBucket(from: decoder)
+            self = S3Error.noSuchBucket(errorPayload)
+        case noSuchKeyIdentity:
+            let errorPayload = try NoSuchKey(from: decoder)
+            self = S3Error.noSuchKey(errorPayload)
+        case noSuchUploadIdentity:
+            let errorPayload = try NoSuchUpload(from: decoder)
+            self = S3Error.noSuchUpload(errorPayload)
+        case objectAlreadyInActiveTierIdentity:
+            let errorPayload = try ObjectAlreadyInActiveTierError(from: decoder)
+            self = S3Error.objectAlreadyInActiveTier(errorPayload)
+        case objectNotInActiveTierIdentity:
+            let errorPayload = try ObjectNotInActiveTierError(from: decoder)
+            self = S3Error.objectNotInActiveTier(errorPayload)
+        default:
+            throw S3CodingError.unrecognizedError(errorReason, errorMessage)
+        }
+    }
+    
+}
+

--- a/Sources/S3Model/S3ModelOperations.swift
+++ b/Sources/S3Model/S3ModelOperations.swift
@@ -1,0 +1,5939 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// S3ModelOperations.swift
+// S3Model
+//
+
+import Foundation
+
+/**
+ Operation enumeration for the S3Model.
+ */
+public enum S3ModelOperations: String {
+    case abortMultipartUpload = "AbortMultipartUpload"
+    case completeMultipartUpload = "CompleteMultipartUpload"
+    case copyObject = "CopyObject"
+    case createBucket = "CreateBucket"
+    case createMultipartUpload = "CreateMultipartUpload"
+    case deleteBucket = "DeleteBucket"
+    case deleteBucketAnalyticsConfiguration = "DeleteBucketAnalyticsConfiguration"
+    case deleteBucketCors = "DeleteBucketCors"
+    case deleteBucketEncryption = "DeleteBucketEncryption"
+    case deleteBucketInventoryConfiguration = "DeleteBucketInventoryConfiguration"
+    case deleteBucketLifecycle = "DeleteBucketLifecycle"
+    case deleteBucketMetricsConfiguration = "DeleteBucketMetricsConfiguration"
+    case deleteBucketPolicy = "DeleteBucketPolicy"
+    case deleteBucketReplication = "DeleteBucketReplication"
+    case deleteBucketTagging = "DeleteBucketTagging"
+    case deleteBucketWebsite = "DeleteBucketWebsite"
+    case deleteObject = "DeleteObject"
+    case deleteObjectTagging = "DeleteObjectTagging"
+    case deleteObjects = "DeleteObjects"
+    case deletePublicAccessBlock = "DeletePublicAccessBlock"
+    case getBucketAccelerateConfiguration = "GetBucketAccelerateConfiguration"
+    case getBucketAcl = "GetBucketAcl"
+    case getBucketAnalyticsConfiguration = "GetBucketAnalyticsConfiguration"
+    case getBucketCors = "GetBucketCors"
+    case getBucketEncryption = "GetBucketEncryption"
+    case getBucketInventoryConfiguration = "GetBucketInventoryConfiguration"
+    case getBucketLifecycle = "GetBucketLifecycle"
+    case getBucketLifecycleConfiguration = "GetBucketLifecycleConfiguration"
+    case getBucketLocation = "GetBucketLocation"
+    case getBucketLogging = "GetBucketLogging"
+    case getBucketMetricsConfiguration = "GetBucketMetricsConfiguration"
+    case getBucketNotification = "GetBucketNotification"
+    case getBucketNotificationConfiguration = "GetBucketNotificationConfiguration"
+    case getBucketPolicy = "GetBucketPolicy"
+    case getBucketPolicyStatus = "GetBucketPolicyStatus"
+    case getBucketReplication = "GetBucketReplication"
+    case getBucketRequestPayment = "GetBucketRequestPayment"
+    case getBucketTagging = "GetBucketTagging"
+    case getBucketVersioning = "GetBucketVersioning"
+    case getBucketWebsite = "GetBucketWebsite"
+    case getObject = "GetObject"
+    case getObjectAcl = "GetObjectAcl"
+    case getObjectTagging = "GetObjectTagging"
+    case getObjectTorrent = "GetObjectTorrent"
+    case getPublicAccessBlock = "GetPublicAccessBlock"
+    case headBucket = "HeadBucket"
+    case headObject = "HeadObject"
+    case listBucketAnalyticsConfigurations = "ListBucketAnalyticsConfigurations"
+    case listBucketInventoryConfigurations = "ListBucketInventoryConfigurations"
+    case listBucketMetricsConfigurations = "ListBucketMetricsConfigurations"
+    case listBuckets = "ListBuckets"
+    case listMultipartUploads = "ListMultipartUploads"
+    case listObjectVersions = "ListObjectVersions"
+    case listObjects = "ListObjects"
+    case listObjectsV2 = "ListObjectsV2"
+    case listParts = "ListParts"
+    case putBucketAccelerateConfiguration = "PutBucketAccelerateConfiguration"
+    case putBucketAcl = "PutBucketAcl"
+    case putBucketAnalyticsConfiguration = "PutBucketAnalyticsConfiguration"
+    case putBucketCors = "PutBucketCors"
+    case putBucketEncryption = "PutBucketEncryption"
+    case putBucketInventoryConfiguration = "PutBucketInventoryConfiguration"
+    case putBucketLifecycle = "PutBucketLifecycle"
+    case putBucketLifecycleConfiguration = "PutBucketLifecycleConfiguration"
+    case putBucketLogging = "PutBucketLogging"
+    case putBucketMetricsConfiguration = "PutBucketMetricsConfiguration"
+    case putBucketNotification = "PutBucketNotification"
+    case putBucketNotificationConfiguration = "PutBucketNotificationConfiguration"
+    case putBucketPolicy = "PutBucketPolicy"
+    case putBucketReplication = "PutBucketReplication"
+    case putBucketRequestPayment = "PutBucketRequestPayment"
+    case putBucketTagging = "PutBucketTagging"
+    case putBucketVersioning = "PutBucketVersioning"
+    case putBucketWebsite = "PutBucketWebsite"
+    case putObject = "PutObject"
+    case putObjectAcl = "PutObjectAcl"
+    case putObjectTagging = "PutObjectTagging"
+    case putPublicAccessBlock = "PutPublicAccessBlock"
+    case restoreObject = "RestoreObject"
+    case selectObjectContent = "SelectObjectContent"
+    case uploadPart = "UploadPart"
+    case uploadPartCopy = "UploadPartCopy"
+
+    public var operationPath: String {
+        switch self {
+        case .abortMultipartUpload:
+            return "/{Bucket}/{Key+}"
+        case .completeMultipartUpload:
+            return "/{Bucket}/{Key+}"
+        case .copyObject:
+            return "/{Bucket}/{Key+}"
+        case .createBucket:
+            return "/{Bucket}"
+        case .createMultipartUpload:
+            return "/{Bucket}/{Key+}?uploads"
+        case .deleteBucket:
+            return "/{Bucket}"
+        case .deleteBucketAnalyticsConfiguration:
+            return "/{Bucket}?analytics"
+        case .deleteBucketCors:
+            return "/{Bucket}?cors"
+        case .deleteBucketEncryption:
+            return "/{Bucket}?encryption"
+        case .deleteBucketInventoryConfiguration:
+            return "/{Bucket}?inventory"
+        case .deleteBucketLifecycle:
+            return "/{Bucket}?lifecycle"
+        case .deleteBucketMetricsConfiguration:
+            return "/{Bucket}?metrics"
+        case .deleteBucketPolicy:
+            return "/{Bucket}?policy"
+        case .deleteBucketReplication:
+            return "/{Bucket}?replication"
+        case .deleteBucketTagging:
+            return "/{Bucket}?tagging"
+        case .deleteBucketWebsite:
+            return "/{Bucket}?website"
+        case .deleteObject:
+            return "/{Bucket}/{Key+}"
+        case .deleteObjectTagging:
+            return "/{Bucket}/{Key+}?tagging"
+        case .deleteObjects:
+            return "/{Bucket}?delete"
+        case .deletePublicAccessBlock:
+            return "/{Bucket}?publicAccessBlock"
+        case .getBucketAccelerateConfiguration:
+            return "/{Bucket}?accelerate"
+        case .getBucketAcl:
+            return "/{Bucket}?acl"
+        case .getBucketAnalyticsConfiguration:
+            return "/{Bucket}?analytics"
+        case .getBucketCors:
+            return "/{Bucket}?cors"
+        case .getBucketEncryption:
+            return "/{Bucket}?encryption"
+        case .getBucketInventoryConfiguration:
+            return "/{Bucket}?inventory"
+        case .getBucketLifecycle:
+            return "/{Bucket}?lifecycle"
+        case .getBucketLifecycleConfiguration:
+            return "/{Bucket}?lifecycle"
+        case .getBucketLocation:
+            return "/{Bucket}?location"
+        case .getBucketLogging:
+            return "/{Bucket}?logging"
+        case .getBucketMetricsConfiguration:
+            return "/{Bucket}?metrics"
+        case .getBucketNotification:
+            return "/{Bucket}?notification"
+        case .getBucketNotificationConfiguration:
+            return "/{Bucket}?notification"
+        case .getBucketPolicy:
+            return "/{Bucket}?policy"
+        case .getBucketPolicyStatus:
+            return "/{Bucket}?policyStatus"
+        case .getBucketReplication:
+            return "/{Bucket}?replication"
+        case .getBucketRequestPayment:
+            return "/{Bucket}?requestPayment"
+        case .getBucketTagging:
+            return "/{Bucket}?tagging"
+        case .getBucketVersioning:
+            return "/{Bucket}?versioning"
+        case .getBucketWebsite:
+            return "/{Bucket}?website"
+        case .getObject:
+            return "/{Bucket}/{Key+}"
+        case .getObjectAcl:
+            return "/{Bucket}/{Key+}?acl"
+        case .getObjectTagging:
+            return "/{Bucket}/{Key+}?tagging"
+        case .getObjectTorrent:
+            return "/{Bucket}/{Key+}?torrent"
+        case .getPublicAccessBlock:
+            return "/{Bucket}?publicAccessBlock"
+        case .headBucket:
+            return "/{Bucket}"
+        case .headObject:
+            return "/{Bucket}/{Key+}"
+        case .listBucketAnalyticsConfigurations:
+            return "/{Bucket}?analytics"
+        case .listBucketInventoryConfigurations:
+            return "/{Bucket}?inventory"
+        case .listBucketMetricsConfigurations:
+            return "/{Bucket}?metrics"
+        case .listBuckets:
+            return "/"
+        case .listMultipartUploads:
+            return "/{Bucket}?uploads"
+        case .listObjectVersions:
+            return "/{Bucket}?versions"
+        case .listObjects:
+            return "/{Bucket}"
+        case .listObjectsV2:
+            return "/{Bucket}?list-type=2"
+        case .listParts:
+            return "/{Bucket}/{Key+}"
+        case .putBucketAccelerateConfiguration:
+            return "/{Bucket}?accelerate"
+        case .putBucketAcl:
+            return "/{Bucket}?acl"
+        case .putBucketAnalyticsConfiguration:
+            return "/{Bucket}?analytics"
+        case .putBucketCors:
+            return "/{Bucket}?cors"
+        case .putBucketEncryption:
+            return "/{Bucket}?encryption"
+        case .putBucketInventoryConfiguration:
+            return "/{Bucket}?inventory"
+        case .putBucketLifecycle:
+            return "/{Bucket}?lifecycle"
+        case .putBucketLifecycleConfiguration:
+            return "/{Bucket}?lifecycle"
+        case .putBucketLogging:
+            return "/{Bucket}?logging"
+        case .putBucketMetricsConfiguration:
+            return "/{Bucket}?metrics"
+        case .putBucketNotification:
+            return "/{Bucket}?notification"
+        case .putBucketNotificationConfiguration:
+            return "/{Bucket}?notification"
+        case .putBucketPolicy:
+            return "/{Bucket}?policy"
+        case .putBucketReplication:
+            return "/{Bucket}?replication"
+        case .putBucketRequestPayment:
+            return "/{Bucket}?requestPayment"
+        case .putBucketTagging:
+            return "/{Bucket}?tagging"
+        case .putBucketVersioning:
+            return "/{Bucket}?versioning"
+        case .putBucketWebsite:
+            return "/{Bucket}?website"
+        case .putObject:
+            return "/{Bucket}/{Key+}"
+        case .putObjectAcl:
+            return "/{Bucket}/{Key+}?acl"
+        case .putObjectTagging:
+            return "/{Bucket}/{Key+}?tagging"
+        case .putPublicAccessBlock:
+            return "/{Bucket}?publicAccessBlock"
+        case .restoreObject:
+            return "/{Bucket}/{Key+}?restore"
+        case .selectObjectContent:
+            return "/{Bucket}/{Key+}?select&select-type=2"
+        case .uploadPart:
+            return "/{Bucket}/{Key+}"
+        case .uploadPartCopy:
+            return "/{Bucket}/{Key+}"
+        }
+    }
+}
+
+
+/**
+ Structure to encode the path input for the AbortMultipartUpload
+ operation.
+ */
+public struct AbortMultipartUploadOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension AbortMultipartUploadRequest {
+    public func asS3ModelAbortMultipartUploadOperationInputPath() -> AbortMultipartUploadOperationInputPath {
+        return AbortMultipartUploadOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the AbortMultipartUpload
+ operation.
+ */
+public struct AbortMultipartUploadOperationInputQuery: Codable, Equatable {
+    public var uploadId: MultipartUploadId
+
+    public init(uploadId: MultipartUploadId) {
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case uploadId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension AbortMultipartUploadRequest {
+    public func asS3ModelAbortMultipartUploadOperationInputQuery() -> AbortMultipartUploadOperationInputQuery {
+        return AbortMultipartUploadOperationInputQuery(
+            uploadId: uploadId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the AbortMultipartUpload
+ operation.
+ */
+public struct AbortMultipartUploadOperationInputAdditionalHeaders: Codable, Equatable {
+    public var requestPayer: RequestPayer?
+
+    public init(requestPayer: RequestPayer? = nil) {
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension AbortMultipartUploadRequest {
+    public func asS3ModelAbortMultipartUploadOperationInputAdditionalHeaders() -> AbortMultipartUploadOperationInputAdditionalHeaders {
+        return AbortMultipartUploadOperationInputAdditionalHeaders(
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the CompleteMultipartUpload
+ operation.
+ */
+public struct CompleteMultipartUploadOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension CompleteMultipartUploadRequest {
+    public func asS3ModelCompleteMultipartUploadOperationInputPath() -> CompleteMultipartUploadOperationInputPath {
+        return CompleteMultipartUploadOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the CompleteMultipartUpload
+ operation.
+ */
+public struct CompleteMultipartUploadOperationInputQuery: Codable, Equatable {
+    public var uploadId: MultipartUploadId
+
+    public init(uploadId: MultipartUploadId) {
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case uploadId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension CompleteMultipartUploadRequest {
+    public func asS3ModelCompleteMultipartUploadOperationInputQuery() -> CompleteMultipartUploadOperationInputQuery {
+        return CompleteMultipartUploadOperationInputQuery(
+            uploadId: uploadId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the CompleteMultipartUpload
+ operation.
+ */
+public struct CompleteMultipartUploadOperationInputAdditionalHeaders: Codable, Equatable {
+    public var requestPayer: RequestPayer?
+
+    public init(requestPayer: RequestPayer? = nil) {
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension CompleteMultipartUploadRequest {
+    public func asS3ModelCompleteMultipartUploadOperationInputAdditionalHeaders() -> CompleteMultipartUploadOperationInputAdditionalHeaders {
+        return CompleteMultipartUploadOperationInputAdditionalHeaders(
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the CompleteMultipartUpload
+ operation.
+ */
+public struct CompleteMultipartUploadOperationOutputBody: Codable, Equatable {
+    public var bucket: BucketName?
+    public var eTag: ETag?
+    public var key: ObjectKey?
+    public var location: Location?
+
+    public init(bucket: BucketName? = nil,
+                eTag: ETag? = nil,
+                key: ObjectKey? = nil,
+                location: Location? = nil) {
+        self.bucket = bucket
+        self.eTag = eTag
+        self.key = key
+        self.location = location
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case eTag = "ETag"
+        case key = "Key"
+        case location = "Location"
+    }
+
+    public func validate() throws {
+        try key?.validateAsObjectKey()
+    }
+}
+
+public extension CompleteMultipartUploadOutput {
+    public func asS3ModelCompleteMultipartUploadOperationOutputBody() -> CompleteMultipartUploadOperationOutputBody {
+        return CompleteMultipartUploadOperationOutputBody(
+            bucket: bucket,
+            eTag: eTag,
+            key: key,
+            location: location)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the CompleteMultipartUpload
+ operation.
+ */
+public struct CompleteMultipartUploadOperationOutputHeaders: Codable, Equatable {
+    public var expiration: Expiration?
+    public var requestCharged: RequestCharged?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var versionId: ObjectVersionId?
+
+    public init(expiration: Expiration? = nil,
+                requestCharged: RequestCharged? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.expiration = expiration
+        self.requestCharged = requestCharged
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case expiration = "x-amz-expiration"
+        case requestCharged = "x-amz-request-charged"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case versionId = "x-amz-version-id"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension CompleteMultipartUploadOutput {
+    public func asS3ModelCompleteMultipartUploadOperationOutputHeaders() -> CompleteMultipartUploadOperationOutputHeaders {
+        return CompleteMultipartUploadOperationOutputHeaders(
+            expiration: expiration,
+            requestCharged: requestCharged,
+            sSEKMSKeyId: sSEKMSKeyId,
+            serverSideEncryption: serverSideEncryption,
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the CopyObject
+ operation.
+ */
+public struct CopyObjectOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension CopyObjectRequest {
+    public func asS3ModelCopyObjectOperationInputPath() -> CopyObjectOperationInputPath {
+        return CopyObjectOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the CopyObject
+ operation.
+ */
+public struct CopyObjectOperationInputAdditionalHeaders: Codable, Equatable {
+    public var aCL: ObjectCannedACL?
+    public var cacheControl: CacheControl?
+    public var contentDisposition: ContentDisposition?
+    public var contentEncoding: ContentEncoding?
+    public var contentLanguage: ContentLanguage?
+    public var contentType: ContentType?
+    public var copySource: CopySource
+    public var copySourceIfMatch: CopySourceIfMatch?
+    public var copySourceIfModifiedSince: CopySourceIfModifiedSince?
+    public var copySourceIfNoneMatch: CopySourceIfNoneMatch?
+    public var copySourceIfUnmodifiedSince: CopySourceIfUnmodifiedSince?
+    public var copySourceSSECustomerAlgorithm: CopySourceSSECustomerAlgorithm?
+    public var copySourceSSECustomerKey: CopySourceSSECustomerKey?
+    public var copySourceSSECustomerKeyMD5: CopySourceSSECustomerKeyMD5?
+    public var expires: Expires?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWriteACP: GrantWriteACP?
+    public var metadata: Metadata?
+    public var metadataDirective: MetadataDirective?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var storageClass: StorageClass?
+    public var tagging: TaggingHeader?
+    public var taggingDirective: TaggingDirective?
+    public var websiteRedirectLocation: WebsiteRedirectLocation?
+
+    public init(aCL: ObjectCannedACL? = nil,
+                cacheControl: CacheControl? = nil,
+                contentDisposition: ContentDisposition? = nil,
+                contentEncoding: ContentEncoding? = nil,
+                contentLanguage: ContentLanguage? = nil,
+                contentType: ContentType? = nil,
+                copySource: CopySource,
+                copySourceIfMatch: CopySourceIfMatch? = nil,
+                copySourceIfModifiedSince: CopySourceIfModifiedSince? = nil,
+                copySourceIfNoneMatch: CopySourceIfNoneMatch? = nil,
+                copySourceIfUnmodifiedSince: CopySourceIfUnmodifiedSince? = nil,
+                copySourceSSECustomerAlgorithm: CopySourceSSECustomerAlgorithm? = nil,
+                copySourceSSECustomerKey: CopySourceSSECustomerKey? = nil,
+                copySourceSSECustomerKeyMD5: CopySourceSSECustomerKeyMD5? = nil,
+                expires: Expires? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWriteACP: GrantWriteACP? = nil,
+                metadata: Metadata? = nil,
+                metadataDirective: MetadataDirective? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                storageClass: StorageClass? = nil,
+                tagging: TaggingHeader? = nil,
+                taggingDirective: TaggingDirective? = nil,
+                websiteRedirectLocation: WebsiteRedirectLocation? = nil) {
+        self.aCL = aCL
+        self.cacheControl = cacheControl
+        self.contentDisposition = contentDisposition
+        self.contentEncoding = contentEncoding
+        self.contentLanguage = contentLanguage
+        self.contentType = contentType
+        self.copySource = copySource
+        self.copySourceIfMatch = copySourceIfMatch
+        self.copySourceIfModifiedSince = copySourceIfModifiedSince
+        self.copySourceIfNoneMatch = copySourceIfNoneMatch
+        self.copySourceIfUnmodifiedSince = copySourceIfUnmodifiedSince
+        self.copySourceSSECustomerAlgorithm = copySourceSSECustomerAlgorithm
+        self.copySourceSSECustomerKey = copySourceSSECustomerKey
+        self.copySourceSSECustomerKeyMD5 = copySourceSSECustomerKeyMD5
+        self.expires = expires
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWriteACP = grantWriteACP
+        self.metadata = metadata
+        self.metadataDirective = metadataDirective
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.storageClass = storageClass
+        self.tagging = tagging
+        self.taggingDirective = taggingDirective
+        self.websiteRedirectLocation = websiteRedirectLocation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case cacheControl = "Cache-Control"
+        case contentDisposition = "Content-Disposition"
+        case contentEncoding = "Content-Encoding"
+        case contentLanguage = "Content-Language"
+        case contentType = "Content-Type"
+        case copySource = "x-amz-copy-source"
+        case copySourceIfMatch = "x-amz-copy-source-if-match"
+        case copySourceIfModifiedSince = "x-amz-copy-source-if-modified-since"
+        case copySourceIfNoneMatch = "x-amz-copy-source-if-none-match"
+        case copySourceIfUnmodifiedSince = "x-amz-copy-source-if-unmodified-since"
+        case copySourceSSECustomerAlgorithm = "x-amz-copy-source-server-side-encryption-customer-algorithm"
+        case copySourceSSECustomerKey = "x-amz-copy-source-server-side-encryption-customer-key"
+        case copySourceSSECustomerKeyMD5 = "x-amz-copy-source-server-side-encryption-customer-key-MD5"
+        case expires = "Expires"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWriteACP = "x-amz-grant-write-acp"
+        case metadata = "x-amz-meta-"
+        case metadataDirective = "x-amz-metadata-directive"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case storageClass = "x-amz-storage-class"
+        case tagging = "x-amz-tagging"
+        case taggingDirective = "x-amz-tagging-directive"
+        case websiteRedirectLocation = "x-amz-website-redirect-location"
+    }
+
+    public func validate() throws {
+        try copySource.validateAsCopySource()
+    }
+}
+
+public extension CopyObjectRequest {
+    public func asS3ModelCopyObjectOperationInputAdditionalHeaders() -> CopyObjectOperationInputAdditionalHeaders {
+        return CopyObjectOperationInputAdditionalHeaders(
+            aCL: aCL,
+            cacheControl: cacheControl,
+            contentDisposition: contentDisposition,
+            contentEncoding: contentEncoding,
+            contentLanguage: contentLanguage,
+            contentType: contentType,
+            copySource: copySource,
+            copySourceIfMatch: copySourceIfMatch,
+            copySourceIfModifiedSince: copySourceIfModifiedSince,
+            copySourceIfNoneMatch: copySourceIfNoneMatch,
+            copySourceIfUnmodifiedSince: copySourceIfUnmodifiedSince,
+            copySourceSSECustomerAlgorithm: copySourceSSECustomerAlgorithm,
+            copySourceSSECustomerKey: copySourceSSECustomerKey,
+            copySourceSSECustomerKeyMD5: copySourceSSECustomerKeyMD5,
+            expires: expires,
+            grantFullControl: grantFullControl,
+            grantRead: grantRead,
+            grantReadACP: grantReadACP,
+            grantWriteACP: grantWriteACP,
+            metadata: metadata,
+            metadataDirective: metadataDirective,
+            requestPayer: requestPayer,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKey: sSECustomerKey,
+            sSECustomerKeyMD5: sSECustomerKeyMD5,
+            sSEKMSKeyId: sSEKMSKeyId,
+            serverSideEncryption: serverSideEncryption,
+            storageClass: storageClass,
+            tagging: tagging,
+            taggingDirective: taggingDirective,
+            websiteRedirectLocation: websiteRedirectLocation)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the CopyObject
+ operation.
+ */
+public struct CopyObjectOperationOutputHeaders: Codable, Equatable {
+    public var copySourceVersionId: CopySourceVersionId?
+    public var expiration: Expiration?
+    public var requestCharged: RequestCharged?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var versionId: ObjectVersionId?
+
+    public init(copySourceVersionId: CopySourceVersionId? = nil,
+                expiration: Expiration? = nil,
+                requestCharged: RequestCharged? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.copySourceVersionId = copySourceVersionId
+        self.expiration = expiration
+        self.requestCharged = requestCharged
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case copySourceVersionId = "x-amz-copy-source-version-id"
+        case expiration = "x-amz-expiration"
+        case requestCharged = "x-amz-request-charged"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case versionId = "x-amz-version-id"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension CopyObjectOutput {
+    public func asS3ModelCopyObjectOperationOutputHeaders() -> CopyObjectOperationOutputHeaders {
+        return CopyObjectOperationOutputHeaders(
+            copySourceVersionId: copySourceVersionId,
+            expiration: expiration,
+            requestCharged: requestCharged,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKeyMD5: sSECustomerKeyMD5,
+            sSEKMSKeyId: sSEKMSKeyId,
+            serverSideEncryption: serverSideEncryption,
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the CreateBucket
+ operation.
+ */
+public struct CreateBucketOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension CreateBucketRequest {
+    public func asS3ModelCreateBucketOperationInputPath() -> CreateBucketOperationInputPath {
+        return CreateBucketOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the CreateBucket
+ operation.
+ */
+public struct CreateBucketOperationInputAdditionalHeaders: Codable, Equatable {
+    public var aCL: BucketCannedACL?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWrite: GrantWrite?
+    public var grantWriteACP: GrantWriteACP?
+
+    public init(aCL: BucketCannedACL? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWrite: GrantWrite? = nil,
+                grantWriteACP: GrantWriteACP? = nil) {
+        self.aCL = aCL
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWrite = grantWrite
+        self.grantWriteACP = grantWriteACP
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWrite = "x-amz-grant-write"
+        case grantWriteACP = "x-amz-grant-write-acp"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension CreateBucketRequest {
+    public func asS3ModelCreateBucketOperationInputAdditionalHeaders() -> CreateBucketOperationInputAdditionalHeaders {
+        return CreateBucketOperationInputAdditionalHeaders(
+            aCL: aCL,
+            grantFullControl: grantFullControl,
+            grantRead: grantRead,
+            grantReadACP: grantReadACP,
+            grantWrite: grantWrite,
+            grantWriteACP: grantWriteACP)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the CreateMultipartUpload
+ operation.
+ */
+public struct CreateMultipartUploadOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension CreateMultipartUploadRequest {
+    public func asS3ModelCreateMultipartUploadOperationInputPath() -> CreateMultipartUploadOperationInputPath {
+        return CreateMultipartUploadOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the CreateMultipartUpload
+ operation.
+ */
+public struct CreateMultipartUploadOperationInputAdditionalHeaders: Codable, Equatable {
+    public var aCL: ObjectCannedACL?
+    public var cacheControl: CacheControl?
+    public var contentDisposition: ContentDisposition?
+    public var contentEncoding: ContentEncoding?
+    public var contentLanguage: ContentLanguage?
+    public var contentType: ContentType?
+    public var expires: Expires?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWriteACP: GrantWriteACP?
+    public var metadata: Metadata?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var storageClass: StorageClass?
+    public var tagging: TaggingHeader?
+    public var websiteRedirectLocation: WebsiteRedirectLocation?
+
+    public init(aCL: ObjectCannedACL? = nil,
+                cacheControl: CacheControl? = nil,
+                contentDisposition: ContentDisposition? = nil,
+                contentEncoding: ContentEncoding? = nil,
+                contentLanguage: ContentLanguage? = nil,
+                contentType: ContentType? = nil,
+                expires: Expires? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWriteACP: GrantWriteACP? = nil,
+                metadata: Metadata? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                storageClass: StorageClass? = nil,
+                tagging: TaggingHeader? = nil,
+                websiteRedirectLocation: WebsiteRedirectLocation? = nil) {
+        self.aCL = aCL
+        self.cacheControl = cacheControl
+        self.contentDisposition = contentDisposition
+        self.contentEncoding = contentEncoding
+        self.contentLanguage = contentLanguage
+        self.contentType = contentType
+        self.expires = expires
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWriteACP = grantWriteACP
+        self.metadata = metadata
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.storageClass = storageClass
+        self.tagging = tagging
+        self.websiteRedirectLocation = websiteRedirectLocation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case cacheControl = "Cache-Control"
+        case contentDisposition = "Content-Disposition"
+        case contentEncoding = "Content-Encoding"
+        case contentLanguage = "Content-Language"
+        case contentType = "Content-Type"
+        case expires = "Expires"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWriteACP = "x-amz-grant-write-acp"
+        case metadata = "x-amz-meta-"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case storageClass = "x-amz-storage-class"
+        case tagging = "x-amz-tagging"
+        case websiteRedirectLocation = "x-amz-website-redirect-location"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension CreateMultipartUploadRequest {
+    public func asS3ModelCreateMultipartUploadOperationInputAdditionalHeaders() -> CreateMultipartUploadOperationInputAdditionalHeaders {
+        return CreateMultipartUploadOperationInputAdditionalHeaders(
+            aCL: aCL,
+            cacheControl: cacheControl,
+            contentDisposition: contentDisposition,
+            contentEncoding: contentEncoding,
+            contentLanguage: contentLanguage,
+            contentType: contentType,
+            expires: expires,
+            grantFullControl: grantFullControl,
+            grantRead: grantRead,
+            grantReadACP: grantReadACP,
+            grantWriteACP: grantWriteACP,
+            metadata: metadata,
+            requestPayer: requestPayer,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKey: sSECustomerKey,
+            sSECustomerKeyMD5: sSECustomerKeyMD5,
+            sSEKMSKeyId: sSEKMSKeyId,
+            serverSideEncryption: serverSideEncryption,
+            storageClass: storageClass,
+            tagging: tagging,
+            websiteRedirectLocation: websiteRedirectLocation)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the CreateMultipartUpload
+ operation.
+ */
+public struct CreateMultipartUploadOperationOutputBody: Codable, Equatable {
+    public var bucket: BucketName?
+    public var key: ObjectKey?
+    public var uploadId: MultipartUploadId?
+
+    public init(bucket: BucketName? = nil,
+                key: ObjectKey? = nil,
+                uploadId: MultipartUploadId? = nil) {
+        self.bucket = bucket
+        self.key = key
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+        case uploadId = "UploadId"
+    }
+
+    public func validate() throws {
+        try key?.validateAsObjectKey()
+    }
+}
+
+public extension CreateMultipartUploadOutput {
+    public func asS3ModelCreateMultipartUploadOperationOutputBody() -> CreateMultipartUploadOperationOutputBody {
+        return CreateMultipartUploadOperationOutputBody(
+            bucket: bucket,
+            key: key,
+            uploadId: uploadId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the CreateMultipartUpload
+ operation.
+ */
+public struct CreateMultipartUploadOperationOutputHeaders: Codable, Equatable {
+    public var abortDate: AbortDate?
+    public var abortRuleId: AbortRuleId?
+    public var requestCharged: RequestCharged?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+
+    public init(abortDate: AbortDate? = nil,
+                abortRuleId: AbortRuleId? = nil,
+                requestCharged: RequestCharged? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil) {
+        self.abortDate = abortDate
+        self.abortRuleId = abortRuleId
+        self.requestCharged = requestCharged
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case abortDate = "x-amz-abort-date"
+        case abortRuleId = "x-amz-abort-rule-id"
+        case requestCharged = "x-amz-request-charged"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension CreateMultipartUploadOutput {
+    public func asS3ModelCreateMultipartUploadOperationOutputHeaders() -> CreateMultipartUploadOperationOutputHeaders {
+        return CreateMultipartUploadOperationOutputHeaders(
+            abortDate: abortDate,
+            abortRuleId: abortRuleId,
+            requestCharged: requestCharged,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKeyMD5: sSECustomerKeyMD5,
+            sSEKMSKeyId: sSEKMSKeyId,
+            serverSideEncryption: serverSideEncryption)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucket
+ operation.
+ */
+public struct DeleteBucketOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketRequest {
+    public func asS3ModelDeleteBucketOperationInputPath() -> DeleteBucketOperationInputPath {
+        return DeleteBucketOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucketAnalyticsConfiguration
+ operation.
+ */
+public struct DeleteBucketAnalyticsConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketAnalyticsConfigurationRequest {
+    public func asS3ModelDeleteBucketAnalyticsConfigurationOperationInputPath() -> DeleteBucketAnalyticsConfigurationOperationInputPath {
+        return DeleteBucketAnalyticsConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the DeleteBucketAnalyticsConfiguration
+ operation.
+ */
+public struct DeleteBucketAnalyticsConfigurationOperationInputQuery: Codable, Equatable {
+    public var id: AnalyticsId
+
+    public init(id: AnalyticsId) {
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketAnalyticsConfigurationRequest {
+    public func asS3ModelDeleteBucketAnalyticsConfigurationOperationInputQuery() -> DeleteBucketAnalyticsConfigurationOperationInputQuery {
+        return DeleteBucketAnalyticsConfigurationOperationInputQuery(
+            id: id)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucketCors
+ operation.
+ */
+public struct DeleteBucketCorsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketCorsRequest {
+    public func asS3ModelDeleteBucketCorsOperationInputPath() -> DeleteBucketCorsOperationInputPath {
+        return DeleteBucketCorsOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucketEncryption
+ operation.
+ */
+public struct DeleteBucketEncryptionOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketEncryptionRequest {
+    public func asS3ModelDeleteBucketEncryptionOperationInputPath() -> DeleteBucketEncryptionOperationInputPath {
+        return DeleteBucketEncryptionOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucketInventoryConfiguration
+ operation.
+ */
+public struct DeleteBucketInventoryConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketInventoryConfigurationRequest {
+    public func asS3ModelDeleteBucketInventoryConfigurationOperationInputPath() -> DeleteBucketInventoryConfigurationOperationInputPath {
+        return DeleteBucketInventoryConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the DeleteBucketInventoryConfiguration
+ operation.
+ */
+public struct DeleteBucketInventoryConfigurationOperationInputQuery: Codable, Equatable {
+    public var id: InventoryId
+
+    public init(id: InventoryId) {
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketInventoryConfigurationRequest {
+    public func asS3ModelDeleteBucketInventoryConfigurationOperationInputQuery() -> DeleteBucketInventoryConfigurationOperationInputQuery {
+        return DeleteBucketInventoryConfigurationOperationInputQuery(
+            id: id)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucketLifecycle
+ operation.
+ */
+public struct DeleteBucketLifecycleOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketLifecycleRequest {
+    public func asS3ModelDeleteBucketLifecycleOperationInputPath() -> DeleteBucketLifecycleOperationInputPath {
+        return DeleteBucketLifecycleOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucketMetricsConfiguration
+ operation.
+ */
+public struct DeleteBucketMetricsConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketMetricsConfigurationRequest {
+    public func asS3ModelDeleteBucketMetricsConfigurationOperationInputPath() -> DeleteBucketMetricsConfigurationOperationInputPath {
+        return DeleteBucketMetricsConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the DeleteBucketMetricsConfiguration
+ operation.
+ */
+public struct DeleteBucketMetricsConfigurationOperationInputQuery: Codable, Equatable {
+    public var id: MetricsId
+
+    public init(id: MetricsId) {
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketMetricsConfigurationRequest {
+    public func asS3ModelDeleteBucketMetricsConfigurationOperationInputQuery() -> DeleteBucketMetricsConfigurationOperationInputQuery {
+        return DeleteBucketMetricsConfigurationOperationInputQuery(
+            id: id)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucketPolicy
+ operation.
+ */
+public struct DeleteBucketPolicyOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketPolicyRequest {
+    public func asS3ModelDeleteBucketPolicyOperationInputPath() -> DeleteBucketPolicyOperationInputPath {
+        return DeleteBucketPolicyOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucketReplication
+ operation.
+ */
+public struct DeleteBucketReplicationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketReplicationRequest {
+    public func asS3ModelDeleteBucketReplicationOperationInputPath() -> DeleteBucketReplicationOperationInputPath {
+        return DeleteBucketReplicationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucketTagging
+ operation.
+ */
+public struct DeleteBucketTaggingOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketTaggingRequest {
+    public func asS3ModelDeleteBucketTaggingOperationInputPath() -> DeleteBucketTaggingOperationInputPath {
+        return DeleteBucketTaggingOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteBucketWebsite
+ operation.
+ */
+public struct DeleteBucketWebsiteOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteBucketWebsiteRequest {
+    public func asS3ModelDeleteBucketWebsiteOperationInputPath() -> DeleteBucketWebsiteOperationInputPath {
+        return DeleteBucketWebsiteOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteObject
+ operation.
+ */
+public struct DeleteObjectOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension DeleteObjectRequest {
+    public func asS3ModelDeleteObjectOperationInputPath() -> DeleteObjectOperationInputPath {
+        return DeleteObjectOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the DeleteObject
+ operation.
+ */
+public struct DeleteObjectOperationInputQuery: Codable, Equatable {
+    public var versionId: ObjectVersionId?
+
+    public init(versionId: ObjectVersionId? = nil) {
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case versionId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteObjectRequest {
+    public func asS3ModelDeleteObjectOperationInputQuery() -> DeleteObjectOperationInputQuery {
+        return DeleteObjectOperationInputQuery(
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the DeleteObject
+ operation.
+ */
+public struct DeleteObjectOperationInputAdditionalHeaders: Codable, Equatable {
+    public var mFA: MFA?
+    public var requestPayer: RequestPayer?
+
+    public init(mFA: MFA? = nil,
+                requestPayer: RequestPayer? = nil) {
+        self.mFA = mFA
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case mFA = "x-amz-mfa"
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteObjectRequest {
+    public func asS3ModelDeleteObjectOperationInputAdditionalHeaders() -> DeleteObjectOperationInputAdditionalHeaders {
+        return DeleteObjectOperationInputAdditionalHeaders(
+            mFA: mFA,
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteObjectTagging
+ operation.
+ */
+public struct DeleteObjectTaggingOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension DeleteObjectTaggingRequest {
+    public func asS3ModelDeleteObjectTaggingOperationInputPath() -> DeleteObjectTaggingOperationInputPath {
+        return DeleteObjectTaggingOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the DeleteObjectTagging
+ operation.
+ */
+public struct DeleteObjectTaggingOperationInputQuery: Codable, Equatable {
+    public var versionId: ObjectVersionId?
+
+    public init(versionId: ObjectVersionId? = nil) {
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case versionId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteObjectTaggingRequest {
+    public func asS3ModelDeleteObjectTaggingOperationInputQuery() -> DeleteObjectTaggingOperationInputQuery {
+        return DeleteObjectTaggingOperationInputQuery(
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeleteObjects
+ operation.
+ */
+public struct DeleteObjectsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteObjectsRequest {
+    public func asS3ModelDeleteObjectsOperationInputPath() -> DeleteObjectsOperationInputPath {
+        return DeleteObjectsOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the DeleteObjects
+ operation.
+ */
+public struct DeleteObjectsOperationInputAdditionalHeaders: Codable, Equatable {
+    public var mFA: MFA?
+    public var requestPayer: RequestPayer?
+
+    public init(mFA: MFA? = nil,
+                requestPayer: RequestPayer? = nil) {
+        self.mFA = mFA
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case mFA = "x-amz-mfa"
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteObjectsRequest {
+    public func asS3ModelDeleteObjectsOperationInputAdditionalHeaders() -> DeleteObjectsOperationInputAdditionalHeaders {
+        return DeleteObjectsOperationInputAdditionalHeaders(
+            mFA: mFA,
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the DeleteObjects
+ operation.
+ */
+public struct DeleteObjectsOperationOutputBody: Codable, Equatable {
+    public var deleted: DeletedObjects?
+    public var errors: Errors?
+
+    public init(deleted: DeletedObjects? = nil,
+                errors: Errors? = nil) {
+        self.deleted = deleted
+        self.errors = errors
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case deleted = "Deleted"
+        case errors = "Error"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteObjectsOutput {
+    public func asS3ModelDeleteObjectsOperationOutputBody() -> DeleteObjectsOperationOutputBody {
+        return DeleteObjectsOperationOutputBody(
+            deleted: deleted,
+            errors: errors)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the DeleteObjects
+ operation.
+ */
+public struct DeleteObjectsOperationOutputHeaders: Codable, Equatable {
+    public var requestCharged: RequestCharged?
+
+    public init(requestCharged: RequestCharged? = nil) {
+        self.requestCharged = requestCharged
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestCharged = "x-amz-request-charged"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeleteObjectsOutput {
+    public func asS3ModelDeleteObjectsOperationOutputHeaders() -> DeleteObjectsOperationOutputHeaders {
+        return DeleteObjectsOperationOutputHeaders(
+            requestCharged: requestCharged)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the DeletePublicAccessBlock
+ operation.
+ */
+public struct DeletePublicAccessBlockOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension DeletePublicAccessBlockRequest {
+    public func asS3ModelDeletePublicAccessBlockOperationInputPath() -> DeletePublicAccessBlockOperationInputPath {
+        return DeletePublicAccessBlockOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketAccelerateConfiguration
+ operation.
+ */
+public struct GetBucketAccelerateConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketAccelerateConfigurationRequest {
+    public func asS3ModelGetBucketAccelerateConfigurationOperationInputPath() -> GetBucketAccelerateConfigurationOperationInputPath {
+        return GetBucketAccelerateConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketAcl
+ operation.
+ */
+public struct GetBucketAclOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketAclRequest {
+    public func asS3ModelGetBucketAclOperationInputPath() -> GetBucketAclOperationInputPath {
+        return GetBucketAclOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketAnalyticsConfiguration
+ operation.
+ */
+public struct GetBucketAnalyticsConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketAnalyticsConfigurationRequest {
+    public func asS3ModelGetBucketAnalyticsConfigurationOperationInputPath() -> GetBucketAnalyticsConfigurationOperationInputPath {
+        return GetBucketAnalyticsConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the GetBucketAnalyticsConfiguration
+ operation.
+ */
+public struct GetBucketAnalyticsConfigurationOperationInputQuery: Codable, Equatable {
+    public var id: AnalyticsId
+
+    public init(id: AnalyticsId) {
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketAnalyticsConfigurationRequest {
+    public func asS3ModelGetBucketAnalyticsConfigurationOperationInputQuery() -> GetBucketAnalyticsConfigurationOperationInputQuery {
+        return GetBucketAnalyticsConfigurationOperationInputQuery(
+            id: id)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketCors
+ operation.
+ */
+public struct GetBucketCorsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketCorsRequest {
+    public func asS3ModelGetBucketCorsOperationInputPath() -> GetBucketCorsOperationInputPath {
+        return GetBucketCorsOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketEncryption
+ operation.
+ */
+public struct GetBucketEncryptionOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketEncryptionRequest {
+    public func asS3ModelGetBucketEncryptionOperationInputPath() -> GetBucketEncryptionOperationInputPath {
+        return GetBucketEncryptionOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketInventoryConfiguration
+ operation.
+ */
+public struct GetBucketInventoryConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketInventoryConfigurationRequest {
+    public func asS3ModelGetBucketInventoryConfigurationOperationInputPath() -> GetBucketInventoryConfigurationOperationInputPath {
+        return GetBucketInventoryConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the GetBucketInventoryConfiguration
+ operation.
+ */
+public struct GetBucketInventoryConfigurationOperationInputQuery: Codable, Equatable {
+    public var id: InventoryId
+
+    public init(id: InventoryId) {
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketInventoryConfigurationRequest {
+    public func asS3ModelGetBucketInventoryConfigurationOperationInputQuery() -> GetBucketInventoryConfigurationOperationInputQuery {
+        return GetBucketInventoryConfigurationOperationInputQuery(
+            id: id)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketLifecycle
+ operation.
+ */
+public struct GetBucketLifecycleOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketLifecycleRequest {
+    public func asS3ModelGetBucketLifecycleOperationInputPath() -> GetBucketLifecycleOperationInputPath {
+        return GetBucketLifecycleOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketLifecycleConfiguration
+ operation.
+ */
+public struct GetBucketLifecycleConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketLifecycleConfigurationRequest {
+    public func asS3ModelGetBucketLifecycleConfigurationOperationInputPath() -> GetBucketLifecycleConfigurationOperationInputPath {
+        return GetBucketLifecycleConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketLocation
+ operation.
+ */
+public struct GetBucketLocationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketLocationRequest {
+    public func asS3ModelGetBucketLocationOperationInputPath() -> GetBucketLocationOperationInputPath {
+        return GetBucketLocationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketLogging
+ operation.
+ */
+public struct GetBucketLoggingOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketLoggingRequest {
+    public func asS3ModelGetBucketLoggingOperationInputPath() -> GetBucketLoggingOperationInputPath {
+        return GetBucketLoggingOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketMetricsConfiguration
+ operation.
+ */
+public struct GetBucketMetricsConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketMetricsConfigurationRequest {
+    public func asS3ModelGetBucketMetricsConfigurationOperationInputPath() -> GetBucketMetricsConfigurationOperationInputPath {
+        return GetBucketMetricsConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the GetBucketMetricsConfiguration
+ operation.
+ */
+public struct GetBucketMetricsConfigurationOperationInputQuery: Codable, Equatable {
+    public var id: MetricsId
+
+    public init(id: MetricsId) {
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketMetricsConfigurationRequest {
+    public func asS3ModelGetBucketMetricsConfigurationOperationInputQuery() -> GetBucketMetricsConfigurationOperationInputQuery {
+        return GetBucketMetricsConfigurationOperationInputQuery(
+            id: id)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketNotification
+ operation.
+ */
+public struct GetBucketNotificationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketNotificationConfigurationRequest {
+    public func asS3ModelGetBucketNotificationOperationInputPath() -> GetBucketNotificationOperationInputPath {
+        return GetBucketNotificationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketNotificationConfiguration
+ operation.
+ */
+public struct GetBucketNotificationConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketNotificationConfigurationRequest {
+    public func asS3ModelGetBucketNotificationConfigurationOperationInputPath() -> GetBucketNotificationConfigurationOperationInputPath {
+        return GetBucketNotificationConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketPolicy
+ operation.
+ */
+public struct GetBucketPolicyOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketPolicyRequest {
+    public func asS3ModelGetBucketPolicyOperationInputPath() -> GetBucketPolicyOperationInputPath {
+        return GetBucketPolicyOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketPolicyStatus
+ operation.
+ */
+public struct GetBucketPolicyStatusOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketPolicyStatusRequest {
+    public func asS3ModelGetBucketPolicyStatusOperationInputPath() -> GetBucketPolicyStatusOperationInputPath {
+        return GetBucketPolicyStatusOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketReplication
+ operation.
+ */
+public struct GetBucketReplicationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketReplicationRequest {
+    public func asS3ModelGetBucketReplicationOperationInputPath() -> GetBucketReplicationOperationInputPath {
+        return GetBucketReplicationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketRequestPayment
+ operation.
+ */
+public struct GetBucketRequestPaymentOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketRequestPaymentRequest {
+    public func asS3ModelGetBucketRequestPaymentOperationInputPath() -> GetBucketRequestPaymentOperationInputPath {
+        return GetBucketRequestPaymentOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketTagging
+ operation.
+ */
+public struct GetBucketTaggingOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketTaggingRequest {
+    public func asS3ModelGetBucketTaggingOperationInputPath() -> GetBucketTaggingOperationInputPath {
+        return GetBucketTaggingOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketVersioning
+ operation.
+ */
+public struct GetBucketVersioningOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketVersioningRequest {
+    public func asS3ModelGetBucketVersioningOperationInputPath() -> GetBucketVersioningOperationInputPath {
+        return GetBucketVersioningOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetBucketWebsite
+ operation.
+ */
+public struct GetBucketWebsiteOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetBucketWebsiteRequest {
+    public func asS3ModelGetBucketWebsiteOperationInputPath() -> GetBucketWebsiteOperationInputPath {
+        return GetBucketWebsiteOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetObject
+ operation.
+ */
+public struct GetObjectOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension GetObjectRequest {
+    public func asS3ModelGetObjectOperationInputPath() -> GetObjectOperationInputPath {
+        return GetObjectOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the GetObject
+ operation.
+ */
+public struct GetObjectOperationInputQuery: Codable, Equatable {
+    public var partNumber: PartNumber?
+    public var responseCacheControl: ResponseCacheControl?
+    public var responseContentDisposition: ResponseContentDisposition?
+    public var responseContentEncoding: ResponseContentEncoding?
+    public var responseContentLanguage: ResponseContentLanguage?
+    public var responseContentType: ResponseContentType?
+    public var responseExpires: ResponseExpires?
+    public var versionId: ObjectVersionId?
+
+    public init(partNumber: PartNumber? = nil,
+                responseCacheControl: ResponseCacheControl? = nil,
+                responseContentDisposition: ResponseContentDisposition? = nil,
+                responseContentEncoding: ResponseContentEncoding? = nil,
+                responseContentLanguage: ResponseContentLanguage? = nil,
+                responseContentType: ResponseContentType? = nil,
+                responseExpires: ResponseExpires? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.partNumber = partNumber
+        self.responseCacheControl = responseCacheControl
+        self.responseContentDisposition = responseContentDisposition
+        self.responseContentEncoding = responseContentEncoding
+        self.responseContentLanguage = responseContentLanguage
+        self.responseContentType = responseContentType
+        self.responseExpires = responseExpires
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case partNumber
+        case responseCacheControl = "response-cache-control"
+        case responseContentDisposition = "response-content-disposition"
+        case responseContentEncoding = "response-content-encoding"
+        case responseContentLanguage = "response-content-language"
+        case responseContentType = "response-content-type"
+        case responseExpires = "response-expires"
+        case versionId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectRequest {
+    public func asS3ModelGetObjectOperationInputQuery() -> GetObjectOperationInputQuery {
+        return GetObjectOperationInputQuery(
+            partNumber: partNumber,
+            responseCacheControl: responseCacheControl,
+            responseContentDisposition: responseContentDisposition,
+            responseContentEncoding: responseContentEncoding,
+            responseContentLanguage: responseContentLanguage,
+            responseContentType: responseContentType,
+            responseExpires: responseExpires,
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the GetObject
+ operation.
+ */
+public struct GetObjectOperationInputAdditionalHeaders: Codable, Equatable {
+    public var ifMatch: IfMatch?
+    public var ifModifiedSince: IfModifiedSince?
+    public var ifNoneMatch: IfNoneMatch?
+    public var ifUnmodifiedSince: IfUnmodifiedSince?
+    public var range: Range?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+
+    public init(ifMatch: IfMatch? = nil,
+                ifModifiedSince: IfModifiedSince? = nil,
+                ifNoneMatch: IfNoneMatch? = nil,
+                ifUnmodifiedSince: IfUnmodifiedSince? = nil,
+                range: Range? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil) {
+        self.ifMatch = ifMatch
+        self.ifModifiedSince = ifModifiedSince
+        self.ifNoneMatch = ifNoneMatch
+        self.ifUnmodifiedSince = ifUnmodifiedSince
+        self.range = range
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case ifMatch = "If-Match"
+        case ifModifiedSince = "If-Modified-Since"
+        case ifNoneMatch = "If-None-Match"
+        case ifUnmodifiedSince = "If-Unmodified-Since"
+        case range = "Range"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectRequest {
+    public func asS3ModelGetObjectOperationInputAdditionalHeaders() -> GetObjectOperationInputAdditionalHeaders {
+        return GetObjectOperationInputAdditionalHeaders(
+            ifMatch: ifMatch,
+            ifModifiedSince: ifModifiedSince,
+            ifNoneMatch: ifNoneMatch,
+            ifUnmodifiedSince: ifUnmodifiedSince,
+            range: range,
+            requestPayer: requestPayer,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKey: sSECustomerKey,
+            sSECustomerKeyMD5: sSECustomerKeyMD5)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the GetObject
+ operation.
+ */
+public struct GetObjectOperationOutputHeaders: Codable, Equatable {
+    public var acceptRanges: AcceptRanges?
+    public var cacheControl: CacheControl?
+    public var contentDisposition: ContentDisposition?
+    public var contentEncoding: ContentEncoding?
+    public var contentLanguage: ContentLanguage?
+    public var contentLength: ContentLength?
+    public var contentRange: ContentRange?
+    public var contentType: ContentType?
+    public var deleteMarker: DeleteMarker?
+    public var eTag: ETag?
+    public var expiration: Expiration?
+    public var expires: Expires?
+    public var lastModified: LastModified?
+    public var metadata: Metadata?
+    public var missingMeta: MissingMeta?
+    public var partsCount: PartsCount?
+    public var replicationStatus: ReplicationStatus?
+    public var requestCharged: RequestCharged?
+    public var restore: Restore?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var storageClass: StorageClass?
+    public var tagCount: TagCount?
+    public var versionId: ObjectVersionId?
+    public var websiteRedirectLocation: WebsiteRedirectLocation?
+
+    public init(acceptRanges: AcceptRanges? = nil,
+                cacheControl: CacheControl? = nil,
+                contentDisposition: ContentDisposition? = nil,
+                contentEncoding: ContentEncoding? = nil,
+                contentLanguage: ContentLanguage? = nil,
+                contentLength: ContentLength? = nil,
+                contentRange: ContentRange? = nil,
+                contentType: ContentType? = nil,
+                deleteMarker: DeleteMarker? = nil,
+                eTag: ETag? = nil,
+                expiration: Expiration? = nil,
+                expires: Expires? = nil,
+                lastModified: LastModified? = nil,
+                metadata: Metadata? = nil,
+                missingMeta: MissingMeta? = nil,
+                partsCount: PartsCount? = nil,
+                replicationStatus: ReplicationStatus? = nil,
+                requestCharged: RequestCharged? = nil,
+                restore: Restore? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                storageClass: StorageClass? = nil,
+                tagCount: TagCount? = nil,
+                versionId: ObjectVersionId? = nil,
+                websiteRedirectLocation: WebsiteRedirectLocation? = nil) {
+        self.acceptRanges = acceptRanges
+        self.cacheControl = cacheControl
+        self.contentDisposition = contentDisposition
+        self.contentEncoding = contentEncoding
+        self.contentLanguage = contentLanguage
+        self.contentLength = contentLength
+        self.contentRange = contentRange
+        self.contentType = contentType
+        self.deleteMarker = deleteMarker
+        self.eTag = eTag
+        self.expiration = expiration
+        self.expires = expires
+        self.lastModified = lastModified
+        self.metadata = metadata
+        self.missingMeta = missingMeta
+        self.partsCount = partsCount
+        self.replicationStatus = replicationStatus
+        self.requestCharged = requestCharged
+        self.restore = restore
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.storageClass = storageClass
+        self.tagCount = tagCount
+        self.versionId = versionId
+        self.websiteRedirectLocation = websiteRedirectLocation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case acceptRanges = "accept-ranges"
+        case cacheControl = "Cache-Control"
+        case contentDisposition = "Content-Disposition"
+        case contentEncoding = "Content-Encoding"
+        case contentLanguage = "Content-Language"
+        case contentLength = "Content-Length"
+        case contentRange = "Content-Range"
+        case contentType = "Content-Type"
+        case deleteMarker = "x-amz-delete-marker"
+        case eTag = "ETag"
+        case expiration = "x-amz-expiration"
+        case expires = "Expires"
+        case lastModified = "Last-Modified"
+        case metadata = "x-amz-meta-"
+        case missingMeta = "x-amz-missing-meta"
+        case partsCount = "x-amz-mp-parts-count"
+        case replicationStatus = "x-amz-replication-status"
+        case requestCharged = "x-amz-request-charged"
+        case restore = "x-amz-restore"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case storageClass = "x-amz-storage-class"
+        case tagCount = "x-amz-tagging-count"
+        case versionId = "x-amz-version-id"
+        case websiteRedirectLocation = "x-amz-website-redirect-location"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectOutput {
+    public func asS3ModelGetObjectOperationOutputHeaders() -> GetObjectOperationOutputHeaders {
+        return GetObjectOperationOutputHeaders(
+            acceptRanges: acceptRanges,
+            cacheControl: cacheControl,
+            contentDisposition: contentDisposition,
+            contentEncoding: contentEncoding,
+            contentLanguage: contentLanguage,
+            contentLength: contentLength,
+            contentRange: contentRange,
+            contentType: contentType,
+            deleteMarker: deleteMarker,
+            eTag: eTag,
+            expiration: expiration,
+            expires: expires,
+            lastModified: lastModified,
+            metadata: metadata,
+            missingMeta: missingMeta,
+            partsCount: partsCount,
+            replicationStatus: replicationStatus,
+            requestCharged: requestCharged,
+            restore: restore,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKeyMD5: sSECustomerKeyMD5,
+            sSEKMSKeyId: sSEKMSKeyId,
+            serverSideEncryption: serverSideEncryption,
+            storageClass: storageClass,
+            tagCount: tagCount,
+            versionId: versionId,
+            websiteRedirectLocation: websiteRedirectLocation)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetObjectAcl
+ operation.
+ */
+public struct GetObjectAclOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension GetObjectAclRequest {
+    public func asS3ModelGetObjectAclOperationInputPath() -> GetObjectAclOperationInputPath {
+        return GetObjectAclOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the GetObjectAcl
+ operation.
+ */
+public struct GetObjectAclOperationInputQuery: Codable, Equatable {
+    public var versionId: ObjectVersionId?
+
+    public init(versionId: ObjectVersionId? = nil) {
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case versionId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectAclRequest {
+    public func asS3ModelGetObjectAclOperationInputQuery() -> GetObjectAclOperationInputQuery {
+        return GetObjectAclOperationInputQuery(
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the GetObjectAcl
+ operation.
+ */
+public struct GetObjectAclOperationInputAdditionalHeaders: Codable, Equatable {
+    public var requestPayer: RequestPayer?
+
+    public init(requestPayer: RequestPayer? = nil) {
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectAclRequest {
+    public func asS3ModelGetObjectAclOperationInputAdditionalHeaders() -> GetObjectAclOperationInputAdditionalHeaders {
+        return GetObjectAclOperationInputAdditionalHeaders(
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the GetObjectAcl
+ operation.
+ */
+public struct GetObjectAclOperationOutputBody: Codable, Equatable {
+    public var grants: Grants?
+    public var owner: Owner?
+
+    public init(grants: Grants? = nil,
+                owner: Owner? = nil) {
+        self.grants = grants
+        self.owner = owner
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case grants = "AccessControlList"
+        case owner = "Owner"
+    }
+
+    public func validate() throws {
+        try owner?.validate()
+    }
+}
+
+public extension GetObjectAclOutput {
+    public func asS3ModelGetObjectAclOperationOutputBody() -> GetObjectAclOperationOutputBody {
+        return GetObjectAclOperationOutputBody(
+            grants: grants,
+            owner: owner)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the GetObjectAcl
+ operation.
+ */
+public struct GetObjectAclOperationOutputHeaders: Codable, Equatable {
+    public var requestCharged: RequestCharged?
+
+    public init(requestCharged: RequestCharged? = nil) {
+        self.requestCharged = requestCharged
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestCharged = "x-amz-request-charged"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectAclOutput {
+    public func asS3ModelGetObjectAclOperationOutputHeaders() -> GetObjectAclOperationOutputHeaders {
+        return GetObjectAclOperationOutputHeaders(
+            requestCharged: requestCharged)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetObjectTagging
+ operation.
+ */
+public struct GetObjectTaggingOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension GetObjectTaggingRequest {
+    public func asS3ModelGetObjectTaggingOperationInputPath() -> GetObjectTaggingOperationInputPath {
+        return GetObjectTaggingOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the GetObjectTagging
+ operation.
+ */
+public struct GetObjectTaggingOperationInputQuery: Codable, Equatable {
+    public var versionId: ObjectVersionId?
+
+    public init(versionId: ObjectVersionId? = nil) {
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case versionId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectTaggingRequest {
+    public func asS3ModelGetObjectTaggingOperationInputQuery() -> GetObjectTaggingOperationInputQuery {
+        return GetObjectTaggingOperationInputQuery(
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the GetObjectTagging
+ operation.
+ */
+public struct GetObjectTaggingOperationOutputBody: Codable, Equatable {
+    public var tagSet: TagSet
+
+    public init(tagSet: TagSet) {
+        self.tagSet = tagSet
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case tagSet = "TagSet"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectTaggingOutput {
+    public func asS3ModelGetObjectTaggingOperationOutputBody() -> GetObjectTaggingOperationOutputBody {
+        return GetObjectTaggingOperationOutputBody(
+            tagSet: tagSet)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the GetObjectTagging
+ operation.
+ */
+public struct GetObjectTaggingOperationOutputHeaders: Codable, Equatable {
+    public var versionId: ObjectVersionId?
+
+    public init(versionId: ObjectVersionId? = nil) {
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case versionId = "x-amz-version-id"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectTaggingOutput {
+    public func asS3ModelGetObjectTaggingOperationOutputHeaders() -> GetObjectTaggingOperationOutputHeaders {
+        return GetObjectTaggingOperationOutputHeaders(
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetObjectTorrent
+ operation.
+ */
+public struct GetObjectTorrentOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension GetObjectTorrentRequest {
+    public func asS3ModelGetObjectTorrentOperationInputPath() -> GetObjectTorrentOperationInputPath {
+        return GetObjectTorrentOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the GetObjectTorrent
+ operation.
+ */
+public struct GetObjectTorrentOperationInputAdditionalHeaders: Codable, Equatable {
+    public var requestPayer: RequestPayer?
+
+    public init(requestPayer: RequestPayer? = nil) {
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectTorrentRequest {
+    public func asS3ModelGetObjectTorrentOperationInputAdditionalHeaders() -> GetObjectTorrentOperationInputAdditionalHeaders {
+        return GetObjectTorrentOperationInputAdditionalHeaders(
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the GetObjectTorrent
+ operation.
+ */
+public struct GetObjectTorrentOperationOutputHeaders: Codable, Equatable {
+    public var requestCharged: RequestCharged?
+
+    public init(requestCharged: RequestCharged? = nil) {
+        self.requestCharged = requestCharged
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestCharged = "x-amz-request-charged"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetObjectTorrentOutput {
+    public func asS3ModelGetObjectTorrentOperationOutputHeaders() -> GetObjectTorrentOperationOutputHeaders {
+        return GetObjectTorrentOperationOutputHeaders(
+            requestCharged: requestCharged)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the GetPublicAccessBlock
+ operation.
+ */
+public struct GetPublicAccessBlockOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension GetPublicAccessBlockRequest {
+    public func asS3ModelGetPublicAccessBlockOperationInputPath() -> GetPublicAccessBlockOperationInputPath {
+        return GetPublicAccessBlockOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the HeadBucket
+ operation.
+ */
+public struct HeadBucketOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension HeadBucketRequest {
+    public func asS3ModelHeadBucketOperationInputPath() -> HeadBucketOperationInputPath {
+        return HeadBucketOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the HeadObject
+ operation.
+ */
+public struct HeadObjectOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension HeadObjectRequest {
+    public func asS3ModelHeadObjectOperationInputPath() -> HeadObjectOperationInputPath {
+        return HeadObjectOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the HeadObject
+ operation.
+ */
+public struct HeadObjectOperationInputQuery: Codable, Equatable {
+    public var partNumber: PartNumber?
+    public var versionId: ObjectVersionId?
+
+    public init(partNumber: PartNumber? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.partNumber = partNumber
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case partNumber
+        case versionId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension HeadObjectRequest {
+    public func asS3ModelHeadObjectOperationInputQuery() -> HeadObjectOperationInputQuery {
+        return HeadObjectOperationInputQuery(
+            partNumber: partNumber,
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the HeadObject
+ operation.
+ */
+public struct HeadObjectOperationInputAdditionalHeaders: Codable, Equatable {
+    public var ifMatch: IfMatch?
+    public var ifModifiedSince: IfModifiedSince?
+    public var ifNoneMatch: IfNoneMatch?
+    public var ifUnmodifiedSince: IfUnmodifiedSince?
+    public var range: Range?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+
+    public init(ifMatch: IfMatch? = nil,
+                ifModifiedSince: IfModifiedSince? = nil,
+                ifNoneMatch: IfNoneMatch? = nil,
+                ifUnmodifiedSince: IfUnmodifiedSince? = nil,
+                range: Range? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil) {
+        self.ifMatch = ifMatch
+        self.ifModifiedSince = ifModifiedSince
+        self.ifNoneMatch = ifNoneMatch
+        self.ifUnmodifiedSince = ifUnmodifiedSince
+        self.range = range
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case ifMatch = "If-Match"
+        case ifModifiedSince = "If-Modified-Since"
+        case ifNoneMatch = "If-None-Match"
+        case ifUnmodifiedSince = "If-Unmodified-Since"
+        case range = "Range"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension HeadObjectRequest {
+    public func asS3ModelHeadObjectOperationInputAdditionalHeaders() -> HeadObjectOperationInputAdditionalHeaders {
+        return HeadObjectOperationInputAdditionalHeaders(
+            ifMatch: ifMatch,
+            ifModifiedSince: ifModifiedSince,
+            ifNoneMatch: ifNoneMatch,
+            ifUnmodifiedSince: ifUnmodifiedSince,
+            range: range,
+            requestPayer: requestPayer,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKey: sSECustomerKey,
+            sSECustomerKeyMD5: sSECustomerKeyMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the ListBucketAnalyticsConfigurations
+ operation.
+ */
+public struct ListBucketAnalyticsConfigurationsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListBucketAnalyticsConfigurationsRequest {
+    public func asS3ModelListBucketAnalyticsConfigurationsOperationInputPath() -> ListBucketAnalyticsConfigurationsOperationInputPath {
+        return ListBucketAnalyticsConfigurationsOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the ListBucketAnalyticsConfigurations
+ operation.
+ */
+public struct ListBucketAnalyticsConfigurationsOperationInputQuery: Codable, Equatable {
+    public var continuationToken: Token?
+
+    public init(continuationToken: Token? = nil) {
+        self.continuationToken = continuationToken
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case continuationToken = "continuation-token"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListBucketAnalyticsConfigurationsRequest {
+    public func asS3ModelListBucketAnalyticsConfigurationsOperationInputQuery() -> ListBucketAnalyticsConfigurationsOperationInputQuery {
+        return ListBucketAnalyticsConfigurationsOperationInputQuery(
+            continuationToken: continuationToken)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the ListBucketInventoryConfigurations
+ operation.
+ */
+public struct ListBucketInventoryConfigurationsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListBucketInventoryConfigurationsRequest {
+    public func asS3ModelListBucketInventoryConfigurationsOperationInputPath() -> ListBucketInventoryConfigurationsOperationInputPath {
+        return ListBucketInventoryConfigurationsOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the ListBucketInventoryConfigurations
+ operation.
+ */
+public struct ListBucketInventoryConfigurationsOperationInputQuery: Codable, Equatable {
+    public var continuationToken: Token?
+
+    public init(continuationToken: Token? = nil) {
+        self.continuationToken = continuationToken
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case continuationToken = "continuation-token"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListBucketInventoryConfigurationsRequest {
+    public func asS3ModelListBucketInventoryConfigurationsOperationInputQuery() -> ListBucketInventoryConfigurationsOperationInputQuery {
+        return ListBucketInventoryConfigurationsOperationInputQuery(
+            continuationToken: continuationToken)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the ListBucketMetricsConfigurations
+ operation.
+ */
+public struct ListBucketMetricsConfigurationsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListBucketMetricsConfigurationsRequest {
+    public func asS3ModelListBucketMetricsConfigurationsOperationInputPath() -> ListBucketMetricsConfigurationsOperationInputPath {
+        return ListBucketMetricsConfigurationsOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the ListBucketMetricsConfigurations
+ operation.
+ */
+public struct ListBucketMetricsConfigurationsOperationInputQuery: Codable, Equatable {
+    public var continuationToken: Token?
+
+    public init(continuationToken: Token? = nil) {
+        self.continuationToken = continuationToken
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case continuationToken = "continuation-token"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListBucketMetricsConfigurationsRequest {
+    public func asS3ModelListBucketMetricsConfigurationsOperationInputQuery() -> ListBucketMetricsConfigurationsOperationInputQuery {
+        return ListBucketMetricsConfigurationsOperationInputQuery(
+            continuationToken: continuationToken)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the ListMultipartUploads
+ operation.
+ */
+public struct ListMultipartUploadsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListMultipartUploadsRequest {
+    public func asS3ModelListMultipartUploadsOperationInputPath() -> ListMultipartUploadsOperationInputPath {
+        return ListMultipartUploadsOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the ListMultipartUploads
+ operation.
+ */
+public struct ListMultipartUploadsOperationInputQuery: Codable, Equatable {
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var keyMarker: KeyMarker?
+    public var maxUploads: MaxUploads?
+    public var prefix: Prefix?
+    public var uploadIdMarker: UploadIdMarker?
+
+    public init(delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                keyMarker: KeyMarker? = nil,
+                maxUploads: MaxUploads? = nil,
+                prefix: Prefix? = nil,
+                uploadIdMarker: UploadIdMarker? = nil) {
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.keyMarker = keyMarker
+        self.maxUploads = maxUploads
+        self.prefix = prefix
+        self.uploadIdMarker = uploadIdMarker
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case delimiter
+        case encodingType = "encoding-type"
+        case keyMarker = "key-marker"
+        case maxUploads = "max-uploads"
+        case prefix
+        case uploadIdMarker = "upload-id-marker"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListMultipartUploadsRequest {
+    public func asS3ModelListMultipartUploadsOperationInputQuery() -> ListMultipartUploadsOperationInputQuery {
+        return ListMultipartUploadsOperationInputQuery(
+            delimiter: delimiter,
+            encodingType: encodingType,
+            keyMarker: keyMarker,
+            maxUploads: maxUploads,
+            prefix: prefix,
+            uploadIdMarker: uploadIdMarker)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the ListObjectVersions
+ operation.
+ */
+public struct ListObjectVersionsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListObjectVersionsRequest {
+    public func asS3ModelListObjectVersionsOperationInputPath() -> ListObjectVersionsOperationInputPath {
+        return ListObjectVersionsOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the ListObjectVersions
+ operation.
+ */
+public struct ListObjectVersionsOperationInputQuery: Codable, Equatable {
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var keyMarker: KeyMarker?
+    public var maxKeys: MaxKeys?
+    public var prefix: Prefix?
+    public var versionIdMarker: VersionIdMarker?
+
+    public init(delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                keyMarker: KeyMarker? = nil,
+                maxKeys: MaxKeys? = nil,
+                prefix: Prefix? = nil,
+                versionIdMarker: VersionIdMarker? = nil) {
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.keyMarker = keyMarker
+        self.maxKeys = maxKeys
+        self.prefix = prefix
+        self.versionIdMarker = versionIdMarker
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case delimiter
+        case encodingType = "encoding-type"
+        case keyMarker = "key-marker"
+        case maxKeys = "max-keys"
+        case prefix
+        case versionIdMarker = "version-id-marker"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListObjectVersionsRequest {
+    public func asS3ModelListObjectVersionsOperationInputQuery() -> ListObjectVersionsOperationInputQuery {
+        return ListObjectVersionsOperationInputQuery(
+            delimiter: delimiter,
+            encodingType: encodingType,
+            keyMarker: keyMarker,
+            maxKeys: maxKeys,
+            prefix: prefix,
+            versionIdMarker: versionIdMarker)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the ListObjects
+ operation.
+ */
+public struct ListObjectsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListObjectsRequest {
+    public func asS3ModelListObjectsOperationInputPath() -> ListObjectsOperationInputPath {
+        return ListObjectsOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the ListObjects
+ operation.
+ */
+public struct ListObjectsOperationInputQuery: Codable, Equatable {
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var marker: Marker?
+    public var maxKeys: MaxKeys?
+    public var prefix: Prefix?
+
+    public init(delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                marker: Marker? = nil,
+                maxKeys: MaxKeys? = nil,
+                prefix: Prefix? = nil) {
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.marker = marker
+        self.maxKeys = maxKeys
+        self.prefix = prefix
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case delimiter
+        case encodingType = "encoding-type"
+        case marker
+        case maxKeys = "max-keys"
+        case prefix
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListObjectsRequest {
+    public func asS3ModelListObjectsOperationInputQuery() -> ListObjectsOperationInputQuery {
+        return ListObjectsOperationInputQuery(
+            delimiter: delimiter,
+            encodingType: encodingType,
+            marker: marker,
+            maxKeys: maxKeys,
+            prefix: prefix)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the ListObjects
+ operation.
+ */
+public struct ListObjectsOperationInputAdditionalHeaders: Codable, Equatable {
+    public var requestPayer: RequestPayer?
+
+    public init(requestPayer: RequestPayer? = nil) {
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListObjectsRequest {
+    public func asS3ModelListObjectsOperationInputAdditionalHeaders() -> ListObjectsOperationInputAdditionalHeaders {
+        return ListObjectsOperationInputAdditionalHeaders(
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the ListObjectsV2
+ operation.
+ */
+public struct ListObjectsV2OperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListObjectsV2Request {
+    public func asS3ModelListObjectsV2OperationInputPath() -> ListObjectsV2OperationInputPath {
+        return ListObjectsV2OperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the ListObjectsV2
+ operation.
+ */
+public struct ListObjectsV2OperationInputQuery: Codable, Equatable {
+    public var continuationToken: Token?
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var fetchOwner: FetchOwner?
+    public var maxKeys: MaxKeys?
+    public var prefix: Prefix?
+    public var startAfter: StartAfter?
+
+    public init(continuationToken: Token? = nil,
+                delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                fetchOwner: FetchOwner? = nil,
+                maxKeys: MaxKeys? = nil,
+                prefix: Prefix? = nil,
+                startAfter: StartAfter? = nil) {
+        self.continuationToken = continuationToken
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.fetchOwner = fetchOwner
+        self.maxKeys = maxKeys
+        self.prefix = prefix
+        self.startAfter = startAfter
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case continuationToken = "continuation-token"
+        case delimiter
+        case encodingType = "encoding-type"
+        case fetchOwner = "fetch-owner"
+        case maxKeys = "max-keys"
+        case prefix
+        case startAfter = "start-after"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListObjectsV2Request {
+    public func asS3ModelListObjectsV2OperationInputQuery() -> ListObjectsV2OperationInputQuery {
+        return ListObjectsV2OperationInputQuery(
+            continuationToken: continuationToken,
+            delimiter: delimiter,
+            encodingType: encodingType,
+            fetchOwner: fetchOwner,
+            maxKeys: maxKeys,
+            prefix: prefix,
+            startAfter: startAfter)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the ListObjectsV2
+ operation.
+ */
+public struct ListObjectsV2OperationInputAdditionalHeaders: Codable, Equatable {
+    public var requestPayer: RequestPayer?
+
+    public init(requestPayer: RequestPayer? = nil) {
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListObjectsV2Request {
+    public func asS3ModelListObjectsV2OperationInputAdditionalHeaders() -> ListObjectsV2OperationInputAdditionalHeaders {
+        return ListObjectsV2OperationInputAdditionalHeaders(
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the ListParts
+ operation.
+ */
+public struct ListPartsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension ListPartsRequest {
+    public func asS3ModelListPartsOperationInputPath() -> ListPartsOperationInputPath {
+        return ListPartsOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the ListParts
+ operation.
+ */
+public struct ListPartsOperationInputQuery: Codable, Equatable {
+    public var maxParts: MaxParts?
+    public var partNumberMarker: PartNumberMarker?
+    public var uploadId: MultipartUploadId
+
+    public init(maxParts: MaxParts? = nil,
+                partNumberMarker: PartNumberMarker? = nil,
+                uploadId: MultipartUploadId) {
+        self.maxParts = maxParts
+        self.partNumberMarker = partNumberMarker
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case maxParts = "max-parts"
+        case partNumberMarker = "part-number-marker"
+        case uploadId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListPartsRequest {
+    public func asS3ModelListPartsOperationInputQuery() -> ListPartsOperationInputQuery {
+        return ListPartsOperationInputQuery(
+            maxParts: maxParts,
+            partNumberMarker: partNumberMarker,
+            uploadId: uploadId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the ListParts
+ operation.
+ */
+public struct ListPartsOperationInputAdditionalHeaders: Codable, Equatable {
+    public var requestPayer: RequestPayer?
+
+    public init(requestPayer: RequestPayer? = nil) {
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListPartsRequest {
+    public func asS3ModelListPartsOperationInputAdditionalHeaders() -> ListPartsOperationInputAdditionalHeaders {
+        return ListPartsOperationInputAdditionalHeaders(
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the ListParts
+ operation.
+ */
+public struct ListPartsOperationOutputBody: Codable, Equatable {
+    public var bucket: BucketName?
+    public var initiator: Initiator?
+    public var isTruncated: IsTruncated?
+    public var key: ObjectKey?
+    public var maxParts: MaxParts?
+    public var nextPartNumberMarker: NextPartNumberMarker?
+    public var owner: Owner?
+    public var partNumberMarker: PartNumberMarker?
+    public var parts: Parts?
+    public var storageClass: StorageClass?
+    public var uploadId: MultipartUploadId?
+
+    public init(bucket: BucketName? = nil,
+                initiator: Initiator? = nil,
+                isTruncated: IsTruncated? = nil,
+                key: ObjectKey? = nil,
+                maxParts: MaxParts? = nil,
+                nextPartNumberMarker: NextPartNumberMarker? = nil,
+                owner: Owner? = nil,
+                partNumberMarker: PartNumberMarker? = nil,
+                parts: Parts? = nil,
+                storageClass: StorageClass? = nil,
+                uploadId: MultipartUploadId? = nil) {
+        self.bucket = bucket
+        self.initiator = initiator
+        self.isTruncated = isTruncated
+        self.key = key
+        self.maxParts = maxParts
+        self.nextPartNumberMarker = nextPartNumberMarker
+        self.owner = owner
+        self.partNumberMarker = partNumberMarker
+        self.parts = parts
+        self.storageClass = storageClass
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case initiator = "Initiator"
+        case isTruncated = "IsTruncated"
+        case key = "Key"
+        case maxParts = "MaxParts"
+        case nextPartNumberMarker = "NextPartNumberMarker"
+        case owner = "Owner"
+        case partNumberMarker = "PartNumberMarker"
+        case parts = "Part"
+        case storageClass = "StorageClass"
+        case uploadId = "UploadId"
+    }
+
+    public func validate() throws {
+        try initiator?.validate()
+        try key?.validateAsObjectKey()
+        try owner?.validate()
+    }
+}
+
+public extension ListPartsOutput {
+    public func asS3ModelListPartsOperationOutputBody() -> ListPartsOperationOutputBody {
+        return ListPartsOperationOutputBody(
+            bucket: bucket,
+            initiator: initiator,
+            isTruncated: isTruncated,
+            key: key,
+            maxParts: maxParts,
+            nextPartNumberMarker: nextPartNumberMarker,
+            owner: owner,
+            partNumberMarker: partNumberMarker,
+            parts: parts,
+            storageClass: storageClass,
+            uploadId: uploadId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the ListParts
+ operation.
+ */
+public struct ListPartsOperationOutputHeaders: Codable, Equatable {
+    public var abortDate: AbortDate?
+    public var abortRuleId: AbortRuleId?
+    public var requestCharged: RequestCharged?
+
+    public init(abortDate: AbortDate? = nil,
+                abortRuleId: AbortRuleId? = nil,
+                requestCharged: RequestCharged? = nil) {
+        self.abortDate = abortDate
+        self.abortRuleId = abortRuleId
+        self.requestCharged = requestCharged
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case abortDate = "x-amz-abort-date"
+        case abortRuleId = "x-amz-abort-rule-id"
+        case requestCharged = "x-amz-request-charged"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension ListPartsOutput {
+    public func asS3ModelListPartsOperationOutputHeaders() -> ListPartsOperationOutputHeaders {
+        return ListPartsOperationOutputHeaders(
+            abortDate: abortDate,
+            abortRuleId: abortRuleId,
+            requestCharged: requestCharged)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketAccelerateConfiguration
+ operation.
+ */
+public struct PutBucketAccelerateConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketAccelerateConfigurationRequest {
+    public func asS3ModelPutBucketAccelerateConfigurationOperationInputPath() -> PutBucketAccelerateConfigurationOperationInputPath {
+        return PutBucketAccelerateConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketAcl
+ operation.
+ */
+public struct PutBucketAclOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketAclRequest {
+    public func asS3ModelPutBucketAclOperationInputPath() -> PutBucketAclOperationInputPath {
+        return PutBucketAclOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketAcl
+ operation.
+ */
+public struct PutBucketAclOperationInputAdditionalHeaders: Codable, Equatable {
+    public var aCL: BucketCannedACL?
+    public var contentMD5: ContentMD5?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWrite: GrantWrite?
+    public var grantWriteACP: GrantWriteACP?
+
+    public init(aCL: BucketCannedACL? = nil,
+                contentMD5: ContentMD5? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWrite: GrantWrite? = nil,
+                grantWriteACP: GrantWriteACP? = nil) {
+        self.aCL = aCL
+        self.contentMD5 = contentMD5
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWrite = grantWrite
+        self.grantWriteACP = grantWriteACP
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case contentMD5 = "Content-MD5"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWrite = "x-amz-grant-write"
+        case grantWriteACP = "x-amz-grant-write-acp"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketAclRequest {
+    public func asS3ModelPutBucketAclOperationInputAdditionalHeaders() -> PutBucketAclOperationInputAdditionalHeaders {
+        return PutBucketAclOperationInputAdditionalHeaders(
+            aCL: aCL,
+            contentMD5: contentMD5,
+            grantFullControl: grantFullControl,
+            grantRead: grantRead,
+            grantReadACP: grantReadACP,
+            grantWrite: grantWrite,
+            grantWriteACP: grantWriteACP)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketAnalyticsConfiguration
+ operation.
+ */
+public struct PutBucketAnalyticsConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketAnalyticsConfigurationRequest {
+    public func asS3ModelPutBucketAnalyticsConfigurationOperationInputPath() -> PutBucketAnalyticsConfigurationOperationInputPath {
+        return PutBucketAnalyticsConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the PutBucketAnalyticsConfiguration
+ operation.
+ */
+public struct PutBucketAnalyticsConfigurationOperationInputQuery: Codable, Equatable {
+    public var id: AnalyticsId
+
+    public init(id: AnalyticsId) {
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketAnalyticsConfigurationRequest {
+    public func asS3ModelPutBucketAnalyticsConfigurationOperationInputQuery() -> PutBucketAnalyticsConfigurationOperationInputQuery {
+        return PutBucketAnalyticsConfigurationOperationInputQuery(
+            id: id)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketCors
+ operation.
+ */
+public struct PutBucketCorsOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketCorsRequest {
+    public func asS3ModelPutBucketCorsOperationInputPath() -> PutBucketCorsOperationInputPath {
+        return PutBucketCorsOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketCors
+ operation.
+ */
+public struct PutBucketCorsOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketCorsRequest {
+    public func asS3ModelPutBucketCorsOperationInputAdditionalHeaders() -> PutBucketCorsOperationInputAdditionalHeaders {
+        return PutBucketCorsOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketEncryption
+ operation.
+ */
+public struct PutBucketEncryptionOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketEncryptionRequest {
+    public func asS3ModelPutBucketEncryptionOperationInputPath() -> PutBucketEncryptionOperationInputPath {
+        return PutBucketEncryptionOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketEncryption
+ operation.
+ */
+public struct PutBucketEncryptionOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketEncryptionRequest {
+    public func asS3ModelPutBucketEncryptionOperationInputAdditionalHeaders() -> PutBucketEncryptionOperationInputAdditionalHeaders {
+        return PutBucketEncryptionOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketInventoryConfiguration
+ operation.
+ */
+public struct PutBucketInventoryConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketInventoryConfigurationRequest {
+    public func asS3ModelPutBucketInventoryConfigurationOperationInputPath() -> PutBucketInventoryConfigurationOperationInputPath {
+        return PutBucketInventoryConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the PutBucketInventoryConfiguration
+ operation.
+ */
+public struct PutBucketInventoryConfigurationOperationInputQuery: Codable, Equatable {
+    public var id: InventoryId
+
+    public init(id: InventoryId) {
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketInventoryConfigurationRequest {
+    public func asS3ModelPutBucketInventoryConfigurationOperationInputQuery() -> PutBucketInventoryConfigurationOperationInputQuery {
+        return PutBucketInventoryConfigurationOperationInputQuery(
+            id: id)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketLifecycle
+ operation.
+ */
+public struct PutBucketLifecycleOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketLifecycleRequest {
+    public func asS3ModelPutBucketLifecycleOperationInputPath() -> PutBucketLifecycleOperationInputPath {
+        return PutBucketLifecycleOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketLifecycle
+ operation.
+ */
+public struct PutBucketLifecycleOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketLifecycleRequest {
+    public func asS3ModelPutBucketLifecycleOperationInputAdditionalHeaders() -> PutBucketLifecycleOperationInputAdditionalHeaders {
+        return PutBucketLifecycleOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketLifecycleConfiguration
+ operation.
+ */
+public struct PutBucketLifecycleConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketLifecycleConfigurationRequest {
+    public func asS3ModelPutBucketLifecycleConfigurationOperationInputPath() -> PutBucketLifecycleConfigurationOperationInputPath {
+        return PutBucketLifecycleConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketLogging
+ operation.
+ */
+public struct PutBucketLoggingOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketLoggingRequest {
+    public func asS3ModelPutBucketLoggingOperationInputPath() -> PutBucketLoggingOperationInputPath {
+        return PutBucketLoggingOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketLogging
+ operation.
+ */
+public struct PutBucketLoggingOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketLoggingRequest {
+    public func asS3ModelPutBucketLoggingOperationInputAdditionalHeaders() -> PutBucketLoggingOperationInputAdditionalHeaders {
+        return PutBucketLoggingOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketMetricsConfiguration
+ operation.
+ */
+public struct PutBucketMetricsConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketMetricsConfigurationRequest {
+    public func asS3ModelPutBucketMetricsConfigurationOperationInputPath() -> PutBucketMetricsConfigurationOperationInputPath {
+        return PutBucketMetricsConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the PutBucketMetricsConfiguration
+ operation.
+ */
+public struct PutBucketMetricsConfigurationOperationInputQuery: Codable, Equatable {
+    public var id: MetricsId
+
+    public init(id: MetricsId) {
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketMetricsConfigurationRequest {
+    public func asS3ModelPutBucketMetricsConfigurationOperationInputQuery() -> PutBucketMetricsConfigurationOperationInputQuery {
+        return PutBucketMetricsConfigurationOperationInputQuery(
+            id: id)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketNotification
+ operation.
+ */
+public struct PutBucketNotificationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketNotificationRequest {
+    public func asS3ModelPutBucketNotificationOperationInputPath() -> PutBucketNotificationOperationInputPath {
+        return PutBucketNotificationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketNotification
+ operation.
+ */
+public struct PutBucketNotificationOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketNotificationRequest {
+    public func asS3ModelPutBucketNotificationOperationInputAdditionalHeaders() -> PutBucketNotificationOperationInputAdditionalHeaders {
+        return PutBucketNotificationOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketNotificationConfiguration
+ operation.
+ */
+public struct PutBucketNotificationConfigurationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketNotificationConfigurationRequest {
+    public func asS3ModelPutBucketNotificationConfigurationOperationInputPath() -> PutBucketNotificationConfigurationOperationInputPath {
+        return PutBucketNotificationConfigurationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketPolicy
+ operation.
+ */
+public struct PutBucketPolicyOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketPolicyRequest {
+    public func asS3ModelPutBucketPolicyOperationInputPath() -> PutBucketPolicyOperationInputPath {
+        return PutBucketPolicyOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketPolicy
+ operation.
+ */
+public struct PutBucketPolicyOperationInputAdditionalHeaders: Codable, Equatable {
+    public var confirmRemoveSelfBucketAccess: ConfirmRemoveSelfBucketAccess?
+    public var contentMD5: ContentMD5?
+
+    public init(confirmRemoveSelfBucketAccess: ConfirmRemoveSelfBucketAccess? = nil,
+                contentMD5: ContentMD5? = nil) {
+        self.confirmRemoveSelfBucketAccess = confirmRemoveSelfBucketAccess
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case confirmRemoveSelfBucketAccess = "x-amz-confirm-remove-self-bucket-access"
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketPolicyRequest {
+    public func asS3ModelPutBucketPolicyOperationInputAdditionalHeaders() -> PutBucketPolicyOperationInputAdditionalHeaders {
+        return PutBucketPolicyOperationInputAdditionalHeaders(
+            confirmRemoveSelfBucketAccess: confirmRemoveSelfBucketAccess,
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketReplication
+ operation.
+ */
+public struct PutBucketReplicationOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketReplicationRequest {
+    public func asS3ModelPutBucketReplicationOperationInputPath() -> PutBucketReplicationOperationInputPath {
+        return PutBucketReplicationOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketReplication
+ operation.
+ */
+public struct PutBucketReplicationOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketReplicationRequest {
+    public func asS3ModelPutBucketReplicationOperationInputAdditionalHeaders() -> PutBucketReplicationOperationInputAdditionalHeaders {
+        return PutBucketReplicationOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketRequestPayment
+ operation.
+ */
+public struct PutBucketRequestPaymentOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketRequestPaymentRequest {
+    public func asS3ModelPutBucketRequestPaymentOperationInputPath() -> PutBucketRequestPaymentOperationInputPath {
+        return PutBucketRequestPaymentOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketRequestPayment
+ operation.
+ */
+public struct PutBucketRequestPaymentOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketRequestPaymentRequest {
+    public func asS3ModelPutBucketRequestPaymentOperationInputAdditionalHeaders() -> PutBucketRequestPaymentOperationInputAdditionalHeaders {
+        return PutBucketRequestPaymentOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketTagging
+ operation.
+ */
+public struct PutBucketTaggingOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketTaggingRequest {
+    public func asS3ModelPutBucketTaggingOperationInputPath() -> PutBucketTaggingOperationInputPath {
+        return PutBucketTaggingOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketTagging
+ operation.
+ */
+public struct PutBucketTaggingOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketTaggingRequest {
+    public func asS3ModelPutBucketTaggingOperationInputAdditionalHeaders() -> PutBucketTaggingOperationInputAdditionalHeaders {
+        return PutBucketTaggingOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketVersioning
+ operation.
+ */
+public struct PutBucketVersioningOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketVersioningRequest {
+    public func asS3ModelPutBucketVersioningOperationInputPath() -> PutBucketVersioningOperationInputPath {
+        return PutBucketVersioningOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketVersioning
+ operation.
+ */
+public struct PutBucketVersioningOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+    public var mFA: MFA?
+
+    public init(contentMD5: ContentMD5? = nil,
+                mFA: MFA? = nil) {
+        self.contentMD5 = contentMD5
+        self.mFA = mFA
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+        case mFA = "x-amz-mfa"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketVersioningRequest {
+    public func asS3ModelPutBucketVersioningOperationInputAdditionalHeaders() -> PutBucketVersioningOperationInputAdditionalHeaders {
+        return PutBucketVersioningOperationInputAdditionalHeaders(
+            contentMD5: contentMD5,
+            mFA: mFA)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutBucketWebsite
+ operation.
+ */
+public struct PutBucketWebsiteOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketWebsiteRequest {
+    public func asS3ModelPutBucketWebsiteOperationInputPath() -> PutBucketWebsiteOperationInputPath {
+        return PutBucketWebsiteOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutBucketWebsite
+ operation.
+ */
+public struct PutBucketWebsiteOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutBucketWebsiteRequest {
+    public func asS3ModelPutBucketWebsiteOperationInputAdditionalHeaders() -> PutBucketWebsiteOperationInputAdditionalHeaders {
+        return PutBucketWebsiteOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutObject
+ operation.
+ */
+public struct PutObjectOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension PutObjectRequest {
+    public func asS3ModelPutObjectOperationInputPath() -> PutObjectOperationInputPath {
+        return PutObjectOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutObject
+ operation.
+ */
+public struct PutObjectOperationInputAdditionalHeaders: Codable, Equatable {
+    public var aCL: ObjectCannedACL?
+    public var cacheControl: CacheControl?
+    public var contentDisposition: ContentDisposition?
+    public var contentEncoding: ContentEncoding?
+    public var contentLanguage: ContentLanguage?
+    public var contentLength: ContentLength?
+    public var contentMD5: ContentMD5?
+    public var contentType: ContentType?
+    public var expires: Expires?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWriteACP: GrantWriteACP?
+    public var metadata: Metadata?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var storageClass: StorageClass?
+    public var tagging: TaggingHeader?
+    public var websiteRedirectLocation: WebsiteRedirectLocation?
+
+    public init(aCL: ObjectCannedACL? = nil,
+                cacheControl: CacheControl? = nil,
+                contentDisposition: ContentDisposition? = nil,
+                contentEncoding: ContentEncoding? = nil,
+                contentLanguage: ContentLanguage? = nil,
+                contentLength: ContentLength? = nil,
+                contentMD5: ContentMD5? = nil,
+                contentType: ContentType? = nil,
+                expires: Expires? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWriteACP: GrantWriteACP? = nil,
+                metadata: Metadata? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                storageClass: StorageClass? = nil,
+                tagging: TaggingHeader? = nil,
+                websiteRedirectLocation: WebsiteRedirectLocation? = nil) {
+        self.aCL = aCL
+        self.cacheControl = cacheControl
+        self.contentDisposition = contentDisposition
+        self.contentEncoding = contentEncoding
+        self.contentLanguage = contentLanguage
+        self.contentLength = contentLength
+        self.contentMD5 = contentMD5
+        self.contentType = contentType
+        self.expires = expires
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWriteACP = grantWriteACP
+        self.metadata = metadata
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.storageClass = storageClass
+        self.tagging = tagging
+        self.websiteRedirectLocation = websiteRedirectLocation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case cacheControl = "Cache-Control"
+        case contentDisposition = "Content-Disposition"
+        case contentEncoding = "Content-Encoding"
+        case contentLanguage = "Content-Language"
+        case contentLength = "Content-Length"
+        case contentMD5 = "Content-MD5"
+        case contentType = "Content-Type"
+        case expires = "Expires"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWriteACP = "x-amz-grant-write-acp"
+        case metadata = "x-amz-meta-"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case storageClass = "x-amz-storage-class"
+        case tagging = "x-amz-tagging"
+        case websiteRedirectLocation = "x-amz-website-redirect-location"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutObjectRequest {
+    public func asS3ModelPutObjectOperationInputAdditionalHeaders() -> PutObjectOperationInputAdditionalHeaders {
+        return PutObjectOperationInputAdditionalHeaders(
+            aCL: aCL,
+            cacheControl: cacheControl,
+            contentDisposition: contentDisposition,
+            contentEncoding: contentEncoding,
+            contentLanguage: contentLanguage,
+            contentLength: contentLength,
+            contentMD5: contentMD5,
+            contentType: contentType,
+            expires: expires,
+            grantFullControl: grantFullControl,
+            grantRead: grantRead,
+            grantReadACP: grantReadACP,
+            grantWriteACP: grantWriteACP,
+            metadata: metadata,
+            requestPayer: requestPayer,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKey: sSECustomerKey,
+            sSECustomerKeyMD5: sSECustomerKeyMD5,
+            sSEKMSKeyId: sSEKMSKeyId,
+            serverSideEncryption: serverSideEncryption,
+            storageClass: storageClass,
+            tagging: tagging,
+            websiteRedirectLocation: websiteRedirectLocation)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutObjectAcl
+ operation.
+ */
+public struct PutObjectAclOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension PutObjectAclRequest {
+    public func asS3ModelPutObjectAclOperationInputPath() -> PutObjectAclOperationInputPath {
+        return PutObjectAclOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the PutObjectAcl
+ operation.
+ */
+public struct PutObjectAclOperationInputQuery: Codable, Equatable {
+    public var versionId: ObjectVersionId?
+
+    public init(versionId: ObjectVersionId? = nil) {
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case versionId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutObjectAclRequest {
+    public func asS3ModelPutObjectAclOperationInputQuery() -> PutObjectAclOperationInputQuery {
+        return PutObjectAclOperationInputQuery(
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutObjectAcl
+ operation.
+ */
+public struct PutObjectAclOperationInputAdditionalHeaders: Codable, Equatable {
+    public var aCL: ObjectCannedACL?
+    public var contentMD5: ContentMD5?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWrite: GrantWrite?
+    public var grantWriteACP: GrantWriteACP?
+    public var requestPayer: RequestPayer?
+
+    public init(aCL: ObjectCannedACL? = nil,
+                contentMD5: ContentMD5? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWrite: GrantWrite? = nil,
+                grantWriteACP: GrantWriteACP? = nil,
+                requestPayer: RequestPayer? = nil) {
+        self.aCL = aCL
+        self.contentMD5 = contentMD5
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWrite = grantWrite
+        self.grantWriteACP = grantWriteACP
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case contentMD5 = "Content-MD5"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWrite = "x-amz-grant-write"
+        case grantWriteACP = "x-amz-grant-write-acp"
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutObjectAclRequest {
+    public func asS3ModelPutObjectAclOperationInputAdditionalHeaders() -> PutObjectAclOperationInputAdditionalHeaders {
+        return PutObjectAclOperationInputAdditionalHeaders(
+            aCL: aCL,
+            contentMD5: contentMD5,
+            grantFullControl: grantFullControl,
+            grantRead: grantRead,
+            grantReadACP: grantReadACP,
+            grantWrite: grantWrite,
+            grantWriteACP: grantWriteACP,
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutObjectTagging
+ operation.
+ */
+public struct PutObjectTaggingOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension PutObjectTaggingRequest {
+    public func asS3ModelPutObjectTaggingOperationInputPath() -> PutObjectTaggingOperationInputPath {
+        return PutObjectTaggingOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the PutObjectTagging
+ operation.
+ */
+public struct PutObjectTaggingOperationInputQuery: Codable, Equatable {
+    public var versionId: ObjectVersionId?
+
+    public init(versionId: ObjectVersionId? = nil) {
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case versionId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutObjectTaggingRequest {
+    public func asS3ModelPutObjectTaggingOperationInputQuery() -> PutObjectTaggingOperationInputQuery {
+        return PutObjectTaggingOperationInputQuery(
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutObjectTagging
+ operation.
+ */
+public struct PutObjectTaggingOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutObjectTaggingRequest {
+    public func asS3ModelPutObjectTaggingOperationInputAdditionalHeaders() -> PutObjectTaggingOperationInputAdditionalHeaders {
+        return PutObjectTaggingOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the PutPublicAccessBlock
+ operation.
+ */
+public struct PutPublicAccessBlockOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutPublicAccessBlockRequest {
+    public func asS3ModelPutPublicAccessBlockOperationInputPath() -> PutPublicAccessBlockOperationInputPath {
+        return PutPublicAccessBlockOperationInputPath(
+            bucket: bucket)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the PutPublicAccessBlock
+ operation.
+ */
+public struct PutPublicAccessBlockOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentMD5: ContentMD5?
+
+    public init(contentMD5: ContentMD5? = nil) {
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension PutPublicAccessBlockRequest {
+    public func asS3ModelPutPublicAccessBlockOperationInputAdditionalHeaders() -> PutPublicAccessBlockOperationInputAdditionalHeaders {
+        return PutPublicAccessBlockOperationInputAdditionalHeaders(
+            contentMD5: contentMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the RestoreObject
+ operation.
+ */
+public struct RestoreObjectOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension RestoreObjectRequest {
+    public func asS3ModelRestoreObjectOperationInputPath() -> RestoreObjectOperationInputPath {
+        return RestoreObjectOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the RestoreObject
+ operation.
+ */
+public struct RestoreObjectOperationInputQuery: Codable, Equatable {
+    public var versionId: ObjectVersionId?
+
+    public init(versionId: ObjectVersionId? = nil) {
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case versionId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension RestoreObjectRequest {
+    public func asS3ModelRestoreObjectOperationInputQuery() -> RestoreObjectOperationInputQuery {
+        return RestoreObjectOperationInputQuery(
+            versionId: versionId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the RestoreObject
+ operation.
+ */
+public struct RestoreObjectOperationInputAdditionalHeaders: Codable, Equatable {
+    public var requestPayer: RequestPayer?
+
+    public init(requestPayer: RequestPayer? = nil) {
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension RestoreObjectRequest {
+    public func asS3ModelRestoreObjectOperationInputAdditionalHeaders() -> RestoreObjectOperationInputAdditionalHeaders {
+        return RestoreObjectOperationInputAdditionalHeaders(
+            requestPayer: requestPayer)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the SelectObjectContent
+ operation.
+ */
+public struct SelectObjectContentOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension SelectObjectContentRequest {
+    public func asS3ModelSelectObjectContentOperationInputPath() -> SelectObjectContentOperationInputPath {
+        return SelectObjectContentOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the SelectObjectContent
+ operation.
+ */
+public struct SelectObjectContentOperationInputBody: Codable, Equatable {
+    public var expression: Expression
+    public var expressionType: ExpressionType
+    public var inputSerialization: InputSerialization
+    public var outputSerialization: OutputSerialization
+    public var requestProgress: RequestProgress?
+
+    public init(expression: Expression,
+                expressionType: ExpressionType,
+                inputSerialization: InputSerialization,
+                outputSerialization: OutputSerialization,
+                requestProgress: RequestProgress? = nil) {
+        self.expression = expression
+        self.expressionType = expressionType
+        self.inputSerialization = inputSerialization
+        self.outputSerialization = outputSerialization
+        self.requestProgress = requestProgress
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case expression = "Expression"
+        case expressionType = "ExpressionType"
+        case inputSerialization = "InputSerialization"
+        case outputSerialization = "OutputSerialization"
+        case requestProgress = "RequestProgress"
+    }
+
+    public func validate() throws {
+        try inputSerialization.validate()
+        try outputSerialization.validate()
+        try requestProgress?.validate()
+    }
+}
+
+public extension SelectObjectContentRequest {
+    public func asS3ModelSelectObjectContentOperationInputBody() -> SelectObjectContentOperationInputBody {
+        return SelectObjectContentOperationInputBody(
+            expression: expression,
+            expressionType: expressionType,
+            inputSerialization: inputSerialization,
+            outputSerialization: outputSerialization,
+            requestProgress: requestProgress)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the SelectObjectContent
+ operation.
+ */
+public struct SelectObjectContentOperationInputAdditionalHeaders: Codable, Equatable {
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+
+    public init(sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil) {
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension SelectObjectContentRequest {
+    public func asS3ModelSelectObjectContentOperationInputAdditionalHeaders() -> SelectObjectContentOperationInputAdditionalHeaders {
+        return SelectObjectContentOperationInputAdditionalHeaders(
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKey: sSECustomerKey,
+            sSECustomerKeyMD5: sSECustomerKeyMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the UploadPart
+ operation.
+ */
+public struct UploadPartOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension UploadPartRequest {
+    public func asS3ModelUploadPartOperationInputPath() -> UploadPartOperationInputPath {
+        return UploadPartOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the UploadPart
+ operation.
+ */
+public struct UploadPartOperationInputQuery: Codable, Equatable {
+    public var partNumber: PartNumber
+    public var uploadId: MultipartUploadId
+
+    public init(partNumber: PartNumber,
+                uploadId: MultipartUploadId) {
+        self.partNumber = partNumber
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case partNumber
+        case uploadId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension UploadPartRequest {
+    public func asS3ModelUploadPartOperationInputQuery() -> UploadPartOperationInputQuery {
+        return UploadPartOperationInputQuery(
+            partNumber: partNumber,
+            uploadId: uploadId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the UploadPart
+ operation.
+ */
+public struct UploadPartOperationInputAdditionalHeaders: Codable, Equatable {
+    public var contentLength: ContentLength?
+    public var contentMD5: ContentMD5?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+
+    public init(contentLength: ContentLength? = nil,
+                contentMD5: ContentMD5? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil) {
+        self.contentLength = contentLength
+        self.contentMD5 = contentMD5
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case contentLength = "Content-Length"
+        case contentMD5 = "Content-MD5"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension UploadPartRequest {
+    public func asS3ModelUploadPartOperationInputAdditionalHeaders() -> UploadPartOperationInputAdditionalHeaders {
+        return UploadPartOperationInputAdditionalHeaders(
+            contentLength: contentLength,
+            contentMD5: contentMD5,
+            requestPayer: requestPayer,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKey: sSECustomerKey,
+            sSECustomerKeyMD5: sSECustomerKeyMD5)
+    }
+}
+
+
+/**
+ Structure to encode the path input for the UploadPartCopy
+ operation.
+ */
+public struct UploadPartCopyOperationInputPath: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+
+    public init(bucket: BucketName,
+                key: ObjectKey) {
+        self.bucket = bucket
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public extension UploadPartCopyRequest {
+    public func asS3ModelUploadPartCopyOperationInputPath() -> UploadPartCopyOperationInputPath {
+        return UploadPartCopyOperationInputPath(
+            bucket: bucket,
+            key: key)
+    }
+}
+
+
+/**
+ Structure to encode the query input for the UploadPartCopy
+ operation.
+ */
+public struct UploadPartCopyOperationInputQuery: Codable, Equatable {
+    public var partNumber: PartNumber
+    public var uploadId: MultipartUploadId
+
+    public init(partNumber: PartNumber,
+                uploadId: MultipartUploadId) {
+        self.partNumber = partNumber
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case partNumber
+        case uploadId
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension UploadPartCopyRequest {
+    public func asS3ModelUploadPartCopyOperationInputQuery() -> UploadPartCopyOperationInputQuery {
+        return UploadPartCopyOperationInputQuery(
+            partNumber: partNumber,
+            uploadId: uploadId)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the UploadPartCopy
+ operation.
+ */
+public struct UploadPartCopyOperationInputAdditionalHeaders: Codable, Equatable {
+    public var copySource: CopySource
+    public var copySourceIfMatch: CopySourceIfMatch?
+    public var copySourceIfModifiedSince: CopySourceIfModifiedSince?
+    public var copySourceIfNoneMatch: CopySourceIfNoneMatch?
+    public var copySourceIfUnmodifiedSince: CopySourceIfUnmodifiedSince?
+    public var copySourceRange: CopySourceRange?
+    public var copySourceSSECustomerAlgorithm: CopySourceSSECustomerAlgorithm?
+    public var copySourceSSECustomerKey: CopySourceSSECustomerKey?
+    public var copySourceSSECustomerKeyMD5: CopySourceSSECustomerKeyMD5?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+
+    public init(copySource: CopySource,
+                copySourceIfMatch: CopySourceIfMatch? = nil,
+                copySourceIfModifiedSince: CopySourceIfModifiedSince? = nil,
+                copySourceIfNoneMatch: CopySourceIfNoneMatch? = nil,
+                copySourceIfUnmodifiedSince: CopySourceIfUnmodifiedSince? = nil,
+                copySourceRange: CopySourceRange? = nil,
+                copySourceSSECustomerAlgorithm: CopySourceSSECustomerAlgorithm? = nil,
+                copySourceSSECustomerKey: CopySourceSSECustomerKey? = nil,
+                copySourceSSECustomerKeyMD5: CopySourceSSECustomerKeyMD5? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil) {
+        self.copySource = copySource
+        self.copySourceIfMatch = copySourceIfMatch
+        self.copySourceIfModifiedSince = copySourceIfModifiedSince
+        self.copySourceIfNoneMatch = copySourceIfNoneMatch
+        self.copySourceIfUnmodifiedSince = copySourceIfUnmodifiedSince
+        self.copySourceRange = copySourceRange
+        self.copySourceSSECustomerAlgorithm = copySourceSSECustomerAlgorithm
+        self.copySourceSSECustomerKey = copySourceSSECustomerKey
+        self.copySourceSSECustomerKeyMD5 = copySourceSSECustomerKeyMD5
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case copySource = "x-amz-copy-source"
+        case copySourceIfMatch = "x-amz-copy-source-if-match"
+        case copySourceIfModifiedSince = "x-amz-copy-source-if-modified-since"
+        case copySourceIfNoneMatch = "x-amz-copy-source-if-none-match"
+        case copySourceIfUnmodifiedSince = "x-amz-copy-source-if-unmodified-since"
+        case copySourceRange = "x-amz-copy-source-range"
+        case copySourceSSECustomerAlgorithm = "x-amz-copy-source-server-side-encryption-customer-algorithm"
+        case copySourceSSECustomerKey = "x-amz-copy-source-server-side-encryption-customer-key"
+        case copySourceSSECustomerKeyMD5 = "x-amz-copy-source-server-side-encryption-customer-key-MD5"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+    }
+
+    public func validate() throws {
+        try copySource.validateAsCopySource()
+    }
+}
+
+public extension UploadPartCopyRequest {
+    public func asS3ModelUploadPartCopyOperationInputAdditionalHeaders() -> UploadPartCopyOperationInputAdditionalHeaders {
+        return UploadPartCopyOperationInputAdditionalHeaders(
+            copySource: copySource,
+            copySourceIfMatch: copySourceIfMatch,
+            copySourceIfModifiedSince: copySourceIfModifiedSince,
+            copySourceIfNoneMatch: copySourceIfNoneMatch,
+            copySourceIfUnmodifiedSince: copySourceIfUnmodifiedSince,
+            copySourceRange: copySourceRange,
+            copySourceSSECustomerAlgorithm: copySourceSSECustomerAlgorithm,
+            copySourceSSECustomerKey: copySourceSSECustomerKey,
+            copySourceSSECustomerKeyMD5: copySourceSSECustomerKeyMD5,
+            requestPayer: requestPayer,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKey: sSECustomerKey,
+            sSECustomerKeyMD5: sSECustomerKeyMD5)
+    }
+}
+
+
+/**
+ Structure to encode the body input for the UploadPartCopy
+ operation.
+ */
+public struct UploadPartCopyOperationOutputHeaders: Codable, Equatable {
+    public var copySourceVersionId: CopySourceVersionId?
+    public var requestCharged: RequestCharged?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+
+    public init(copySourceVersionId: CopySourceVersionId? = nil,
+                requestCharged: RequestCharged? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil) {
+        self.copySourceVersionId = copySourceVersionId
+        self.requestCharged = requestCharged
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case copySourceVersionId = "x-amz-copy-source-version-id"
+        case requestCharged = "x-amz-request-charged"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public extension UploadPartCopyOutput {
+    public func asS3ModelUploadPartCopyOperationOutputHeaders() -> UploadPartCopyOperationOutputHeaders {
+        return UploadPartCopyOperationOutputHeaders(
+            copySourceVersionId: copySourceVersionId,
+            requestCharged: requestCharged,
+            sSECustomerAlgorithm: sSECustomerAlgorithm,
+            sSECustomerKeyMD5: sSECustomerKeyMD5,
+            sSEKMSKeyId: sSEKMSKeyId,
+            serverSideEncryption: serverSideEncryption)
+    }
+}
+

--- a/Sources/S3Model/S3ModelStructures.swift
+++ b/Sources/S3Model/S3ModelStructures.swift
@@ -1,0 +1,6435 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// S3ModelStructures.swift
+// S3Model
+//
+
+import Foundation
+
+public struct AbortIncompleteMultipartUpload: Codable, Equatable {
+    public var daysAfterInitiation: DaysAfterInitiation?
+
+    public init(daysAfterInitiation: DaysAfterInitiation? = nil) {
+        self.daysAfterInitiation = daysAfterInitiation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case daysAfterInitiation = "DaysAfterInitiation"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct AbortMultipartUploadOutput: Codable, Equatable {
+    public var requestCharged: RequestCharged?
+
+    public init(requestCharged: RequestCharged? = nil) {
+        self.requestCharged = requestCharged
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestCharged = "x-amz-request-charged"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct AbortMultipartUploadRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+    public var requestPayer: RequestPayer?
+    public var uploadId: MultipartUploadId
+
+    public init(bucket: BucketName,
+                key: ObjectKey,
+                requestPayer: RequestPayer? = nil,
+                uploadId: MultipartUploadId) {
+        self.bucket = bucket
+        self.key = key
+        self.requestPayer = requestPayer
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+        case requestPayer = "x-amz-request-payer"
+        case uploadId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct AccelerateConfiguration: Codable, Equatable {
+    public var status: BucketAccelerateStatus?
+
+    public init(status: BucketAccelerateStatus? = nil) {
+        self.status = status
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case status = "Status"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct AccessControlPolicy: Codable, Equatable {
+    public var grants: Grants?
+    public var owner: Owner?
+
+    public init(grants: Grants? = nil,
+                owner: Owner? = nil) {
+        self.grants = grants
+        self.owner = owner
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case grants = "AccessControlList"
+        case owner = "Owner"
+    }
+
+    public func validate() throws {
+        try owner?.validate()
+    }
+}
+
+public struct AccessControlTranslation: Codable, Equatable {
+    public var owner: OwnerOverride
+
+    public init(owner: OwnerOverride) {
+        self.owner = owner
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case owner = "Owner"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct AnalyticsAndOperator: Codable, Equatable {
+    public var prefix: Prefix?
+    public var tags: TagSet?
+
+    public init(prefix: Prefix? = nil,
+                tags: TagSet? = nil) {
+        self.prefix = prefix
+        self.tags = tags
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case prefix = "Prefix"
+        case tags = "Tag"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct AnalyticsConfiguration: Codable, Equatable {
+    public var filter: AnalyticsFilter?
+    public var id: AnalyticsId
+    public var storageClassAnalysis: StorageClassAnalysis
+
+    public init(filter: AnalyticsFilter? = nil,
+                id: AnalyticsId,
+                storageClassAnalysis: StorageClassAnalysis) {
+        self.filter = filter
+        self.id = id
+        self.storageClassAnalysis = storageClassAnalysis
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case filter = "Filter"
+        case id = "Id"
+        case storageClassAnalysis = "StorageClassAnalysis"
+    }
+
+    public func validate() throws {
+        try filter?.validate()
+        try storageClassAnalysis.validate()
+    }
+}
+
+public struct AnalyticsExportDestination: Codable, Equatable {
+    public var s3BucketDestination: AnalyticsS3BucketDestination
+
+    public init(s3BucketDestination: AnalyticsS3BucketDestination) {
+        self.s3BucketDestination = s3BucketDestination
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case s3BucketDestination = "S3BucketDestination"
+    }
+
+    public func validate() throws {
+        try s3BucketDestination.validate()
+    }
+}
+
+public struct AnalyticsFilter: Codable, Equatable {
+    public var and: AnalyticsAndOperator?
+    public var prefix: Prefix?
+    public var tag: Tag?
+
+    public init(and: AnalyticsAndOperator? = nil,
+                prefix: Prefix? = nil,
+                tag: Tag? = nil) {
+        self.and = and
+        self.prefix = prefix
+        self.tag = tag
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case and = "And"
+        case prefix = "Prefix"
+        case tag = "Tag"
+    }
+
+    public func validate() throws {
+        try and?.validate()
+        try tag?.validate()
+    }
+}
+
+public struct AnalyticsS3BucketDestination: Codable, Equatable {
+    public var bucket: BucketName
+    public var bucketAccountId: AccountId?
+    public var format: AnalyticsS3ExportFileFormat
+    public var prefix: Prefix?
+
+    public init(bucket: BucketName,
+                bucketAccountId: AccountId? = nil,
+                format: AnalyticsS3ExportFileFormat,
+                prefix: Prefix? = nil) {
+        self.bucket = bucket
+        self.bucketAccountId = bucketAccountId
+        self.format = format
+        self.prefix = prefix
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case bucketAccountId = "BucketAccountId"
+        case format = "Format"
+        case prefix = "Prefix"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct Bucket: Codable, Equatable {
+    public var creationDate: CreationDate?
+    public var name: BucketName?
+
+    public init(creationDate: CreationDate? = nil,
+                name: BucketName? = nil) {
+        self.creationDate = creationDate
+        self.name = name
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case creationDate = "CreationDate"
+        case name = "Name"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct BucketAlreadyExists: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct BucketAlreadyOwnedByYou: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct BucketLifecycleConfiguration: Codable, Equatable {
+    public var rules: LifecycleRules
+
+    public init(rules: LifecycleRules) {
+        self.rules = rules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case rules = "Rule"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct BucketLoggingStatus: Codable, Equatable {
+    public var loggingEnabled: LoggingEnabled?
+
+    public init(loggingEnabled: LoggingEnabled? = nil) {
+        self.loggingEnabled = loggingEnabled
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case loggingEnabled = "LoggingEnabled"
+    }
+
+    public func validate() throws {
+        try loggingEnabled?.validate()
+    }
+}
+
+public struct CORSConfiguration: Codable, Equatable {
+    public var cORSRules: CORSRules
+
+    public init(cORSRules: CORSRules) {
+        self.cORSRules = cORSRules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case cORSRules = "CORSRule"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CORSRule: Codable, Equatable {
+    public var allowedHeaders: AllowedHeaders?
+    public var allowedMethods: AllowedMethods
+    public var allowedOrigins: AllowedOrigins
+    public var exposeHeaders: ExposeHeaders?
+    public var maxAgeSeconds: MaxAgeSeconds?
+
+    public init(allowedHeaders: AllowedHeaders? = nil,
+                allowedMethods: AllowedMethods,
+                allowedOrigins: AllowedOrigins,
+                exposeHeaders: ExposeHeaders? = nil,
+                maxAgeSeconds: MaxAgeSeconds? = nil) {
+        self.allowedHeaders = allowedHeaders
+        self.allowedMethods = allowedMethods
+        self.allowedOrigins = allowedOrigins
+        self.exposeHeaders = exposeHeaders
+        self.maxAgeSeconds = maxAgeSeconds
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case allowedHeaders = "AllowedHeader"
+        case allowedMethods = "AllowedMethod"
+        case allowedOrigins = "AllowedOrigin"
+        case exposeHeaders = "ExposeHeader"
+        case maxAgeSeconds = "MaxAgeSeconds"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CSVInput: Codable, Equatable {
+    public var allowQuotedRecordDelimiter: AllowQuotedRecordDelimiter?
+    public var comments: Comments?
+    public var fieldDelimiter: FieldDelimiter?
+    public var fileHeaderInfo: FileHeaderInfo?
+    public var quoteCharacter: QuoteCharacter?
+    public var quoteEscapeCharacter: QuoteEscapeCharacter?
+    public var recordDelimiter: RecordDelimiter?
+
+    public init(allowQuotedRecordDelimiter: AllowQuotedRecordDelimiter? = nil,
+                comments: Comments? = nil,
+                fieldDelimiter: FieldDelimiter? = nil,
+                fileHeaderInfo: FileHeaderInfo? = nil,
+                quoteCharacter: QuoteCharacter? = nil,
+                quoteEscapeCharacter: QuoteEscapeCharacter? = nil,
+                recordDelimiter: RecordDelimiter? = nil) {
+        self.allowQuotedRecordDelimiter = allowQuotedRecordDelimiter
+        self.comments = comments
+        self.fieldDelimiter = fieldDelimiter
+        self.fileHeaderInfo = fileHeaderInfo
+        self.quoteCharacter = quoteCharacter
+        self.quoteEscapeCharacter = quoteEscapeCharacter
+        self.recordDelimiter = recordDelimiter
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case allowQuotedRecordDelimiter = "AllowQuotedRecordDelimiter"
+        case comments = "Comments"
+        case fieldDelimiter = "FieldDelimiter"
+        case fileHeaderInfo = "FileHeaderInfo"
+        case quoteCharacter = "QuoteCharacter"
+        case quoteEscapeCharacter = "QuoteEscapeCharacter"
+        case recordDelimiter = "RecordDelimiter"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CSVOutput: Codable, Equatable {
+    public var fieldDelimiter: FieldDelimiter?
+    public var quoteCharacter: QuoteCharacter?
+    public var quoteEscapeCharacter: QuoteEscapeCharacter?
+    public var quoteFields: QuoteFields?
+    public var recordDelimiter: RecordDelimiter?
+
+    public init(fieldDelimiter: FieldDelimiter? = nil,
+                quoteCharacter: QuoteCharacter? = nil,
+                quoteEscapeCharacter: QuoteEscapeCharacter? = nil,
+                quoteFields: QuoteFields? = nil,
+                recordDelimiter: RecordDelimiter? = nil) {
+        self.fieldDelimiter = fieldDelimiter
+        self.quoteCharacter = quoteCharacter
+        self.quoteEscapeCharacter = quoteEscapeCharacter
+        self.quoteFields = quoteFields
+        self.recordDelimiter = recordDelimiter
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case fieldDelimiter = "FieldDelimiter"
+        case quoteCharacter = "QuoteCharacter"
+        case quoteEscapeCharacter = "QuoteEscapeCharacter"
+        case quoteFields = "QuoteFields"
+        case recordDelimiter = "RecordDelimiter"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CloudFunctionConfiguration: Codable, Equatable {
+    public var cloudFunction: CloudFunction?
+    public var events: EventList?
+    public var id: NotificationId?
+    public var invocationRole: CloudFunctionInvocationRole?
+
+    public init(cloudFunction: CloudFunction? = nil,
+                events: EventList? = nil,
+                id: NotificationId? = nil,
+                invocationRole: CloudFunctionInvocationRole? = nil) {
+        self.cloudFunction = cloudFunction
+        self.events = events
+        self.id = id
+        self.invocationRole = invocationRole
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case cloudFunction = "CloudFunction"
+        case events = "Event"
+        case id = "Id"
+        case invocationRole = "InvocationRole"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CommonPrefix: Codable, Equatable {
+    public var prefix: Prefix?
+
+    public init(prefix: Prefix? = nil) {
+        self.prefix = prefix
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case prefix = "Prefix"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CompleteMultipartUploadOutput: Codable, Equatable {
+    public var bucket: BucketName?
+    public var eTag: ETag?
+    public var expiration: Expiration?
+    public var key: ObjectKey?
+    public var location: Location?
+    public var requestCharged: RequestCharged?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var versionId: ObjectVersionId?
+
+    public init(bucket: BucketName? = nil,
+                eTag: ETag? = nil,
+                expiration: Expiration? = nil,
+                key: ObjectKey? = nil,
+                location: Location? = nil,
+                requestCharged: RequestCharged? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.bucket = bucket
+        self.eTag = eTag
+        self.expiration = expiration
+        self.key = key
+        self.location = location
+        self.requestCharged = requestCharged
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case eTag = "ETag"
+        case expiration = "x-amz-expiration"
+        case key = "Key"
+        case location = "Location"
+        case requestCharged = "x-amz-request-charged"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case versionId = "x-amz-version-id"
+    }
+
+    public func validate() throws {
+        try key?.validateAsObjectKey()
+    }
+}
+
+public struct CompleteMultipartUploadRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+    public var multipartUpload: CompletedMultipartUpload?
+    public var requestPayer: RequestPayer?
+    public var uploadId: MultipartUploadId
+
+    public init(bucket: BucketName,
+                key: ObjectKey,
+                multipartUpload: CompletedMultipartUpload? = nil,
+                requestPayer: RequestPayer? = nil,
+                uploadId: MultipartUploadId) {
+        self.bucket = bucket
+        self.key = key
+        self.multipartUpload = multipartUpload
+        self.requestPayer = requestPayer
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+        case multipartUpload = "CompleteMultipartUpload"
+        case requestPayer = "x-amz-request-payer"
+        case uploadId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+        try multipartUpload?.validate()
+    }
+}
+
+public struct CompletedMultipartUpload: Codable, Equatable {
+    public var parts: CompletedPartList?
+
+    public init(parts: CompletedPartList? = nil) {
+        self.parts = parts
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case parts = "Part"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CompletedPart: Codable, Equatable {
+    public var eTag: ETag?
+    public var partNumber: PartNumber?
+
+    public init(eTag: ETag? = nil,
+                partNumber: PartNumber? = nil) {
+        self.eTag = eTag
+        self.partNumber = partNumber
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case eTag = "ETag"
+        case partNumber = "PartNumber"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct Condition: Codable, Equatable {
+    public var httpErrorCodeReturnedEquals: HttpErrorCodeReturnedEquals?
+    public var keyPrefixEquals: KeyPrefixEquals?
+
+    public init(httpErrorCodeReturnedEquals: HttpErrorCodeReturnedEquals? = nil,
+                keyPrefixEquals: KeyPrefixEquals? = nil) {
+        self.httpErrorCodeReturnedEquals = httpErrorCodeReturnedEquals
+        self.keyPrefixEquals = keyPrefixEquals
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case httpErrorCodeReturnedEquals = "HttpErrorCodeReturnedEquals"
+        case keyPrefixEquals = "KeyPrefixEquals"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ContinuationEvent: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CopyObjectOutput: Codable, Equatable {
+    public var copyObjectResult: CopyObjectResult?
+    public var copySourceVersionId: CopySourceVersionId?
+    public var expiration: Expiration?
+    public var requestCharged: RequestCharged?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var versionId: ObjectVersionId?
+
+    public init(copyObjectResult: CopyObjectResult? = nil,
+                copySourceVersionId: CopySourceVersionId? = nil,
+                expiration: Expiration? = nil,
+                requestCharged: RequestCharged? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.copyObjectResult = copyObjectResult
+        self.copySourceVersionId = copySourceVersionId
+        self.expiration = expiration
+        self.requestCharged = requestCharged
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case copyObjectResult = "CopyObjectResult"
+        case copySourceVersionId = "x-amz-copy-source-version-id"
+        case expiration = "x-amz-expiration"
+        case requestCharged = "x-amz-request-charged"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case versionId = "x-amz-version-id"
+    }
+
+    public func validate() throws {
+        try copyObjectResult?.validate()
+    }
+}
+
+public struct CopyObjectRequest: Codable, Equatable {
+    public var aCL: ObjectCannedACL?
+    public var bucket: BucketName
+    public var cacheControl: CacheControl?
+    public var contentDisposition: ContentDisposition?
+    public var contentEncoding: ContentEncoding?
+    public var contentLanguage: ContentLanguage?
+    public var contentType: ContentType?
+    public var copySource: CopySource
+    public var copySourceIfMatch: CopySourceIfMatch?
+    public var copySourceIfModifiedSince: CopySourceIfModifiedSince?
+    public var copySourceIfNoneMatch: CopySourceIfNoneMatch?
+    public var copySourceIfUnmodifiedSince: CopySourceIfUnmodifiedSince?
+    public var copySourceSSECustomerAlgorithm: CopySourceSSECustomerAlgorithm?
+    public var copySourceSSECustomerKey: CopySourceSSECustomerKey?
+    public var copySourceSSECustomerKeyMD5: CopySourceSSECustomerKeyMD5?
+    public var expires: Expires?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWriteACP: GrantWriteACP?
+    public var key: ObjectKey
+    public var metadata: Metadata?
+    public var metadataDirective: MetadataDirective?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var storageClass: StorageClass?
+    public var tagging: TaggingHeader?
+    public var taggingDirective: TaggingDirective?
+    public var websiteRedirectLocation: WebsiteRedirectLocation?
+
+    public init(aCL: ObjectCannedACL? = nil,
+                bucket: BucketName,
+                cacheControl: CacheControl? = nil,
+                contentDisposition: ContentDisposition? = nil,
+                contentEncoding: ContentEncoding? = nil,
+                contentLanguage: ContentLanguage? = nil,
+                contentType: ContentType? = nil,
+                copySource: CopySource,
+                copySourceIfMatch: CopySourceIfMatch? = nil,
+                copySourceIfModifiedSince: CopySourceIfModifiedSince? = nil,
+                copySourceIfNoneMatch: CopySourceIfNoneMatch? = nil,
+                copySourceIfUnmodifiedSince: CopySourceIfUnmodifiedSince? = nil,
+                copySourceSSECustomerAlgorithm: CopySourceSSECustomerAlgorithm? = nil,
+                copySourceSSECustomerKey: CopySourceSSECustomerKey? = nil,
+                copySourceSSECustomerKeyMD5: CopySourceSSECustomerKeyMD5? = nil,
+                expires: Expires? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWriteACP: GrantWriteACP? = nil,
+                key: ObjectKey,
+                metadata: Metadata? = nil,
+                metadataDirective: MetadataDirective? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                storageClass: StorageClass? = nil,
+                tagging: TaggingHeader? = nil,
+                taggingDirective: TaggingDirective? = nil,
+                websiteRedirectLocation: WebsiteRedirectLocation? = nil) {
+        self.aCL = aCL
+        self.bucket = bucket
+        self.cacheControl = cacheControl
+        self.contentDisposition = contentDisposition
+        self.contentEncoding = contentEncoding
+        self.contentLanguage = contentLanguage
+        self.contentType = contentType
+        self.copySource = copySource
+        self.copySourceIfMatch = copySourceIfMatch
+        self.copySourceIfModifiedSince = copySourceIfModifiedSince
+        self.copySourceIfNoneMatch = copySourceIfNoneMatch
+        self.copySourceIfUnmodifiedSince = copySourceIfUnmodifiedSince
+        self.copySourceSSECustomerAlgorithm = copySourceSSECustomerAlgorithm
+        self.copySourceSSECustomerKey = copySourceSSECustomerKey
+        self.copySourceSSECustomerKeyMD5 = copySourceSSECustomerKeyMD5
+        self.expires = expires
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWriteACP = grantWriteACP
+        self.key = key
+        self.metadata = metadata
+        self.metadataDirective = metadataDirective
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.storageClass = storageClass
+        self.tagging = tagging
+        self.taggingDirective = taggingDirective
+        self.websiteRedirectLocation = websiteRedirectLocation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case bucket = "Bucket"
+        case cacheControl = "Cache-Control"
+        case contentDisposition = "Content-Disposition"
+        case contentEncoding = "Content-Encoding"
+        case contentLanguage = "Content-Language"
+        case contentType = "Content-Type"
+        case copySource = "x-amz-copy-source"
+        case copySourceIfMatch = "x-amz-copy-source-if-match"
+        case copySourceIfModifiedSince = "x-amz-copy-source-if-modified-since"
+        case copySourceIfNoneMatch = "x-amz-copy-source-if-none-match"
+        case copySourceIfUnmodifiedSince = "x-amz-copy-source-if-unmodified-since"
+        case copySourceSSECustomerAlgorithm = "x-amz-copy-source-server-side-encryption-customer-algorithm"
+        case copySourceSSECustomerKey = "x-amz-copy-source-server-side-encryption-customer-key"
+        case copySourceSSECustomerKeyMD5 = "x-amz-copy-source-server-side-encryption-customer-key-MD5"
+        case expires = "Expires"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWriteACP = "x-amz-grant-write-acp"
+        case key = "Key"
+        case metadata = "x-amz-meta-"
+        case metadataDirective = "x-amz-metadata-directive"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case storageClass = "x-amz-storage-class"
+        case tagging = "x-amz-tagging"
+        case taggingDirective = "x-amz-tagging-directive"
+        case websiteRedirectLocation = "x-amz-website-redirect-location"
+    }
+
+    public func validate() throws {
+        try copySource.validateAsCopySource()
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct CopyObjectResult: Codable, Equatable {
+    public var eTag: ETag?
+    public var lastModified: LastModified?
+
+    public init(eTag: ETag? = nil,
+                lastModified: LastModified? = nil) {
+        self.eTag = eTag
+        self.lastModified = lastModified
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case eTag = "ETag"
+        case lastModified = "LastModified"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CopyPartResult: Codable, Equatable {
+    public var eTag: ETag?
+    public var lastModified: LastModified?
+
+    public init(eTag: ETag? = nil,
+                lastModified: LastModified? = nil) {
+        self.eTag = eTag
+        self.lastModified = lastModified
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case eTag = "ETag"
+        case lastModified = "LastModified"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CreateBucketConfiguration: Codable, Equatable {
+    public var locationConstraint: BucketLocationConstraint?
+
+    public init(locationConstraint: BucketLocationConstraint? = nil) {
+        self.locationConstraint = locationConstraint
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case locationConstraint = "LocationConstraint"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CreateBucketOutput: Codable, Equatable {
+    public var location: Location?
+
+    public init(location: Location? = nil) {
+        self.location = location
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case location = "Location"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct CreateBucketRequest: Codable, Equatable {
+    public var aCL: BucketCannedACL?
+    public var bucket: BucketName
+    public var createBucketConfiguration: CreateBucketConfiguration?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWrite: GrantWrite?
+    public var grantWriteACP: GrantWriteACP?
+
+    public init(aCL: BucketCannedACL? = nil,
+                bucket: BucketName,
+                createBucketConfiguration: CreateBucketConfiguration? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWrite: GrantWrite? = nil,
+                grantWriteACP: GrantWriteACP? = nil) {
+        self.aCL = aCL
+        self.bucket = bucket
+        self.createBucketConfiguration = createBucketConfiguration
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWrite = grantWrite
+        self.grantWriteACP = grantWriteACP
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case bucket = "Bucket"
+        case createBucketConfiguration = "CreateBucketConfiguration"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWrite = "x-amz-grant-write"
+        case grantWriteACP = "x-amz-grant-write-acp"
+    }
+
+    public func validate() throws {
+        try createBucketConfiguration?.validate()
+    }
+}
+
+public struct CreateMultipartUploadOutput: Codable, Equatable {
+    public var abortDate: AbortDate?
+    public var abortRuleId: AbortRuleId?
+    public var bucket: BucketName?
+    public var key: ObjectKey?
+    public var requestCharged: RequestCharged?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var uploadId: MultipartUploadId?
+
+    public init(abortDate: AbortDate? = nil,
+                abortRuleId: AbortRuleId? = nil,
+                bucket: BucketName? = nil,
+                key: ObjectKey? = nil,
+                requestCharged: RequestCharged? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                uploadId: MultipartUploadId? = nil) {
+        self.abortDate = abortDate
+        self.abortRuleId = abortRuleId
+        self.bucket = bucket
+        self.key = key
+        self.requestCharged = requestCharged
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case abortDate = "x-amz-abort-date"
+        case abortRuleId = "x-amz-abort-rule-id"
+        case bucket = "Bucket"
+        case key = "Key"
+        case requestCharged = "x-amz-request-charged"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case uploadId = "UploadId"
+    }
+
+    public func validate() throws {
+        try key?.validateAsObjectKey()
+    }
+}
+
+public struct CreateMultipartUploadRequest: Codable, Equatable {
+    public var aCL: ObjectCannedACL?
+    public var bucket: BucketName
+    public var cacheControl: CacheControl?
+    public var contentDisposition: ContentDisposition?
+    public var contentEncoding: ContentEncoding?
+    public var contentLanguage: ContentLanguage?
+    public var contentType: ContentType?
+    public var expires: Expires?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWriteACP: GrantWriteACP?
+    public var key: ObjectKey
+    public var metadata: Metadata?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var storageClass: StorageClass?
+    public var tagging: TaggingHeader?
+    public var websiteRedirectLocation: WebsiteRedirectLocation?
+
+    public init(aCL: ObjectCannedACL? = nil,
+                bucket: BucketName,
+                cacheControl: CacheControl? = nil,
+                contentDisposition: ContentDisposition? = nil,
+                contentEncoding: ContentEncoding? = nil,
+                contentLanguage: ContentLanguage? = nil,
+                contentType: ContentType? = nil,
+                expires: Expires? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWriteACP: GrantWriteACP? = nil,
+                key: ObjectKey,
+                metadata: Metadata? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                storageClass: StorageClass? = nil,
+                tagging: TaggingHeader? = nil,
+                websiteRedirectLocation: WebsiteRedirectLocation? = nil) {
+        self.aCL = aCL
+        self.bucket = bucket
+        self.cacheControl = cacheControl
+        self.contentDisposition = contentDisposition
+        self.contentEncoding = contentEncoding
+        self.contentLanguage = contentLanguage
+        self.contentType = contentType
+        self.expires = expires
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWriteACP = grantWriteACP
+        self.key = key
+        self.metadata = metadata
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.storageClass = storageClass
+        self.tagging = tagging
+        self.websiteRedirectLocation = websiteRedirectLocation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case bucket = "Bucket"
+        case cacheControl = "Cache-Control"
+        case contentDisposition = "Content-Disposition"
+        case contentEncoding = "Content-Encoding"
+        case contentLanguage = "Content-Language"
+        case contentType = "Content-Type"
+        case expires = "Expires"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWriteACP = "x-amz-grant-write-acp"
+        case key = "Key"
+        case metadata = "x-amz-meta-"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case storageClass = "x-amz-storage-class"
+        case tagging = "x-amz-tagging"
+        case websiteRedirectLocation = "x-amz-website-redirect-location"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct Delete: Codable, Equatable {
+    public var objects: ObjectIdentifierList
+    public var quiet: Quiet?
+
+    public init(objects: ObjectIdentifierList,
+                quiet: Quiet? = nil) {
+        self.objects = objects
+        self.quiet = quiet
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case objects = "Object"
+        case quiet = "Quiet"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketAnalyticsConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var id: AnalyticsId
+
+    public init(bucket: BucketName,
+                id: AnalyticsId) {
+        self.bucket = bucket
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketCorsRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketEncryptionRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketInventoryConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var id: InventoryId
+
+    public init(bucket: BucketName,
+                id: InventoryId) {
+        self.bucket = bucket
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketLifecycleRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketMetricsConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var id: MetricsId
+
+    public init(bucket: BucketName,
+                id: MetricsId) {
+        self.bucket = bucket
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketPolicyRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketReplicationRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketTaggingRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteBucketWebsiteRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteMarkerEntry: Codable, Equatable {
+    public var isLatest: IsLatest?
+    public var key: ObjectKey?
+    public var lastModified: LastModified?
+    public var owner: Owner?
+    public var versionId: ObjectVersionId?
+
+    public init(isLatest: IsLatest? = nil,
+                key: ObjectKey? = nil,
+                lastModified: LastModified? = nil,
+                owner: Owner? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.isLatest = isLatest
+        self.key = key
+        self.lastModified = lastModified
+        self.owner = owner
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case isLatest = "IsLatest"
+        case key = "Key"
+        case lastModified = "LastModified"
+        case owner = "Owner"
+        case versionId = "VersionId"
+    }
+
+    public func validate() throws {
+        try key?.validateAsObjectKey()
+        try owner?.validate()
+    }
+}
+
+public struct DeleteMarkerReplication: Codable, Equatable {
+    public var status: DeleteMarkerReplicationStatus?
+
+    public init(status: DeleteMarkerReplicationStatus? = nil) {
+        self.status = status
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case status = "Status"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteObjectOutput: Codable, Equatable {
+    public var deleteMarker: DeleteMarker?
+    public var requestCharged: RequestCharged?
+    public var versionId: ObjectVersionId?
+
+    public init(deleteMarker: DeleteMarker? = nil,
+                requestCharged: RequestCharged? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.deleteMarker = deleteMarker
+        self.requestCharged = requestCharged
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case deleteMarker = "x-amz-delete-marker"
+        case requestCharged = "x-amz-request-charged"
+        case versionId = "x-amz-version-id"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteObjectRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+    public var mFA: MFA?
+    public var requestPayer: RequestPayer?
+    public var versionId: ObjectVersionId?
+
+    public init(bucket: BucketName,
+                key: ObjectKey,
+                mFA: MFA? = nil,
+                requestPayer: RequestPayer? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.bucket = bucket
+        self.key = key
+        self.mFA = mFA
+        self.requestPayer = requestPayer
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+        case mFA = "x-amz-mfa"
+        case requestPayer = "x-amz-request-payer"
+        case versionId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct DeleteObjectTaggingOutput: Codable, Equatable {
+    public var versionId: ObjectVersionId?
+
+    public init(versionId: ObjectVersionId? = nil) {
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case versionId = "x-amz-version-id"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteObjectTaggingRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+    public var versionId: ObjectVersionId?
+
+    public init(bucket: BucketName,
+                key: ObjectKey,
+                versionId: ObjectVersionId? = nil) {
+        self.bucket = bucket
+        self.key = key
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+        case versionId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct DeleteObjectsOutput: Codable, Equatable {
+    public var deleted: DeletedObjects?
+    public var errors: Errors?
+    public var requestCharged: RequestCharged?
+
+    public init(deleted: DeletedObjects? = nil,
+                errors: Errors? = nil,
+                requestCharged: RequestCharged? = nil) {
+        self.deleted = deleted
+        self.errors = errors
+        self.requestCharged = requestCharged
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case deleted = "Deleted"
+        case errors = "Error"
+        case requestCharged = "x-amz-request-charged"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeleteObjectsRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var delete: Delete
+    public var mFA: MFA?
+    public var requestPayer: RequestPayer?
+
+    public init(bucket: BucketName,
+                delete: Delete,
+                mFA: MFA? = nil,
+                requestPayer: RequestPayer? = nil) {
+        self.bucket = bucket
+        self.delete = delete
+        self.mFA = mFA
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case delete = "Delete"
+        case mFA = "x-amz-mfa"
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+        try delete.validate()
+    }
+}
+
+public struct DeletePublicAccessBlockRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct DeletedObject: Codable, Equatable {
+    public var deleteMarker: DeleteMarker?
+    public var deleteMarkerVersionId: DeleteMarkerVersionId?
+    public var key: ObjectKey?
+    public var versionId: ObjectVersionId?
+
+    public init(deleteMarker: DeleteMarker? = nil,
+                deleteMarkerVersionId: DeleteMarkerVersionId? = nil,
+                key: ObjectKey? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.deleteMarker = deleteMarker
+        self.deleteMarkerVersionId = deleteMarkerVersionId
+        self.key = key
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case deleteMarker = "DeleteMarker"
+        case deleteMarkerVersionId = "DeleteMarkerVersionId"
+        case key = "Key"
+        case versionId = "VersionId"
+    }
+
+    public func validate() throws {
+        try key?.validateAsObjectKey()
+    }
+}
+
+public struct Destination: Codable, Equatable {
+    public var accessControlTranslation: AccessControlTranslation?
+    public var account: AccountId?
+    public var bucket: BucketName
+    public var encryptionConfiguration: EncryptionConfiguration?
+    public var storageClass: StorageClass?
+
+    public init(accessControlTranslation: AccessControlTranslation? = nil,
+                account: AccountId? = nil,
+                bucket: BucketName,
+                encryptionConfiguration: EncryptionConfiguration? = nil,
+                storageClass: StorageClass? = nil) {
+        self.accessControlTranslation = accessControlTranslation
+        self.account = account
+        self.bucket = bucket
+        self.encryptionConfiguration = encryptionConfiguration
+        self.storageClass = storageClass
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case accessControlTranslation = "AccessControlTranslation"
+        case account = "Account"
+        case bucket = "Bucket"
+        case encryptionConfiguration = "EncryptionConfiguration"
+        case storageClass = "StorageClass"
+    }
+
+    public func validate() throws {
+        try accessControlTranslation?.validate()
+        try encryptionConfiguration?.validate()
+    }
+}
+
+public struct Encryption: Codable, Equatable {
+    public var encryptionType: ServerSideEncryption
+    public var kMSContext: KMSContext?
+    public var kMSKeyId: SSEKMSKeyId?
+
+    public init(encryptionType: ServerSideEncryption,
+                kMSContext: KMSContext? = nil,
+                kMSKeyId: SSEKMSKeyId? = nil) {
+        self.encryptionType = encryptionType
+        self.kMSContext = kMSContext
+        self.kMSKeyId = kMSKeyId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case encryptionType = "EncryptionType"
+        case kMSContext = "KMSContext"
+        case kMSKeyId = "KMSKeyId"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct EncryptionConfiguration: Codable, Equatable {
+    public var replicaKmsKeyID: ReplicaKmsKeyID?
+
+    public init(replicaKmsKeyID: ReplicaKmsKeyID? = nil) {
+        self.replicaKmsKeyID = replicaKmsKeyID
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case replicaKmsKeyID = "ReplicaKmsKeyID"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct EndEvent: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct Error: Codable, Equatable {
+    public var code: Code?
+    public var key: ObjectKey?
+    public var message: Message?
+    public var versionId: ObjectVersionId?
+
+    public init(code: Code? = nil,
+                key: ObjectKey? = nil,
+                message: Message? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.code = code
+        self.key = key
+        self.message = message
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case code = "Code"
+        case key = "Key"
+        case message = "Message"
+        case versionId = "VersionId"
+    }
+
+    public func validate() throws {
+        try key?.validateAsObjectKey()
+    }
+}
+
+public struct ErrorDocument: Codable, Equatable {
+    public var key: ObjectKey
+
+    public init(key: ObjectKey) {
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case key = "Key"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct FilterRule: Codable, Equatable {
+    public var name: FilterRuleName?
+    public var value: FilterRuleValue?
+
+    public init(name: FilterRuleName? = nil,
+                value: FilterRuleValue? = nil) {
+        self.name = name
+        self.value = value
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name = "Name"
+        case value = "Value"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketAccelerateConfigurationOutput: Codable, Equatable {
+    public var status: BucketAccelerateStatus?
+
+    public init(status: BucketAccelerateStatus? = nil) {
+        self.status = status
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case status = "Status"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketAccelerateConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketAclOutput: Codable, Equatable {
+    public var grants: Grants?
+    public var owner: Owner?
+
+    public init(grants: Grants? = nil,
+                owner: Owner? = nil) {
+        self.grants = grants
+        self.owner = owner
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case grants = "AccessControlList"
+        case owner = "Owner"
+    }
+
+    public func validate() throws {
+        try owner?.validate()
+    }
+}
+
+public struct GetBucketAclRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketAnalyticsConfigurationOutput: Codable, Equatable {
+    public var analyticsConfiguration: AnalyticsConfiguration?
+
+    public init(analyticsConfiguration: AnalyticsConfiguration? = nil) {
+        self.analyticsConfiguration = analyticsConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case analyticsConfiguration = "AnalyticsConfiguration"
+    }
+
+    public func validate() throws {
+        try analyticsConfiguration?.validate()
+    }
+}
+
+public struct GetBucketAnalyticsConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var id: AnalyticsId
+
+    public init(bucket: BucketName,
+                id: AnalyticsId) {
+        self.bucket = bucket
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketCorsOutput: Codable, Equatable {
+    public var cORSRules: CORSRules?
+
+    public init(cORSRules: CORSRules? = nil) {
+        self.cORSRules = cORSRules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case cORSRules = "CORSRule"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketCorsRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketEncryptionOutput: Codable, Equatable {
+    public var serverSideEncryptionConfiguration: ServerSideEncryptionConfiguration?
+
+    public init(serverSideEncryptionConfiguration: ServerSideEncryptionConfiguration? = nil) {
+        self.serverSideEncryptionConfiguration = serverSideEncryptionConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case serverSideEncryptionConfiguration = "ServerSideEncryptionConfiguration"
+    }
+
+    public func validate() throws {
+        try serverSideEncryptionConfiguration?.validate()
+    }
+}
+
+public struct GetBucketEncryptionRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketInventoryConfigurationOutput: Codable, Equatable {
+    public var inventoryConfiguration: InventoryConfiguration?
+
+    public init(inventoryConfiguration: InventoryConfiguration? = nil) {
+        self.inventoryConfiguration = inventoryConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case inventoryConfiguration = "InventoryConfiguration"
+    }
+
+    public func validate() throws {
+        try inventoryConfiguration?.validate()
+    }
+}
+
+public struct GetBucketInventoryConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var id: InventoryId
+
+    public init(bucket: BucketName,
+                id: InventoryId) {
+        self.bucket = bucket
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketLifecycleConfigurationOutput: Codable, Equatable {
+    public var rules: LifecycleRules?
+
+    public init(rules: LifecycleRules? = nil) {
+        self.rules = rules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case rules = "Rule"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketLifecycleConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketLifecycleOutput: Codable, Equatable {
+    public var rules: Rules?
+
+    public init(rules: Rules? = nil) {
+        self.rules = rules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case rules = "Rule"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketLifecycleRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketLocationOutput: Codable, Equatable {
+    public var locationConstraint: BucketLocationConstraint?
+
+    public init(locationConstraint: BucketLocationConstraint? = nil) {
+        self.locationConstraint = locationConstraint
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case locationConstraint = "LocationConstraint"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketLocationRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketLoggingOutput: Codable, Equatable {
+    public var loggingEnabled: LoggingEnabled?
+
+    public init(loggingEnabled: LoggingEnabled? = nil) {
+        self.loggingEnabled = loggingEnabled
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case loggingEnabled = "LoggingEnabled"
+    }
+
+    public func validate() throws {
+        try loggingEnabled?.validate()
+    }
+}
+
+public struct GetBucketLoggingRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketMetricsConfigurationOutput: Codable, Equatable {
+    public var metricsConfiguration: MetricsConfiguration?
+
+    public init(metricsConfiguration: MetricsConfiguration? = nil) {
+        self.metricsConfiguration = metricsConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case metricsConfiguration = "MetricsConfiguration"
+    }
+
+    public func validate() throws {
+        try metricsConfiguration?.validate()
+    }
+}
+
+public struct GetBucketMetricsConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var id: MetricsId
+
+    public init(bucket: BucketName,
+                id: MetricsId) {
+        self.bucket = bucket
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case id
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketNotificationConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketPolicyOutput: Codable, Equatable {
+    public var policy: Policy?
+
+    public init(policy: Policy? = nil) {
+        self.policy = policy
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case policy = "Policy"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketPolicyRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketPolicyStatusOutput: Codable, Equatable {
+    public var policyStatus: PolicyStatus?
+
+    public init(policyStatus: PolicyStatus? = nil) {
+        self.policyStatus = policyStatus
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case policyStatus = "PolicyStatus"
+    }
+
+    public func validate() throws {
+        try policyStatus?.validate()
+    }
+}
+
+public struct GetBucketPolicyStatusRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketReplicationOutput: Codable, Equatable {
+    public var replicationConfiguration: ReplicationConfiguration?
+
+    public init(replicationConfiguration: ReplicationConfiguration? = nil) {
+        self.replicationConfiguration = replicationConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case replicationConfiguration = "ReplicationConfiguration"
+    }
+
+    public func validate() throws {
+        try replicationConfiguration?.validate()
+    }
+}
+
+public struct GetBucketReplicationRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketRequestPaymentOutput: Codable, Equatable {
+    public var payer: Payer?
+
+    public init(payer: Payer? = nil) {
+        self.payer = payer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case payer = "Payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketRequestPaymentRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketTaggingOutput: Codable, Equatable {
+    public var tagSet: TagSet
+
+    public init(tagSet: TagSet) {
+        self.tagSet = tagSet
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case tagSet = "TagSet"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketTaggingRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketVersioningOutput: Codable, Equatable {
+    public var mFADelete: MFADeleteStatus?
+    public var status: BucketVersioningStatus?
+
+    public init(mFADelete: MFADeleteStatus? = nil,
+                status: BucketVersioningStatus? = nil) {
+        self.mFADelete = mFADelete
+        self.status = status
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case mFADelete = "MfaDelete"
+        case status = "Status"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketVersioningRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetBucketWebsiteOutput: Codable, Equatable {
+    public var errorDocument: ErrorDocument?
+    public var indexDocument: IndexDocument?
+    public var redirectAllRequestsTo: RedirectAllRequestsTo?
+    public var routingRules: RoutingRules?
+
+    public init(errorDocument: ErrorDocument? = nil,
+                indexDocument: IndexDocument? = nil,
+                redirectAllRequestsTo: RedirectAllRequestsTo? = nil,
+                routingRules: RoutingRules? = nil) {
+        self.errorDocument = errorDocument
+        self.indexDocument = indexDocument
+        self.redirectAllRequestsTo = redirectAllRequestsTo
+        self.routingRules = routingRules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case errorDocument = "ErrorDocument"
+        case indexDocument = "IndexDocument"
+        case redirectAllRequestsTo = "RedirectAllRequestsTo"
+        case routingRules = "RoutingRules"
+    }
+
+    public func validate() throws {
+        try errorDocument?.validate()
+        try indexDocument?.validate()
+        try redirectAllRequestsTo?.validate()
+    }
+}
+
+public struct GetBucketWebsiteRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetObjectAclOutput: Codable, Equatable {
+    public var grants: Grants?
+    public var owner: Owner?
+    public var requestCharged: RequestCharged?
+
+    public init(grants: Grants? = nil,
+                owner: Owner? = nil,
+                requestCharged: RequestCharged? = nil) {
+        self.grants = grants
+        self.owner = owner
+        self.requestCharged = requestCharged
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case grants = "AccessControlList"
+        case owner = "Owner"
+        case requestCharged = "x-amz-request-charged"
+    }
+
+    public func validate() throws {
+        try owner?.validate()
+    }
+}
+
+public struct GetObjectAclRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+    public var requestPayer: RequestPayer?
+    public var versionId: ObjectVersionId?
+
+    public init(bucket: BucketName,
+                key: ObjectKey,
+                requestPayer: RequestPayer? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.bucket = bucket
+        self.key = key
+        self.requestPayer = requestPayer
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+        case requestPayer = "x-amz-request-payer"
+        case versionId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct GetObjectOutput: Codable, Equatable {
+    public var acceptRanges: AcceptRanges?
+    public var body: Body?
+    public var cacheControl: CacheControl?
+    public var contentDisposition: ContentDisposition?
+    public var contentEncoding: ContentEncoding?
+    public var contentLanguage: ContentLanguage?
+    public var contentLength: ContentLength?
+    public var contentRange: ContentRange?
+    public var contentType: ContentType?
+    public var deleteMarker: DeleteMarker?
+    public var eTag: ETag?
+    public var expiration: Expiration?
+    public var expires: Expires?
+    public var lastModified: LastModified?
+    public var metadata: Metadata?
+    public var missingMeta: MissingMeta?
+    public var partsCount: PartsCount?
+    public var replicationStatus: ReplicationStatus?
+    public var requestCharged: RequestCharged?
+    public var restore: Restore?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var storageClass: StorageClass?
+    public var tagCount: TagCount?
+    public var versionId: ObjectVersionId?
+    public var websiteRedirectLocation: WebsiteRedirectLocation?
+
+    public init(acceptRanges: AcceptRanges? = nil,
+                body: Body? = nil,
+                cacheControl: CacheControl? = nil,
+                contentDisposition: ContentDisposition? = nil,
+                contentEncoding: ContentEncoding? = nil,
+                contentLanguage: ContentLanguage? = nil,
+                contentLength: ContentLength? = nil,
+                contentRange: ContentRange? = nil,
+                contentType: ContentType? = nil,
+                deleteMarker: DeleteMarker? = nil,
+                eTag: ETag? = nil,
+                expiration: Expiration? = nil,
+                expires: Expires? = nil,
+                lastModified: LastModified? = nil,
+                metadata: Metadata? = nil,
+                missingMeta: MissingMeta? = nil,
+                partsCount: PartsCount? = nil,
+                replicationStatus: ReplicationStatus? = nil,
+                requestCharged: RequestCharged? = nil,
+                restore: Restore? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                storageClass: StorageClass? = nil,
+                tagCount: TagCount? = nil,
+                versionId: ObjectVersionId? = nil,
+                websiteRedirectLocation: WebsiteRedirectLocation? = nil) {
+        self.acceptRanges = acceptRanges
+        self.body = body
+        self.cacheControl = cacheControl
+        self.contentDisposition = contentDisposition
+        self.contentEncoding = contentEncoding
+        self.contentLanguage = contentLanguage
+        self.contentLength = contentLength
+        self.contentRange = contentRange
+        self.contentType = contentType
+        self.deleteMarker = deleteMarker
+        self.eTag = eTag
+        self.expiration = expiration
+        self.expires = expires
+        self.lastModified = lastModified
+        self.metadata = metadata
+        self.missingMeta = missingMeta
+        self.partsCount = partsCount
+        self.replicationStatus = replicationStatus
+        self.requestCharged = requestCharged
+        self.restore = restore
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.storageClass = storageClass
+        self.tagCount = tagCount
+        self.versionId = versionId
+        self.websiteRedirectLocation = websiteRedirectLocation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case acceptRanges = "accept-ranges"
+        case body = "Body"
+        case cacheControl = "Cache-Control"
+        case contentDisposition = "Content-Disposition"
+        case contentEncoding = "Content-Encoding"
+        case contentLanguage = "Content-Language"
+        case contentLength = "Content-Length"
+        case contentRange = "Content-Range"
+        case contentType = "Content-Type"
+        case deleteMarker = "x-amz-delete-marker"
+        case eTag = "ETag"
+        case expiration = "x-amz-expiration"
+        case expires = "Expires"
+        case lastModified = "Last-Modified"
+        case metadata = "x-amz-meta-"
+        case missingMeta = "x-amz-missing-meta"
+        case partsCount = "x-amz-mp-parts-count"
+        case replicationStatus = "x-amz-replication-status"
+        case requestCharged = "x-amz-request-charged"
+        case restore = "x-amz-restore"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case storageClass = "x-amz-storage-class"
+        case tagCount = "x-amz-tagging-count"
+        case versionId = "x-amz-version-id"
+        case websiteRedirectLocation = "x-amz-website-redirect-location"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetObjectRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var ifMatch: IfMatch?
+    public var ifModifiedSince: IfModifiedSince?
+    public var ifNoneMatch: IfNoneMatch?
+    public var ifUnmodifiedSince: IfUnmodifiedSince?
+    public var key: ObjectKey
+    public var partNumber: PartNumber?
+    public var range: Range?
+    public var requestPayer: RequestPayer?
+    public var responseCacheControl: ResponseCacheControl?
+    public var responseContentDisposition: ResponseContentDisposition?
+    public var responseContentEncoding: ResponseContentEncoding?
+    public var responseContentLanguage: ResponseContentLanguage?
+    public var responseContentType: ResponseContentType?
+    public var responseExpires: ResponseExpires?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var versionId: ObjectVersionId?
+
+    public init(bucket: BucketName,
+                ifMatch: IfMatch? = nil,
+                ifModifiedSince: IfModifiedSince? = nil,
+                ifNoneMatch: IfNoneMatch? = nil,
+                ifUnmodifiedSince: IfUnmodifiedSince? = nil,
+                key: ObjectKey,
+                partNumber: PartNumber? = nil,
+                range: Range? = nil,
+                requestPayer: RequestPayer? = nil,
+                responseCacheControl: ResponseCacheControl? = nil,
+                responseContentDisposition: ResponseContentDisposition? = nil,
+                responseContentEncoding: ResponseContentEncoding? = nil,
+                responseContentLanguage: ResponseContentLanguage? = nil,
+                responseContentType: ResponseContentType? = nil,
+                responseExpires: ResponseExpires? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.bucket = bucket
+        self.ifMatch = ifMatch
+        self.ifModifiedSince = ifModifiedSince
+        self.ifNoneMatch = ifNoneMatch
+        self.ifUnmodifiedSince = ifUnmodifiedSince
+        self.key = key
+        self.partNumber = partNumber
+        self.range = range
+        self.requestPayer = requestPayer
+        self.responseCacheControl = responseCacheControl
+        self.responseContentDisposition = responseContentDisposition
+        self.responseContentEncoding = responseContentEncoding
+        self.responseContentLanguage = responseContentLanguage
+        self.responseContentType = responseContentType
+        self.responseExpires = responseExpires
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case ifMatch = "If-Match"
+        case ifModifiedSince = "If-Modified-Since"
+        case ifNoneMatch = "If-None-Match"
+        case ifUnmodifiedSince = "If-Unmodified-Since"
+        case key = "Key"
+        case partNumber
+        case range = "Range"
+        case requestPayer = "x-amz-request-payer"
+        case responseCacheControl = "response-cache-control"
+        case responseContentDisposition = "response-content-disposition"
+        case responseContentEncoding = "response-content-encoding"
+        case responseContentLanguage = "response-content-language"
+        case responseContentType = "response-content-type"
+        case responseExpires = "response-expires"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case versionId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct GetObjectTaggingOutput: Codable, Equatable {
+    public var tagSet: TagSet
+    public var versionId: ObjectVersionId?
+
+    public init(tagSet: TagSet,
+                versionId: ObjectVersionId? = nil) {
+        self.tagSet = tagSet
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case tagSet = "TagSet"
+        case versionId = "x-amz-version-id"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetObjectTaggingRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+    public var versionId: ObjectVersionId?
+
+    public init(bucket: BucketName,
+                key: ObjectKey,
+                versionId: ObjectVersionId? = nil) {
+        self.bucket = bucket
+        self.key = key
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+        case versionId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct GetObjectTorrentOutput: Codable, Equatable {
+    public var body: Body?
+    public var requestCharged: RequestCharged?
+
+    public init(body: Body? = nil,
+                requestCharged: RequestCharged? = nil) {
+        self.body = body
+        self.requestCharged = requestCharged
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case body = "Body"
+        case requestCharged = "x-amz-request-charged"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GetObjectTorrentRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+    public var requestPayer: RequestPayer?
+
+    public init(bucket: BucketName,
+                key: ObjectKey,
+                requestPayer: RequestPayer? = nil) {
+        self.bucket = bucket
+        self.key = key
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct GetPublicAccessBlockOutput: Codable, Equatable {
+    public var publicAccessBlockConfiguration: PublicAccessBlockConfiguration?
+
+    public init(publicAccessBlockConfiguration: PublicAccessBlockConfiguration? = nil) {
+        self.publicAccessBlockConfiguration = publicAccessBlockConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case publicAccessBlockConfiguration = "PublicAccessBlockConfiguration"
+    }
+
+    public func validate() throws {
+        try publicAccessBlockConfiguration?.validate()
+    }
+}
+
+public struct GetPublicAccessBlockRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct GlacierJobParameters: Codable, Equatable {
+    public var tier: Tier
+
+    public init(tier: Tier) {
+        self.tier = tier
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case tier = "Tier"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct Grant: Codable, Equatable {
+    public var grantee: Grantee?
+    public var permission: Permission?
+
+    public init(grantee: Grantee? = nil,
+                permission: Permission? = nil) {
+        self.grantee = grantee
+        self.permission = permission
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case grantee = "Grantee"
+        case permission = "Permission"
+    }
+
+    public func validate() throws {
+        try grantee?.validate()
+    }
+}
+
+public struct Grantee: Codable, Equatable {
+    public var displayName: DisplayName?
+    public var emailAddress: EmailAddress?
+    public var iD: ID?
+    public var type: Type
+    public var uRI: URI?
+
+    public init(displayName: DisplayName? = nil,
+                emailAddress: EmailAddress? = nil,
+                iD: ID? = nil,
+                type: Type,
+                uRI: URI? = nil) {
+        self.displayName = displayName
+        self.emailAddress = emailAddress
+        self.iD = iD
+        self.type = type
+        self.uRI = uRI
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case displayName = "DisplayName"
+        case emailAddress = "EmailAddress"
+        case iD = "ID"
+        case type = "xsi:type"
+        case uRI = "URI"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct HeadBucketRequest: Codable, Equatable {
+    public var bucket: BucketName
+
+    public init(bucket: BucketName) {
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct HeadObjectOutput: Codable, Equatable {
+    public var acceptRanges: AcceptRanges?
+    public var cacheControl: CacheControl?
+    public var contentDisposition: ContentDisposition?
+    public var contentEncoding: ContentEncoding?
+    public var contentLanguage: ContentLanguage?
+    public var contentLength: ContentLength?
+    public var contentType: ContentType?
+    public var deleteMarker: DeleteMarker?
+    public var eTag: ETag?
+    public var expiration: Expiration?
+    public var expires: Expires?
+    public var lastModified: LastModified?
+    public var metadata: Metadata?
+    public var missingMeta: MissingMeta?
+    public var partsCount: PartsCount?
+    public var replicationStatus: ReplicationStatus?
+    public var requestCharged: RequestCharged?
+    public var restore: Restore?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var storageClass: StorageClass?
+    public var versionId: ObjectVersionId?
+    public var websiteRedirectLocation: WebsiteRedirectLocation?
+
+    public init(acceptRanges: AcceptRanges? = nil,
+                cacheControl: CacheControl? = nil,
+                contentDisposition: ContentDisposition? = nil,
+                contentEncoding: ContentEncoding? = nil,
+                contentLanguage: ContentLanguage? = nil,
+                contentLength: ContentLength? = nil,
+                contentType: ContentType? = nil,
+                deleteMarker: DeleteMarker? = nil,
+                eTag: ETag? = nil,
+                expiration: Expiration? = nil,
+                expires: Expires? = nil,
+                lastModified: LastModified? = nil,
+                metadata: Metadata? = nil,
+                missingMeta: MissingMeta? = nil,
+                partsCount: PartsCount? = nil,
+                replicationStatus: ReplicationStatus? = nil,
+                requestCharged: RequestCharged? = nil,
+                restore: Restore? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                storageClass: StorageClass? = nil,
+                versionId: ObjectVersionId? = nil,
+                websiteRedirectLocation: WebsiteRedirectLocation? = nil) {
+        self.acceptRanges = acceptRanges
+        self.cacheControl = cacheControl
+        self.contentDisposition = contentDisposition
+        self.contentEncoding = contentEncoding
+        self.contentLanguage = contentLanguage
+        self.contentLength = contentLength
+        self.contentType = contentType
+        self.deleteMarker = deleteMarker
+        self.eTag = eTag
+        self.expiration = expiration
+        self.expires = expires
+        self.lastModified = lastModified
+        self.metadata = metadata
+        self.missingMeta = missingMeta
+        self.partsCount = partsCount
+        self.replicationStatus = replicationStatus
+        self.requestCharged = requestCharged
+        self.restore = restore
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.storageClass = storageClass
+        self.versionId = versionId
+        self.websiteRedirectLocation = websiteRedirectLocation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case acceptRanges = "accept-ranges"
+        case cacheControl = "Cache-Control"
+        case contentDisposition = "Content-Disposition"
+        case contentEncoding = "Content-Encoding"
+        case contentLanguage = "Content-Language"
+        case contentLength = "Content-Length"
+        case contentType = "Content-Type"
+        case deleteMarker = "x-amz-delete-marker"
+        case eTag = "ETag"
+        case expiration = "x-amz-expiration"
+        case expires = "Expires"
+        case lastModified = "Last-Modified"
+        case metadata = "x-amz-meta-"
+        case missingMeta = "x-amz-missing-meta"
+        case partsCount = "x-amz-mp-parts-count"
+        case replicationStatus = "x-amz-replication-status"
+        case requestCharged = "x-amz-request-charged"
+        case restore = "x-amz-restore"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case storageClass = "x-amz-storage-class"
+        case versionId = "x-amz-version-id"
+        case websiteRedirectLocation = "x-amz-website-redirect-location"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct HeadObjectRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var ifMatch: IfMatch?
+    public var ifModifiedSince: IfModifiedSince?
+    public var ifNoneMatch: IfNoneMatch?
+    public var ifUnmodifiedSince: IfUnmodifiedSince?
+    public var key: ObjectKey
+    public var partNumber: PartNumber?
+    public var range: Range?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var versionId: ObjectVersionId?
+
+    public init(bucket: BucketName,
+                ifMatch: IfMatch? = nil,
+                ifModifiedSince: IfModifiedSince? = nil,
+                ifNoneMatch: IfNoneMatch? = nil,
+                ifUnmodifiedSince: IfUnmodifiedSince? = nil,
+                key: ObjectKey,
+                partNumber: PartNumber? = nil,
+                range: Range? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.bucket = bucket
+        self.ifMatch = ifMatch
+        self.ifModifiedSince = ifModifiedSince
+        self.ifNoneMatch = ifNoneMatch
+        self.ifUnmodifiedSince = ifUnmodifiedSince
+        self.key = key
+        self.partNumber = partNumber
+        self.range = range
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case ifMatch = "If-Match"
+        case ifModifiedSince = "If-Modified-Since"
+        case ifNoneMatch = "If-None-Match"
+        case ifUnmodifiedSince = "If-Unmodified-Since"
+        case key = "Key"
+        case partNumber
+        case range = "Range"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case versionId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct IndexDocument: Codable, Equatable {
+    public var suffix: Suffix
+
+    public init(suffix: Suffix) {
+        self.suffix = suffix
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case suffix = "Suffix"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct Initiator: Codable, Equatable {
+    public var displayName: DisplayName?
+    public var iD: ID?
+
+    public init(displayName: DisplayName? = nil,
+                iD: ID? = nil) {
+        self.displayName = displayName
+        self.iD = iD
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case displayName = "DisplayName"
+        case iD = "ID"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct InputSerialization: Codable, Equatable {
+    public var cSV: CSVInput?
+    public var compressionType: CompressionType?
+    public var jSON: JSONInput?
+    public var parquet: ParquetInput?
+
+    public init(cSV: CSVInput? = nil,
+                compressionType: CompressionType? = nil,
+                jSON: JSONInput? = nil,
+                parquet: ParquetInput? = nil) {
+        self.cSV = cSV
+        self.compressionType = compressionType
+        self.jSON = jSON
+        self.parquet = parquet
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case cSV = "CSV"
+        case compressionType = "CompressionType"
+        case jSON = "JSON"
+        case parquet = "Parquet"
+    }
+
+    public func validate() throws {
+        try cSV?.validate()
+        try jSON?.validate()
+        try parquet?.validate()
+    }
+}
+
+public struct InventoryConfiguration: Codable, Equatable {
+    public var destination: InventoryDestination
+    public var filter: InventoryFilter?
+    public var id: InventoryId
+    public var includedObjectVersions: InventoryIncludedObjectVersions
+    public var isEnabled: IsEnabled
+    public var optionalFields: InventoryOptionalFields?
+    public var schedule: InventorySchedule
+
+    public init(destination: InventoryDestination,
+                filter: InventoryFilter? = nil,
+                id: InventoryId,
+                includedObjectVersions: InventoryIncludedObjectVersions,
+                isEnabled: IsEnabled,
+                optionalFields: InventoryOptionalFields? = nil,
+                schedule: InventorySchedule) {
+        self.destination = destination
+        self.filter = filter
+        self.id = id
+        self.includedObjectVersions = includedObjectVersions
+        self.isEnabled = isEnabled
+        self.optionalFields = optionalFields
+        self.schedule = schedule
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case destination = "Destination"
+        case filter = "Filter"
+        case id = "Id"
+        case includedObjectVersions = "IncludedObjectVersions"
+        case isEnabled = "IsEnabled"
+        case optionalFields = "OptionalFields"
+        case schedule = "Schedule"
+    }
+
+    public func validate() throws {
+        try destination.validate()
+        try filter?.validate()
+        try schedule.validate()
+    }
+}
+
+public struct InventoryDestination: Codable, Equatable {
+    public var s3BucketDestination: InventoryS3BucketDestination
+
+    public init(s3BucketDestination: InventoryS3BucketDestination) {
+        self.s3BucketDestination = s3BucketDestination
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case s3BucketDestination = "S3BucketDestination"
+    }
+
+    public func validate() throws {
+        try s3BucketDestination.validate()
+    }
+}
+
+public struct InventoryEncryption: Codable, Equatable {
+    public var sSEKMS: SSEKMS?
+    public var sSES3: SSES3?
+
+    public init(sSEKMS: SSEKMS? = nil,
+                sSES3: SSES3? = nil) {
+        self.sSEKMS = sSEKMS
+        self.sSES3 = sSES3
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case sSEKMS = "SSE-KMS"
+        case sSES3 = "SSE-S3"
+    }
+
+    public func validate() throws {
+        try sSEKMS?.validate()
+        try sSES3?.validate()
+    }
+}
+
+public struct InventoryFilter: Codable, Equatable {
+    public var prefix: Prefix
+
+    public init(prefix: Prefix) {
+        self.prefix = prefix
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case prefix = "Prefix"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct InventoryS3BucketDestination: Codable, Equatable {
+    public var accountId: AccountId?
+    public var bucket: BucketName
+    public var encryption: InventoryEncryption?
+    public var format: InventoryFormat
+    public var prefix: Prefix?
+
+    public init(accountId: AccountId? = nil,
+                bucket: BucketName,
+                encryption: InventoryEncryption? = nil,
+                format: InventoryFormat,
+                prefix: Prefix? = nil) {
+        self.accountId = accountId
+        self.bucket = bucket
+        self.encryption = encryption
+        self.format = format
+        self.prefix = prefix
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case accountId = "AccountId"
+        case bucket = "Bucket"
+        case encryption = "Encryption"
+        case format = "Format"
+        case prefix = "Prefix"
+    }
+
+    public func validate() throws {
+        try encryption?.validate()
+    }
+}
+
+public struct InventorySchedule: Codable, Equatable {
+    public var frequency: InventoryFrequency
+
+    public init(frequency: InventoryFrequency) {
+        self.frequency = frequency
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case frequency = "Frequency"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct JSONInput: Codable, Equatable {
+    public var type: JSONType?
+
+    public init(type: JSONType? = nil) {
+        self.type = type
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case type = "Type"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct JSONOutput: Codable, Equatable {
+    public var recordDelimiter: RecordDelimiter?
+
+    public init(recordDelimiter: RecordDelimiter? = nil) {
+        self.recordDelimiter = recordDelimiter
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case recordDelimiter = "RecordDelimiter"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct LambdaFunctionConfiguration: Codable, Equatable {
+    public var events: EventList
+    public var filter: NotificationConfigurationFilter?
+    public var id: NotificationId?
+    public var lambdaFunctionArn: LambdaFunctionArn
+
+    public init(events: EventList,
+                filter: NotificationConfigurationFilter? = nil,
+                id: NotificationId? = nil,
+                lambdaFunctionArn: LambdaFunctionArn) {
+        self.events = events
+        self.filter = filter
+        self.id = id
+        self.lambdaFunctionArn = lambdaFunctionArn
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case events = "Event"
+        case filter = "Filter"
+        case id = "Id"
+        case lambdaFunctionArn = "CloudFunction"
+    }
+
+    public func validate() throws {
+        try filter?.validate()
+    }
+}
+
+public struct LifecycleConfiguration: Codable, Equatable {
+    public var rules: Rules
+
+    public init(rules: Rules) {
+        self.rules = rules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case rules = "Rule"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct LifecycleExpiration: Codable, Equatable {
+    public var date: Date?
+    public var days: Days?
+    public var expiredObjectDeleteMarker: ExpiredObjectDeleteMarker?
+
+    public init(date: Date? = nil,
+                days: Days? = nil,
+                expiredObjectDeleteMarker: ExpiredObjectDeleteMarker? = nil) {
+        self.date = date
+        self.days = days
+        self.expiredObjectDeleteMarker = expiredObjectDeleteMarker
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case date = "Date"
+        case days = "Days"
+        case expiredObjectDeleteMarker = "ExpiredObjectDeleteMarker"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct LifecycleRule: Codable, Equatable {
+    public var abortIncompleteMultipartUpload: AbortIncompleteMultipartUpload?
+    public var expiration: LifecycleExpiration?
+    public var filter: LifecycleRuleFilter?
+    public var iD: ID?
+    public var noncurrentVersionExpiration: NoncurrentVersionExpiration?
+    public var noncurrentVersionTransitions: NoncurrentVersionTransitionList?
+    public var status: ExpirationStatus
+    public var transitions: TransitionList?
+
+    public init(abortIncompleteMultipartUpload: AbortIncompleteMultipartUpload? = nil,
+                expiration: LifecycleExpiration? = nil,
+                filter: LifecycleRuleFilter? = nil,
+                iD: ID? = nil,
+                noncurrentVersionExpiration: NoncurrentVersionExpiration? = nil,
+                noncurrentVersionTransitions: NoncurrentVersionTransitionList? = nil,
+                status: ExpirationStatus,
+                transitions: TransitionList? = nil) {
+        self.abortIncompleteMultipartUpload = abortIncompleteMultipartUpload
+        self.expiration = expiration
+        self.filter = filter
+        self.iD = iD
+        self.noncurrentVersionExpiration = noncurrentVersionExpiration
+        self.noncurrentVersionTransitions = noncurrentVersionTransitions
+        self.status = status
+        self.transitions = transitions
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case abortIncompleteMultipartUpload = "AbortIncompleteMultipartUpload"
+        case expiration = "Expiration"
+        case filter = "Filter"
+        case iD = "ID"
+        case noncurrentVersionExpiration = "NoncurrentVersionExpiration"
+        case noncurrentVersionTransitions = "NoncurrentVersionTransition"
+        case status = "Status"
+        case transitions = "Transition"
+    }
+
+    public func validate() throws {
+        try abortIncompleteMultipartUpload?.validate()
+        try expiration?.validate()
+        try filter?.validate()
+        try noncurrentVersionExpiration?.validate()
+    }
+}
+
+public struct LifecycleRuleAndOperator: Codable, Equatable {
+    public var prefix: Prefix?
+    public var tags: TagSet?
+
+    public init(prefix: Prefix? = nil,
+                tags: TagSet? = nil) {
+        self.prefix = prefix
+        self.tags = tags
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case prefix = "Prefix"
+        case tags = "Tag"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct LifecycleRuleFilter: Codable, Equatable {
+    public var and: LifecycleRuleAndOperator?
+    public var prefix: Prefix?
+    public var tag: Tag?
+
+    public init(and: LifecycleRuleAndOperator? = nil,
+                prefix: Prefix? = nil,
+                tag: Tag? = nil) {
+        self.and = and
+        self.prefix = prefix
+        self.tag = tag
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case and = "And"
+        case prefix = "Prefix"
+        case tag = "Tag"
+    }
+
+    public func validate() throws {
+        try and?.validate()
+        try tag?.validate()
+    }
+}
+
+public struct ListBucketAnalyticsConfigurationsOutput: Codable, Equatable {
+    public var analyticsConfigurationList: AnalyticsConfigurationList?
+    public var continuationToken: Token?
+    public var isTruncated: IsTruncated?
+    public var nextContinuationToken: NextToken?
+
+    public init(analyticsConfigurationList: AnalyticsConfigurationList? = nil,
+                continuationToken: Token? = nil,
+                isTruncated: IsTruncated? = nil,
+                nextContinuationToken: NextToken? = nil) {
+        self.analyticsConfigurationList = analyticsConfigurationList
+        self.continuationToken = continuationToken
+        self.isTruncated = isTruncated
+        self.nextContinuationToken = nextContinuationToken
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case analyticsConfigurationList = "AnalyticsConfiguration"
+        case continuationToken = "ContinuationToken"
+        case isTruncated = "IsTruncated"
+        case nextContinuationToken = "NextContinuationToken"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListBucketAnalyticsConfigurationsRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var continuationToken: Token?
+
+    public init(bucket: BucketName,
+                continuationToken: Token? = nil) {
+        self.bucket = bucket
+        self.continuationToken = continuationToken
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case continuationToken = "continuation-token"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListBucketInventoryConfigurationsOutput: Codable, Equatable {
+    public var continuationToken: Token?
+    public var inventoryConfigurationList: InventoryConfigurationList?
+    public var isTruncated: IsTruncated?
+    public var nextContinuationToken: NextToken?
+
+    public init(continuationToken: Token? = nil,
+                inventoryConfigurationList: InventoryConfigurationList? = nil,
+                isTruncated: IsTruncated? = nil,
+                nextContinuationToken: NextToken? = nil) {
+        self.continuationToken = continuationToken
+        self.inventoryConfigurationList = inventoryConfigurationList
+        self.isTruncated = isTruncated
+        self.nextContinuationToken = nextContinuationToken
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case continuationToken = "ContinuationToken"
+        case inventoryConfigurationList = "InventoryConfiguration"
+        case isTruncated = "IsTruncated"
+        case nextContinuationToken = "NextContinuationToken"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListBucketInventoryConfigurationsRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var continuationToken: Token?
+
+    public init(bucket: BucketName,
+                continuationToken: Token? = nil) {
+        self.bucket = bucket
+        self.continuationToken = continuationToken
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case continuationToken = "continuation-token"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListBucketMetricsConfigurationsOutput: Codable, Equatable {
+    public var continuationToken: Token?
+    public var isTruncated: IsTruncated?
+    public var metricsConfigurationList: MetricsConfigurationList?
+    public var nextContinuationToken: NextToken?
+
+    public init(continuationToken: Token? = nil,
+                isTruncated: IsTruncated? = nil,
+                metricsConfigurationList: MetricsConfigurationList? = nil,
+                nextContinuationToken: NextToken? = nil) {
+        self.continuationToken = continuationToken
+        self.isTruncated = isTruncated
+        self.metricsConfigurationList = metricsConfigurationList
+        self.nextContinuationToken = nextContinuationToken
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case continuationToken = "ContinuationToken"
+        case isTruncated = "IsTruncated"
+        case metricsConfigurationList = "MetricsConfiguration"
+        case nextContinuationToken = "NextContinuationToken"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListBucketMetricsConfigurationsRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var continuationToken: Token?
+
+    public init(bucket: BucketName,
+                continuationToken: Token? = nil) {
+        self.bucket = bucket
+        self.continuationToken = continuationToken
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case continuationToken = "continuation-token"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListBucketsOutput: Codable, Equatable {
+    public var buckets: Buckets?
+    public var owner: Owner?
+
+    public init(buckets: Buckets? = nil,
+                owner: Owner? = nil) {
+        self.buckets = buckets
+        self.owner = owner
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case buckets = "Buckets"
+        case owner = "Owner"
+    }
+
+    public func validate() throws {
+        try owner?.validate()
+    }
+}
+
+public struct ListMultipartUploadsOutput: Codable, Equatable {
+    public var bucket: BucketName?
+    public var commonPrefixes: CommonPrefixList?
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var isTruncated: IsTruncated?
+    public var keyMarker: KeyMarker?
+    public var maxUploads: MaxUploads?
+    public var nextKeyMarker: NextKeyMarker?
+    public var nextUploadIdMarker: NextUploadIdMarker?
+    public var prefix: Prefix?
+    public var uploadIdMarker: UploadIdMarker?
+    public var uploads: MultipartUploadList?
+
+    public init(bucket: BucketName? = nil,
+                commonPrefixes: CommonPrefixList? = nil,
+                delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                isTruncated: IsTruncated? = nil,
+                keyMarker: KeyMarker? = nil,
+                maxUploads: MaxUploads? = nil,
+                nextKeyMarker: NextKeyMarker? = nil,
+                nextUploadIdMarker: NextUploadIdMarker? = nil,
+                prefix: Prefix? = nil,
+                uploadIdMarker: UploadIdMarker? = nil,
+                uploads: MultipartUploadList? = nil) {
+        self.bucket = bucket
+        self.commonPrefixes = commonPrefixes
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.isTruncated = isTruncated
+        self.keyMarker = keyMarker
+        self.maxUploads = maxUploads
+        self.nextKeyMarker = nextKeyMarker
+        self.nextUploadIdMarker = nextUploadIdMarker
+        self.prefix = prefix
+        self.uploadIdMarker = uploadIdMarker
+        self.uploads = uploads
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case commonPrefixes = "CommonPrefixes"
+        case delimiter = "Delimiter"
+        case encodingType = "EncodingType"
+        case isTruncated = "IsTruncated"
+        case keyMarker = "KeyMarker"
+        case maxUploads = "MaxUploads"
+        case nextKeyMarker = "NextKeyMarker"
+        case nextUploadIdMarker = "NextUploadIdMarker"
+        case prefix = "Prefix"
+        case uploadIdMarker = "UploadIdMarker"
+        case uploads = "Upload"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListMultipartUploadsRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var keyMarker: KeyMarker?
+    public var maxUploads: MaxUploads?
+    public var prefix: Prefix?
+    public var uploadIdMarker: UploadIdMarker?
+
+    public init(bucket: BucketName,
+                delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                keyMarker: KeyMarker? = nil,
+                maxUploads: MaxUploads? = nil,
+                prefix: Prefix? = nil,
+                uploadIdMarker: UploadIdMarker? = nil) {
+        self.bucket = bucket
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.keyMarker = keyMarker
+        self.maxUploads = maxUploads
+        self.prefix = prefix
+        self.uploadIdMarker = uploadIdMarker
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case delimiter
+        case encodingType = "encoding-type"
+        case keyMarker = "key-marker"
+        case maxUploads = "max-uploads"
+        case prefix
+        case uploadIdMarker = "upload-id-marker"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListObjectVersionsOutput: Codable, Equatable {
+    public var commonPrefixes: CommonPrefixList?
+    public var deleteMarkers: DeleteMarkers?
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var isTruncated: IsTruncated?
+    public var keyMarker: KeyMarker?
+    public var maxKeys: MaxKeys?
+    public var name: BucketName?
+    public var nextKeyMarker: NextKeyMarker?
+    public var nextVersionIdMarker: NextVersionIdMarker?
+    public var prefix: Prefix?
+    public var versionIdMarker: VersionIdMarker?
+    public var versions: ObjectVersionList?
+
+    public init(commonPrefixes: CommonPrefixList? = nil,
+                deleteMarkers: DeleteMarkers? = nil,
+                delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                isTruncated: IsTruncated? = nil,
+                keyMarker: KeyMarker? = nil,
+                maxKeys: MaxKeys? = nil,
+                name: BucketName? = nil,
+                nextKeyMarker: NextKeyMarker? = nil,
+                nextVersionIdMarker: NextVersionIdMarker? = nil,
+                prefix: Prefix? = nil,
+                versionIdMarker: VersionIdMarker? = nil,
+                versions: ObjectVersionList? = nil) {
+        self.commonPrefixes = commonPrefixes
+        self.deleteMarkers = deleteMarkers
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.isTruncated = isTruncated
+        self.keyMarker = keyMarker
+        self.maxKeys = maxKeys
+        self.name = name
+        self.nextKeyMarker = nextKeyMarker
+        self.nextVersionIdMarker = nextVersionIdMarker
+        self.prefix = prefix
+        self.versionIdMarker = versionIdMarker
+        self.versions = versions
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case commonPrefixes = "CommonPrefixes"
+        case deleteMarkers = "DeleteMarker"
+        case delimiter = "Delimiter"
+        case encodingType = "EncodingType"
+        case isTruncated = "IsTruncated"
+        case keyMarker = "KeyMarker"
+        case maxKeys = "MaxKeys"
+        case name = "Name"
+        case nextKeyMarker = "NextKeyMarker"
+        case nextVersionIdMarker = "NextVersionIdMarker"
+        case prefix = "Prefix"
+        case versionIdMarker = "VersionIdMarker"
+        case versions = "Version"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListObjectVersionsRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var keyMarker: KeyMarker?
+    public var maxKeys: MaxKeys?
+    public var prefix: Prefix?
+    public var versionIdMarker: VersionIdMarker?
+
+    public init(bucket: BucketName,
+                delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                keyMarker: KeyMarker? = nil,
+                maxKeys: MaxKeys? = nil,
+                prefix: Prefix? = nil,
+                versionIdMarker: VersionIdMarker? = nil) {
+        self.bucket = bucket
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.keyMarker = keyMarker
+        self.maxKeys = maxKeys
+        self.prefix = prefix
+        self.versionIdMarker = versionIdMarker
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case delimiter
+        case encodingType = "encoding-type"
+        case keyMarker = "key-marker"
+        case maxKeys = "max-keys"
+        case prefix
+        case versionIdMarker = "version-id-marker"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListObjectsOutput: Codable, Equatable {
+    public var commonPrefixes: CommonPrefixList?
+    public var contents: ObjectList?
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var isTruncated: IsTruncated?
+    public var marker: Marker?
+    public var maxKeys: MaxKeys?
+    public var name: BucketName?
+    public var nextMarker: NextMarker?
+    public var prefix: Prefix?
+
+    public init(commonPrefixes: CommonPrefixList? = nil,
+                contents: ObjectList? = nil,
+                delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                isTruncated: IsTruncated? = nil,
+                marker: Marker? = nil,
+                maxKeys: MaxKeys? = nil,
+                name: BucketName? = nil,
+                nextMarker: NextMarker? = nil,
+                prefix: Prefix? = nil) {
+        self.commonPrefixes = commonPrefixes
+        self.contents = contents
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.isTruncated = isTruncated
+        self.marker = marker
+        self.maxKeys = maxKeys
+        self.name = name
+        self.nextMarker = nextMarker
+        self.prefix = prefix
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case commonPrefixes = "CommonPrefixes"
+        case contents = "Contents"
+        case delimiter = "Delimiter"
+        case encodingType = "EncodingType"
+        case isTruncated = "IsTruncated"
+        case marker = "Marker"
+        case maxKeys = "MaxKeys"
+        case name = "Name"
+        case nextMarker = "NextMarker"
+        case prefix = "Prefix"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListObjectsRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var marker: Marker?
+    public var maxKeys: MaxKeys?
+    public var prefix: Prefix?
+    public var requestPayer: RequestPayer?
+
+    public init(bucket: BucketName,
+                delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                marker: Marker? = nil,
+                maxKeys: MaxKeys? = nil,
+                prefix: Prefix? = nil,
+                requestPayer: RequestPayer? = nil) {
+        self.bucket = bucket
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.marker = marker
+        self.maxKeys = maxKeys
+        self.prefix = prefix
+        self.requestPayer = requestPayer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case delimiter
+        case encodingType = "encoding-type"
+        case marker
+        case maxKeys = "max-keys"
+        case prefix
+        case requestPayer = "x-amz-request-payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListObjectsV2Output: Codable, Equatable {
+    public var commonPrefixes: CommonPrefixList?
+    public var contents: ObjectList?
+    public var continuationToken: Token?
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var isTruncated: IsTruncated?
+    public var keyCount: KeyCount?
+    public var maxKeys: MaxKeys?
+    public var name: BucketName?
+    public var nextContinuationToken: NextToken?
+    public var prefix: Prefix?
+    public var startAfter: StartAfter?
+
+    public init(commonPrefixes: CommonPrefixList? = nil,
+                contents: ObjectList? = nil,
+                continuationToken: Token? = nil,
+                delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                isTruncated: IsTruncated? = nil,
+                keyCount: KeyCount? = nil,
+                maxKeys: MaxKeys? = nil,
+                name: BucketName? = nil,
+                nextContinuationToken: NextToken? = nil,
+                prefix: Prefix? = nil,
+                startAfter: StartAfter? = nil) {
+        self.commonPrefixes = commonPrefixes
+        self.contents = contents
+        self.continuationToken = continuationToken
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.isTruncated = isTruncated
+        self.keyCount = keyCount
+        self.maxKeys = maxKeys
+        self.name = name
+        self.nextContinuationToken = nextContinuationToken
+        self.prefix = prefix
+        self.startAfter = startAfter
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case commonPrefixes = "CommonPrefixes"
+        case contents = "Contents"
+        case continuationToken = "ContinuationToken"
+        case delimiter = "Delimiter"
+        case encodingType = "EncodingType"
+        case isTruncated = "IsTruncated"
+        case keyCount = "KeyCount"
+        case maxKeys = "MaxKeys"
+        case name = "Name"
+        case nextContinuationToken = "NextContinuationToken"
+        case prefix = "Prefix"
+        case startAfter = "StartAfter"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListObjectsV2Request: Codable, Equatable {
+    public var bucket: BucketName
+    public var continuationToken: Token?
+    public var delimiter: Delimiter?
+    public var encodingType: EncodingType?
+    public var fetchOwner: FetchOwner?
+    public var maxKeys: MaxKeys?
+    public var prefix: Prefix?
+    public var requestPayer: RequestPayer?
+    public var startAfter: StartAfter?
+
+    public init(bucket: BucketName,
+                continuationToken: Token? = nil,
+                delimiter: Delimiter? = nil,
+                encodingType: EncodingType? = nil,
+                fetchOwner: FetchOwner? = nil,
+                maxKeys: MaxKeys? = nil,
+                prefix: Prefix? = nil,
+                requestPayer: RequestPayer? = nil,
+                startAfter: StartAfter? = nil) {
+        self.bucket = bucket
+        self.continuationToken = continuationToken
+        self.delimiter = delimiter
+        self.encodingType = encodingType
+        self.fetchOwner = fetchOwner
+        self.maxKeys = maxKeys
+        self.prefix = prefix
+        self.requestPayer = requestPayer
+        self.startAfter = startAfter
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case continuationToken = "continuation-token"
+        case delimiter
+        case encodingType = "encoding-type"
+        case fetchOwner = "fetch-owner"
+        case maxKeys = "max-keys"
+        case prefix
+        case requestPayer = "x-amz-request-payer"
+        case startAfter = "start-after"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ListPartsOutput: Codable, Equatable {
+    public var abortDate: AbortDate?
+    public var abortRuleId: AbortRuleId?
+    public var bucket: BucketName?
+    public var initiator: Initiator?
+    public var isTruncated: IsTruncated?
+    public var key: ObjectKey?
+    public var maxParts: MaxParts?
+    public var nextPartNumberMarker: NextPartNumberMarker?
+    public var owner: Owner?
+    public var partNumberMarker: PartNumberMarker?
+    public var parts: Parts?
+    public var requestCharged: RequestCharged?
+    public var storageClass: StorageClass?
+    public var uploadId: MultipartUploadId?
+
+    public init(abortDate: AbortDate? = nil,
+                abortRuleId: AbortRuleId? = nil,
+                bucket: BucketName? = nil,
+                initiator: Initiator? = nil,
+                isTruncated: IsTruncated? = nil,
+                key: ObjectKey? = nil,
+                maxParts: MaxParts? = nil,
+                nextPartNumberMarker: NextPartNumberMarker? = nil,
+                owner: Owner? = nil,
+                partNumberMarker: PartNumberMarker? = nil,
+                parts: Parts? = nil,
+                requestCharged: RequestCharged? = nil,
+                storageClass: StorageClass? = nil,
+                uploadId: MultipartUploadId? = nil) {
+        self.abortDate = abortDate
+        self.abortRuleId = abortRuleId
+        self.bucket = bucket
+        self.initiator = initiator
+        self.isTruncated = isTruncated
+        self.key = key
+        self.maxParts = maxParts
+        self.nextPartNumberMarker = nextPartNumberMarker
+        self.owner = owner
+        self.partNumberMarker = partNumberMarker
+        self.parts = parts
+        self.requestCharged = requestCharged
+        self.storageClass = storageClass
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case abortDate = "x-amz-abort-date"
+        case abortRuleId = "x-amz-abort-rule-id"
+        case bucket = "Bucket"
+        case initiator = "Initiator"
+        case isTruncated = "IsTruncated"
+        case key = "Key"
+        case maxParts = "MaxParts"
+        case nextPartNumberMarker = "NextPartNumberMarker"
+        case owner = "Owner"
+        case partNumberMarker = "PartNumberMarker"
+        case parts = "Part"
+        case requestCharged = "x-amz-request-charged"
+        case storageClass = "StorageClass"
+        case uploadId = "UploadId"
+    }
+
+    public func validate() throws {
+        try initiator?.validate()
+        try key?.validateAsObjectKey()
+        try owner?.validate()
+    }
+}
+
+public struct ListPartsRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+    public var maxParts: MaxParts?
+    public var partNumberMarker: PartNumberMarker?
+    public var requestPayer: RequestPayer?
+    public var uploadId: MultipartUploadId
+
+    public init(bucket: BucketName,
+                key: ObjectKey,
+                maxParts: MaxParts? = nil,
+                partNumberMarker: PartNumberMarker? = nil,
+                requestPayer: RequestPayer? = nil,
+                uploadId: MultipartUploadId) {
+        self.bucket = bucket
+        self.key = key
+        self.maxParts = maxParts
+        self.partNumberMarker = partNumberMarker
+        self.requestPayer = requestPayer
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+        case maxParts = "max-parts"
+        case partNumberMarker = "part-number-marker"
+        case requestPayer = "x-amz-request-payer"
+        case uploadId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct LoggingEnabled: Codable, Equatable {
+    public var targetBucket: TargetBucket
+    public var targetGrants: TargetGrants?
+    public var targetPrefix: TargetPrefix
+
+    public init(targetBucket: TargetBucket,
+                targetGrants: TargetGrants? = nil,
+                targetPrefix: TargetPrefix) {
+        self.targetBucket = targetBucket
+        self.targetGrants = targetGrants
+        self.targetPrefix = targetPrefix
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case targetBucket = "TargetBucket"
+        case targetGrants = "TargetGrants"
+        case targetPrefix = "TargetPrefix"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct MetadataEntry: Codable, Equatable {
+    public var name: MetadataKey?
+    public var value: MetadataValue?
+
+    public init(name: MetadataKey? = nil,
+                value: MetadataValue? = nil) {
+        self.name = name
+        self.value = value
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name = "Name"
+        case value = "Value"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct MetricsAndOperator: Codable, Equatable {
+    public var prefix: Prefix?
+    public var tags: TagSet?
+
+    public init(prefix: Prefix? = nil,
+                tags: TagSet? = nil) {
+        self.prefix = prefix
+        self.tags = tags
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case prefix = "Prefix"
+        case tags = "Tag"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct MetricsConfiguration: Codable, Equatable {
+    public var filter: MetricsFilter?
+    public var id: MetricsId
+
+    public init(filter: MetricsFilter? = nil,
+                id: MetricsId) {
+        self.filter = filter
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case filter = "Filter"
+        case id = "Id"
+    }
+
+    public func validate() throws {
+        try filter?.validate()
+    }
+}
+
+public struct MetricsFilter: Codable, Equatable {
+    public var and: MetricsAndOperator?
+    public var prefix: Prefix?
+    public var tag: Tag?
+
+    public init(and: MetricsAndOperator? = nil,
+                prefix: Prefix? = nil,
+                tag: Tag? = nil) {
+        self.and = and
+        self.prefix = prefix
+        self.tag = tag
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case and = "And"
+        case prefix = "Prefix"
+        case tag = "Tag"
+    }
+
+    public func validate() throws {
+        try and?.validate()
+        try tag?.validate()
+    }
+}
+
+public struct MultipartUpload: Codable, Equatable {
+    public var initiated: Initiated?
+    public var initiator: Initiator?
+    public var key: ObjectKey?
+    public var owner: Owner?
+    public var storageClass: StorageClass?
+    public var uploadId: MultipartUploadId?
+
+    public init(initiated: Initiated? = nil,
+                initiator: Initiator? = nil,
+                key: ObjectKey? = nil,
+                owner: Owner? = nil,
+                storageClass: StorageClass? = nil,
+                uploadId: MultipartUploadId? = nil) {
+        self.initiated = initiated
+        self.initiator = initiator
+        self.key = key
+        self.owner = owner
+        self.storageClass = storageClass
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case initiated = "Initiated"
+        case initiator = "Initiator"
+        case key = "Key"
+        case owner = "Owner"
+        case storageClass = "StorageClass"
+        case uploadId = "UploadId"
+    }
+
+    public func validate() throws {
+        try initiator?.validate()
+        try key?.validateAsObjectKey()
+        try owner?.validate()
+    }
+}
+
+public struct NoSuchBucket: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct NoSuchKey: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct NoSuchUpload: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct NoncurrentVersionExpiration: Codable, Equatable {
+    public var noncurrentDays: Days?
+
+    public init(noncurrentDays: Days? = nil) {
+        self.noncurrentDays = noncurrentDays
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case noncurrentDays = "NoncurrentDays"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct NoncurrentVersionTransition: Codable, Equatable {
+    public var noncurrentDays: Days?
+    public var storageClass: TransitionStorageClass?
+
+    public init(noncurrentDays: Days? = nil,
+                storageClass: TransitionStorageClass? = nil) {
+        self.noncurrentDays = noncurrentDays
+        self.storageClass = storageClass
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case noncurrentDays = "NoncurrentDays"
+        case storageClass = "StorageClass"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct NotificationConfiguration: Codable, Equatable {
+    public var lambdaFunctionConfigurations: LambdaFunctionConfigurationList?
+    public var queueConfigurations: QueueConfigurationList?
+    public var topicConfigurations: TopicConfigurationList?
+
+    public init(lambdaFunctionConfigurations: LambdaFunctionConfigurationList? = nil,
+                queueConfigurations: QueueConfigurationList? = nil,
+                topicConfigurations: TopicConfigurationList? = nil) {
+        self.lambdaFunctionConfigurations = lambdaFunctionConfigurations
+        self.queueConfigurations = queueConfigurations
+        self.topicConfigurations = topicConfigurations
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case lambdaFunctionConfigurations = "CloudFunctionConfiguration"
+        case queueConfigurations = "QueueConfiguration"
+        case topicConfigurations = "TopicConfiguration"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct NotificationConfigurationDeprecated: Codable, Equatable {
+    public var cloudFunctionConfiguration: CloudFunctionConfiguration?
+    public var queueConfiguration: QueueConfigurationDeprecated?
+    public var topicConfiguration: TopicConfigurationDeprecated?
+
+    public init(cloudFunctionConfiguration: CloudFunctionConfiguration? = nil,
+                queueConfiguration: QueueConfigurationDeprecated? = nil,
+                topicConfiguration: TopicConfigurationDeprecated? = nil) {
+        self.cloudFunctionConfiguration = cloudFunctionConfiguration
+        self.queueConfiguration = queueConfiguration
+        self.topicConfiguration = topicConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case cloudFunctionConfiguration = "CloudFunctionConfiguration"
+        case queueConfiguration = "QueueConfiguration"
+        case topicConfiguration = "TopicConfiguration"
+    }
+
+    public func validate() throws {
+        try cloudFunctionConfiguration?.validate()
+        try queueConfiguration?.validate()
+        try topicConfiguration?.validate()
+    }
+}
+
+public struct NotificationConfigurationFilter: Codable, Equatable {
+    public var key: S3KeyFilter?
+
+    public init(key: S3KeyFilter? = nil) {
+        self.key = key
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case key = "S3Key"
+    }
+
+    public func validate() throws {
+        try key?.validate()
+    }
+}
+
+public struct Object: Codable, Equatable {
+    public var eTag: ETag?
+    public var key: ObjectKey?
+    public var lastModified: LastModified?
+    public var owner: Owner?
+    public var size: Size?
+    public var storageClass: ObjectStorageClass?
+
+    public init(eTag: ETag? = nil,
+                key: ObjectKey? = nil,
+                lastModified: LastModified? = nil,
+                owner: Owner? = nil,
+                size: Size? = nil,
+                storageClass: ObjectStorageClass? = nil) {
+        self.eTag = eTag
+        self.key = key
+        self.lastModified = lastModified
+        self.owner = owner
+        self.size = size
+        self.storageClass = storageClass
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case eTag = "ETag"
+        case key = "Key"
+        case lastModified = "LastModified"
+        case owner = "Owner"
+        case size = "Size"
+        case storageClass = "StorageClass"
+    }
+
+    public func validate() throws {
+        try key?.validateAsObjectKey()
+        try owner?.validate()
+    }
+}
+
+public struct ObjectAlreadyInActiveTierError: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ObjectIdentifier: Codable, Equatable {
+    public var key: ObjectKey
+    public var versionId: ObjectVersionId?
+
+    public init(key: ObjectKey,
+                versionId: ObjectVersionId? = nil) {
+        self.key = key
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case key = "Key"
+        case versionId = "VersionId"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct ObjectNotInActiveTierError: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ObjectVersion: Codable, Equatable {
+    public var eTag: ETag?
+    public var isLatest: IsLatest?
+    public var key: ObjectKey?
+    public var lastModified: LastModified?
+    public var owner: Owner?
+    public var size: Size?
+    public var storageClass: ObjectVersionStorageClass?
+    public var versionId: ObjectVersionId?
+
+    public init(eTag: ETag? = nil,
+                isLatest: IsLatest? = nil,
+                key: ObjectKey? = nil,
+                lastModified: LastModified? = nil,
+                owner: Owner? = nil,
+                size: Size? = nil,
+                storageClass: ObjectVersionStorageClass? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.eTag = eTag
+        self.isLatest = isLatest
+        self.key = key
+        self.lastModified = lastModified
+        self.owner = owner
+        self.size = size
+        self.storageClass = storageClass
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case eTag = "ETag"
+        case isLatest = "IsLatest"
+        case key = "Key"
+        case lastModified = "LastModified"
+        case owner = "Owner"
+        case size = "Size"
+        case storageClass = "StorageClass"
+        case versionId = "VersionId"
+    }
+
+    public func validate() throws {
+        try key?.validateAsObjectKey()
+        try owner?.validate()
+    }
+}
+
+public struct OutputLocation: Codable, Equatable {
+    public var s3: S3Location?
+
+    public init(s3: S3Location? = nil) {
+        self.s3 = s3
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case s3 = "S3"
+    }
+
+    public func validate() throws {
+        try s3?.validate()
+    }
+}
+
+public struct OutputSerialization: Codable, Equatable {
+    public var cSV: CSVOutput?
+    public var jSON: JSONOutput?
+
+    public init(cSV: CSVOutput? = nil,
+                jSON: JSONOutput? = nil) {
+        self.cSV = cSV
+        self.jSON = jSON
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case cSV = "CSV"
+        case jSON = "JSON"
+    }
+
+    public func validate() throws {
+        try cSV?.validate()
+        try jSON?.validate()
+    }
+}
+
+public struct Owner: Codable, Equatable {
+    public var displayName: DisplayName?
+    public var iD: ID?
+
+    public init(displayName: DisplayName? = nil,
+                iD: ID? = nil) {
+        self.displayName = displayName
+        self.iD = iD
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case displayName = "DisplayName"
+        case iD = "ID"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ParquetInput: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct Part: Codable, Equatable {
+    public var eTag: ETag?
+    public var lastModified: LastModified?
+    public var partNumber: PartNumber?
+    public var size: Size?
+
+    public init(eTag: ETag? = nil,
+                lastModified: LastModified? = nil,
+                partNumber: PartNumber? = nil,
+                size: Size? = nil) {
+        self.eTag = eTag
+        self.lastModified = lastModified
+        self.partNumber = partNumber
+        self.size = size
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case eTag = "ETag"
+        case lastModified = "LastModified"
+        case partNumber = "PartNumber"
+        case size = "Size"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct PolicyStatus: Codable, Equatable {
+    public var isPublic: IsPublic?
+
+    public init(isPublic: IsPublic? = nil) {
+        self.isPublic = isPublic
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case isPublic = "IsPublic"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct Progress: Codable, Equatable {
+    public var bytesProcessed: BytesProcessed?
+    public var bytesReturned: BytesReturned?
+    public var bytesScanned: BytesScanned?
+
+    public init(bytesProcessed: BytesProcessed? = nil,
+                bytesReturned: BytesReturned? = nil,
+                bytesScanned: BytesScanned? = nil) {
+        self.bytesProcessed = bytesProcessed
+        self.bytesReturned = bytesReturned
+        self.bytesScanned = bytesScanned
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bytesProcessed = "BytesProcessed"
+        case bytesReturned = "BytesReturned"
+        case bytesScanned = "BytesScanned"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ProgressEvent: Codable, Equatable {
+    public var details: Progress?
+
+    public init(details: Progress? = nil) {
+        self.details = details
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case details = "Details"
+    }
+
+    public func validate() throws {
+        try details?.validate()
+    }
+}
+
+public struct PublicAccessBlockConfiguration: Codable, Equatable {
+    public var blockPublicAcls: Setting?
+    public var blockPublicPolicy: Setting?
+    public var ignorePublicAcls: Setting?
+    public var restrictPublicBuckets: Setting?
+
+    public init(blockPublicAcls: Setting? = nil,
+                blockPublicPolicy: Setting? = nil,
+                ignorePublicAcls: Setting? = nil,
+                restrictPublicBuckets: Setting? = nil) {
+        self.blockPublicAcls = blockPublicAcls
+        self.blockPublicPolicy = blockPublicPolicy
+        self.ignorePublicAcls = ignorePublicAcls
+        self.restrictPublicBuckets = restrictPublicBuckets
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case blockPublicAcls = "BlockPublicAcls"
+        case blockPublicPolicy = "BlockPublicPolicy"
+        case ignorePublicAcls = "IgnorePublicAcls"
+        case restrictPublicBuckets = "RestrictPublicBuckets"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct PutBucketAccelerateConfigurationRequest: Codable, Equatable {
+    public var accelerateConfiguration: AccelerateConfiguration
+    public var bucket: BucketName
+
+    public init(accelerateConfiguration: AccelerateConfiguration,
+                bucket: BucketName) {
+        self.accelerateConfiguration = accelerateConfiguration
+        self.bucket = bucket
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case accelerateConfiguration = "AccelerateConfiguration"
+        case bucket = "Bucket"
+    }
+
+    public func validate() throws {
+        try accelerateConfiguration.validate()
+    }
+}
+
+public struct PutBucketAclRequest: Codable, Equatable {
+    public var aCL: BucketCannedACL?
+    public var accessControlPolicy: AccessControlPolicy?
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWrite: GrantWrite?
+    public var grantWriteACP: GrantWriteACP?
+
+    public init(aCL: BucketCannedACL? = nil,
+                accessControlPolicy: AccessControlPolicy? = nil,
+                bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWrite: GrantWrite? = nil,
+                grantWriteACP: GrantWriteACP? = nil) {
+        self.aCL = aCL
+        self.accessControlPolicy = accessControlPolicy
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWrite = grantWrite
+        self.grantWriteACP = grantWriteACP
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case accessControlPolicy = "AccessControlPolicy"
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWrite = "x-amz-grant-write"
+        case grantWriteACP = "x-amz-grant-write-acp"
+    }
+
+    public func validate() throws {
+        try accessControlPolicy?.validate()
+    }
+}
+
+public struct PutBucketAnalyticsConfigurationRequest: Codable, Equatable {
+    public var analyticsConfiguration: AnalyticsConfiguration
+    public var bucket: BucketName
+    public var id: AnalyticsId
+
+    public init(analyticsConfiguration: AnalyticsConfiguration,
+                bucket: BucketName,
+                id: AnalyticsId) {
+        self.analyticsConfiguration = analyticsConfiguration
+        self.bucket = bucket
+        self.id = id
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case analyticsConfiguration = "AnalyticsConfiguration"
+        case bucket = "Bucket"
+        case id
+    }
+
+    public func validate() throws {
+        try analyticsConfiguration.validate()
+    }
+}
+
+public struct PutBucketCorsRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var cORSConfiguration: CORSConfiguration
+    public var contentMD5: ContentMD5?
+
+    public init(bucket: BucketName,
+                cORSConfiguration: CORSConfiguration,
+                contentMD5: ContentMD5? = nil) {
+        self.bucket = bucket
+        self.cORSConfiguration = cORSConfiguration
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case cORSConfiguration = "CORSConfiguration"
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+        try cORSConfiguration.validate()
+    }
+}
+
+public struct PutBucketEncryptionRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var serverSideEncryptionConfiguration: ServerSideEncryptionConfiguration
+
+    public init(bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                serverSideEncryptionConfiguration: ServerSideEncryptionConfiguration) {
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.serverSideEncryptionConfiguration = serverSideEncryptionConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case serverSideEncryptionConfiguration = "ServerSideEncryptionConfiguration"
+    }
+
+    public func validate() throws {
+        try serverSideEncryptionConfiguration.validate()
+    }
+}
+
+public struct PutBucketInventoryConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var id: InventoryId
+    public var inventoryConfiguration: InventoryConfiguration
+
+    public init(bucket: BucketName,
+                id: InventoryId,
+                inventoryConfiguration: InventoryConfiguration) {
+        self.bucket = bucket
+        self.id = id
+        self.inventoryConfiguration = inventoryConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case id
+        case inventoryConfiguration = "InventoryConfiguration"
+    }
+
+    public func validate() throws {
+        try inventoryConfiguration.validate()
+    }
+}
+
+public struct PutBucketLifecycleConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var lifecycleConfiguration: BucketLifecycleConfiguration?
+
+    public init(bucket: BucketName,
+                lifecycleConfiguration: BucketLifecycleConfiguration? = nil) {
+        self.bucket = bucket
+        self.lifecycleConfiguration = lifecycleConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case lifecycleConfiguration = "LifecycleConfiguration"
+    }
+
+    public func validate() throws {
+        try lifecycleConfiguration?.validate()
+    }
+}
+
+public struct PutBucketLifecycleRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var lifecycleConfiguration: LifecycleConfiguration?
+
+    public init(bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                lifecycleConfiguration: LifecycleConfiguration? = nil) {
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.lifecycleConfiguration = lifecycleConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case lifecycleConfiguration = "LifecycleConfiguration"
+    }
+
+    public func validate() throws {
+        try lifecycleConfiguration?.validate()
+    }
+}
+
+public struct PutBucketLoggingRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var bucketLoggingStatus: BucketLoggingStatus
+    public var contentMD5: ContentMD5?
+
+    public init(bucket: BucketName,
+                bucketLoggingStatus: BucketLoggingStatus,
+                contentMD5: ContentMD5? = nil) {
+        self.bucket = bucket
+        self.bucketLoggingStatus = bucketLoggingStatus
+        self.contentMD5 = contentMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case bucketLoggingStatus = "BucketLoggingStatus"
+        case contentMD5 = "Content-MD5"
+    }
+
+    public func validate() throws {
+        try bucketLoggingStatus.validate()
+    }
+}
+
+public struct PutBucketMetricsConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var id: MetricsId
+    public var metricsConfiguration: MetricsConfiguration
+
+    public init(bucket: BucketName,
+                id: MetricsId,
+                metricsConfiguration: MetricsConfiguration) {
+        self.bucket = bucket
+        self.id = id
+        self.metricsConfiguration = metricsConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case id
+        case metricsConfiguration = "MetricsConfiguration"
+    }
+
+    public func validate() throws {
+        try metricsConfiguration.validate()
+    }
+}
+
+public struct PutBucketNotificationConfigurationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var notificationConfiguration: NotificationConfiguration
+
+    public init(bucket: BucketName,
+                notificationConfiguration: NotificationConfiguration) {
+        self.bucket = bucket
+        self.notificationConfiguration = notificationConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case notificationConfiguration = "NotificationConfiguration"
+    }
+
+    public func validate() throws {
+        try notificationConfiguration.validate()
+    }
+}
+
+public struct PutBucketNotificationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var notificationConfiguration: NotificationConfigurationDeprecated
+
+    public init(bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                notificationConfiguration: NotificationConfigurationDeprecated) {
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.notificationConfiguration = notificationConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case notificationConfiguration = "NotificationConfiguration"
+    }
+
+    public func validate() throws {
+        try notificationConfiguration.validate()
+    }
+}
+
+public struct PutBucketPolicyRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var confirmRemoveSelfBucketAccess: ConfirmRemoveSelfBucketAccess?
+    public var contentMD5: ContentMD5?
+    public var policy: Policy
+
+    public init(bucket: BucketName,
+                confirmRemoveSelfBucketAccess: ConfirmRemoveSelfBucketAccess? = nil,
+                contentMD5: ContentMD5? = nil,
+                policy: Policy) {
+        self.bucket = bucket
+        self.confirmRemoveSelfBucketAccess = confirmRemoveSelfBucketAccess
+        self.contentMD5 = contentMD5
+        self.policy = policy
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case confirmRemoveSelfBucketAccess = "x-amz-confirm-remove-self-bucket-access"
+        case contentMD5 = "Content-MD5"
+        case policy = "Policy"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct PutBucketReplicationRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var replicationConfiguration: ReplicationConfiguration
+
+    public init(bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                replicationConfiguration: ReplicationConfiguration) {
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.replicationConfiguration = replicationConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case replicationConfiguration = "ReplicationConfiguration"
+    }
+
+    public func validate() throws {
+        try replicationConfiguration.validate()
+    }
+}
+
+public struct PutBucketRequestPaymentRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var requestPaymentConfiguration: RequestPaymentConfiguration
+
+    public init(bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                requestPaymentConfiguration: RequestPaymentConfiguration) {
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.requestPaymentConfiguration = requestPaymentConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case requestPaymentConfiguration = "RequestPaymentConfiguration"
+    }
+
+    public func validate() throws {
+        try requestPaymentConfiguration.validate()
+    }
+}
+
+public struct PutBucketTaggingRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var tagging: Tagging
+
+    public init(bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                tagging: Tagging) {
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.tagging = tagging
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case tagging = "Tagging"
+    }
+
+    public func validate() throws {
+        try tagging.validate()
+    }
+}
+
+public struct PutBucketVersioningRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var mFA: MFA?
+    public var versioningConfiguration: VersioningConfiguration
+
+    public init(bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                mFA: MFA? = nil,
+                versioningConfiguration: VersioningConfiguration) {
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.mFA = mFA
+        self.versioningConfiguration = versioningConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case mFA = "x-amz-mfa"
+        case versioningConfiguration = "VersioningConfiguration"
+    }
+
+    public func validate() throws {
+        try versioningConfiguration.validate()
+    }
+}
+
+public struct PutBucketWebsiteRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var websiteConfiguration: WebsiteConfiguration
+
+    public init(bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                websiteConfiguration: WebsiteConfiguration) {
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.websiteConfiguration = websiteConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case websiteConfiguration = "WebsiteConfiguration"
+    }
+
+    public func validate() throws {
+        try websiteConfiguration.validate()
+    }
+}
+
+public struct PutObjectAclOutput: Codable, Equatable {
+    public var requestCharged: RequestCharged?
+
+    public init(requestCharged: RequestCharged? = nil) {
+        self.requestCharged = requestCharged
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestCharged = "x-amz-request-charged"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct PutObjectAclRequest: Codable, Equatable {
+    public var aCL: ObjectCannedACL?
+    public var accessControlPolicy: AccessControlPolicy?
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWrite: GrantWrite?
+    public var grantWriteACP: GrantWriteACP?
+    public var key: ObjectKey
+    public var requestPayer: RequestPayer?
+    public var versionId: ObjectVersionId?
+
+    public init(aCL: ObjectCannedACL? = nil,
+                accessControlPolicy: AccessControlPolicy? = nil,
+                bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWrite: GrantWrite? = nil,
+                grantWriteACP: GrantWriteACP? = nil,
+                key: ObjectKey,
+                requestPayer: RequestPayer? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.aCL = aCL
+        self.accessControlPolicy = accessControlPolicy
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWrite = grantWrite
+        self.grantWriteACP = grantWriteACP
+        self.key = key
+        self.requestPayer = requestPayer
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case accessControlPolicy = "AccessControlPolicy"
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWrite = "x-amz-grant-write"
+        case grantWriteACP = "x-amz-grant-write-acp"
+        case key = "Key"
+        case requestPayer = "x-amz-request-payer"
+        case versionId
+    }
+
+    public func validate() throws {
+        try accessControlPolicy?.validate()
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct PutObjectOutput: Codable, Equatable {
+    public var eTag: ETag?
+    public var expiration: Expiration?
+    public var requestCharged: RequestCharged?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var versionId: ObjectVersionId?
+
+    public init(eTag: ETag? = nil,
+                expiration: Expiration? = nil,
+                requestCharged: RequestCharged? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.eTag = eTag
+        self.expiration = expiration
+        self.requestCharged = requestCharged
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case eTag = "ETag"
+        case expiration = "x-amz-expiration"
+        case requestCharged = "x-amz-request-charged"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case versionId = "x-amz-version-id"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct PutObjectRequest: Codable, Equatable {
+    public var aCL: ObjectCannedACL?
+    public var body: Body?
+    public var bucket: BucketName
+    public var cacheControl: CacheControl?
+    public var contentDisposition: ContentDisposition?
+    public var contentEncoding: ContentEncoding?
+    public var contentLanguage: ContentLanguage?
+    public var contentLength: ContentLength?
+    public var contentMD5: ContentMD5?
+    public var contentType: ContentType?
+    public var expires: Expires?
+    public var grantFullControl: GrantFullControl?
+    public var grantRead: GrantRead?
+    public var grantReadACP: GrantReadACP?
+    public var grantWriteACP: GrantWriteACP?
+    public var key: ObjectKey
+    public var metadata: Metadata?
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+    public var storageClass: StorageClass?
+    public var tagging: TaggingHeader?
+    public var websiteRedirectLocation: WebsiteRedirectLocation?
+
+    public init(aCL: ObjectCannedACL? = nil,
+                body: Body? = nil,
+                bucket: BucketName,
+                cacheControl: CacheControl? = nil,
+                contentDisposition: ContentDisposition? = nil,
+                contentEncoding: ContentEncoding? = nil,
+                contentLanguage: ContentLanguage? = nil,
+                contentLength: ContentLength? = nil,
+                contentMD5: ContentMD5? = nil,
+                contentType: ContentType? = nil,
+                expires: Expires? = nil,
+                grantFullControl: GrantFullControl? = nil,
+                grantRead: GrantRead? = nil,
+                grantReadACP: GrantReadACP? = nil,
+                grantWriteACP: GrantWriteACP? = nil,
+                key: ObjectKey,
+                metadata: Metadata? = nil,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil,
+                storageClass: StorageClass? = nil,
+                tagging: TaggingHeader? = nil,
+                websiteRedirectLocation: WebsiteRedirectLocation? = nil) {
+        self.aCL = aCL
+        self.body = body
+        self.bucket = bucket
+        self.cacheControl = cacheControl
+        self.contentDisposition = contentDisposition
+        self.contentEncoding = contentEncoding
+        self.contentLanguage = contentLanguage
+        self.contentLength = contentLength
+        self.contentMD5 = contentMD5
+        self.contentType = contentType
+        self.expires = expires
+        self.grantFullControl = grantFullControl
+        self.grantRead = grantRead
+        self.grantReadACP = grantReadACP
+        self.grantWriteACP = grantWriteACP
+        self.key = key
+        self.metadata = metadata
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+        self.storageClass = storageClass
+        self.tagging = tagging
+        self.websiteRedirectLocation = websiteRedirectLocation
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case aCL = "x-amz-acl"
+        case body = "Body"
+        case bucket = "Bucket"
+        case cacheControl = "Cache-Control"
+        case contentDisposition = "Content-Disposition"
+        case contentEncoding = "Content-Encoding"
+        case contentLanguage = "Content-Language"
+        case contentLength = "Content-Length"
+        case contentMD5 = "Content-MD5"
+        case contentType = "Content-Type"
+        case expires = "Expires"
+        case grantFullControl = "x-amz-grant-full-control"
+        case grantRead = "x-amz-grant-read"
+        case grantReadACP = "x-amz-grant-read-acp"
+        case grantWriteACP = "x-amz-grant-write-acp"
+        case key = "Key"
+        case metadata = "x-amz-meta-"
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+        case storageClass = "x-amz-storage-class"
+        case tagging = "x-amz-tagging"
+        case websiteRedirectLocation = "x-amz-website-redirect-location"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct PutObjectTaggingOutput: Codable, Equatable {
+    public var versionId: ObjectVersionId?
+
+    public init(versionId: ObjectVersionId? = nil) {
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case versionId = "x-amz-version-id"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct PutObjectTaggingRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var key: ObjectKey
+    public var tagging: Tagging
+    public var versionId: ObjectVersionId?
+
+    public init(bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                key: ObjectKey,
+                tagging: Tagging,
+                versionId: ObjectVersionId? = nil) {
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.key = key
+        self.tagging = tagging
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case key = "Key"
+        case tagging = "Tagging"
+        case versionId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+        try tagging.validate()
+    }
+}
+
+public struct PutPublicAccessBlockRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var contentMD5: ContentMD5?
+    public var publicAccessBlockConfiguration: PublicAccessBlockConfiguration
+
+    public init(bucket: BucketName,
+                contentMD5: ContentMD5? = nil,
+                publicAccessBlockConfiguration: PublicAccessBlockConfiguration) {
+        self.bucket = bucket
+        self.contentMD5 = contentMD5
+        self.publicAccessBlockConfiguration = publicAccessBlockConfiguration
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case contentMD5 = "Content-MD5"
+        case publicAccessBlockConfiguration = "PublicAccessBlockConfiguration"
+    }
+
+    public func validate() throws {
+        try publicAccessBlockConfiguration.validate()
+    }
+}
+
+public struct QueueConfiguration: Codable, Equatable {
+    public var events: EventList
+    public var filter: NotificationConfigurationFilter?
+    public var id: NotificationId?
+    public var queueArn: QueueArn
+
+    public init(events: EventList,
+                filter: NotificationConfigurationFilter? = nil,
+                id: NotificationId? = nil,
+                queueArn: QueueArn) {
+        self.events = events
+        self.filter = filter
+        self.id = id
+        self.queueArn = queueArn
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case events = "Event"
+        case filter = "Filter"
+        case id = "Id"
+        case queueArn = "Queue"
+    }
+
+    public func validate() throws {
+        try filter?.validate()
+    }
+}
+
+public struct QueueConfigurationDeprecated: Codable, Equatable {
+    public var events: EventList?
+    public var id: NotificationId?
+    public var queue: QueueArn?
+
+    public init(events: EventList? = nil,
+                id: NotificationId? = nil,
+                queue: QueueArn? = nil) {
+        self.events = events
+        self.id = id
+        self.queue = queue
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case events = "Event"
+        case id = "Id"
+        case queue = "Queue"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct RecordsEvent: Codable, Equatable {
+    public var payload: Body?
+
+    public init(payload: Body? = nil) {
+        self.payload = payload
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case payload = "Payload"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct Redirect: Codable, Equatable {
+    public var hostName: HostName?
+    public var httpRedirectCode: HttpRedirectCode?
+    public var `protocol`: Protocol?
+    public var replaceKeyPrefixWith: ReplaceKeyPrefixWith?
+    public var replaceKeyWith: ReplaceKeyWith?
+
+    public init(hostName: HostName? = nil,
+                httpRedirectCode: HttpRedirectCode? = nil,
+                `protocol`: Protocol? = nil,
+                replaceKeyPrefixWith: ReplaceKeyPrefixWith? = nil,
+                replaceKeyWith: ReplaceKeyWith? = nil) {
+        self.hostName = hostName
+        self.httpRedirectCode = httpRedirectCode
+        self.`protocol` = `protocol`
+        self.replaceKeyPrefixWith = replaceKeyPrefixWith
+        self.replaceKeyWith = replaceKeyWith
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case hostName = "HostName"
+        case httpRedirectCode = "HttpRedirectCode"
+        case `protocol` = "Protocol"
+        case replaceKeyPrefixWith = "ReplaceKeyPrefixWith"
+        case replaceKeyWith = "ReplaceKeyWith"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct RedirectAllRequestsTo: Codable, Equatable {
+    public var hostName: HostName
+    public var `protocol`: Protocol?
+
+    public init(hostName: HostName,
+                `protocol`: Protocol? = nil) {
+        self.hostName = hostName
+        self.`protocol` = `protocol`
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case hostName = "HostName"
+        case `protocol` = "Protocol"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ReplicationConfiguration: Codable, Equatable {
+    public var role: Role
+    public var rules: ReplicationRules
+
+    public init(role: Role,
+                rules: ReplicationRules) {
+        self.role = role
+        self.rules = rules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case role = "Role"
+        case rules = "Rule"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ReplicationRule: Codable, Equatable {
+    public var deleteMarkerReplication: DeleteMarkerReplication?
+    public var destination: Destination
+    public var filter: ReplicationRuleFilter?
+    public var iD: ID?
+    public var priority: Priority?
+    public var sourceSelectionCriteria: SourceSelectionCriteria?
+    public var status: ReplicationRuleStatus
+
+    public init(deleteMarkerReplication: DeleteMarkerReplication? = nil,
+                destination: Destination,
+                filter: ReplicationRuleFilter? = nil,
+                iD: ID? = nil,
+                priority: Priority? = nil,
+                sourceSelectionCriteria: SourceSelectionCriteria? = nil,
+                status: ReplicationRuleStatus) {
+        self.deleteMarkerReplication = deleteMarkerReplication
+        self.destination = destination
+        self.filter = filter
+        self.iD = iD
+        self.priority = priority
+        self.sourceSelectionCriteria = sourceSelectionCriteria
+        self.status = status
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case deleteMarkerReplication = "DeleteMarkerReplication"
+        case destination = "Destination"
+        case filter = "Filter"
+        case iD = "ID"
+        case priority = "Priority"
+        case sourceSelectionCriteria = "SourceSelectionCriteria"
+        case status = "Status"
+    }
+
+    public func validate() throws {
+        try deleteMarkerReplication?.validate()
+        try destination.validate()
+        try filter?.validate()
+        try sourceSelectionCriteria?.validate()
+    }
+}
+
+public struct ReplicationRuleAndOperator: Codable, Equatable {
+    public var prefix: Prefix?
+    public var tags: TagSet?
+
+    public init(prefix: Prefix? = nil,
+                tags: TagSet? = nil) {
+        self.prefix = prefix
+        self.tags = tags
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case prefix = "Prefix"
+        case tags = "Tag"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ReplicationRuleFilter: Codable, Equatable {
+    public var and: ReplicationRuleAndOperator?
+    public var prefix: Prefix?
+    public var tag: Tag?
+
+    public init(and: ReplicationRuleAndOperator? = nil,
+                prefix: Prefix? = nil,
+                tag: Tag? = nil) {
+        self.and = and
+        self.prefix = prefix
+        self.tag = tag
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case and = "And"
+        case prefix = "Prefix"
+        case tag = "Tag"
+    }
+
+    public func validate() throws {
+        try and?.validate()
+        try tag?.validate()
+    }
+}
+
+public struct RequestPaymentConfiguration: Codable, Equatable {
+    public var payer: Payer
+
+    public init(payer: Payer) {
+        self.payer = payer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case payer = "Payer"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct RequestProgress: Codable, Equatable {
+    public var enabled: EnableRequestProgress?
+
+    public init(enabled: EnableRequestProgress? = nil) {
+        self.enabled = enabled
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case enabled = "Enabled"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct RestoreObjectOutput: Codable, Equatable {
+    public var requestCharged: RequestCharged?
+    public var restoreOutputPath: RestoreOutputPath?
+
+    public init(requestCharged: RequestCharged? = nil,
+                restoreOutputPath: RestoreOutputPath? = nil) {
+        self.requestCharged = requestCharged
+        self.restoreOutputPath = restoreOutputPath
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestCharged = "x-amz-request-charged"
+        case restoreOutputPath = "x-amz-restore-output-path"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct RestoreObjectRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var key: ObjectKey
+    public var requestPayer: RequestPayer?
+    public var restoreRequest: RestoreRequest?
+    public var versionId: ObjectVersionId?
+
+    public init(bucket: BucketName,
+                key: ObjectKey,
+                requestPayer: RequestPayer? = nil,
+                restoreRequest: RestoreRequest? = nil,
+                versionId: ObjectVersionId? = nil) {
+        self.bucket = bucket
+        self.key = key
+        self.requestPayer = requestPayer
+        self.restoreRequest = restoreRequest
+        self.versionId = versionId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case key = "Key"
+        case requestPayer = "x-amz-request-payer"
+        case restoreRequest = "RestoreRequest"
+        case versionId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+        try restoreRequest?.validate()
+    }
+}
+
+public struct RestoreRequest: Codable, Equatable {
+    public var days: Days?
+    public var description: Description?
+    public var glacierJobParameters: GlacierJobParameters?
+    public var outputLocation: OutputLocation?
+    public var selectParameters: SelectParameters?
+    public var tier: Tier?
+    public var type: RestoreRequestType?
+
+    public init(days: Days? = nil,
+                description: Description? = nil,
+                glacierJobParameters: GlacierJobParameters? = nil,
+                outputLocation: OutputLocation? = nil,
+                selectParameters: SelectParameters? = nil,
+                tier: Tier? = nil,
+                type: RestoreRequestType? = nil) {
+        self.days = days
+        self.description = description
+        self.glacierJobParameters = glacierJobParameters
+        self.outputLocation = outputLocation
+        self.selectParameters = selectParameters
+        self.tier = tier
+        self.type = type
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case days = "Days"
+        case description = "Description"
+        case glacierJobParameters = "GlacierJobParameters"
+        case outputLocation = "OutputLocation"
+        case selectParameters = "SelectParameters"
+        case tier = "Tier"
+        case type = "Type"
+    }
+
+    public func validate() throws {
+        try glacierJobParameters?.validate()
+        try outputLocation?.validate()
+        try selectParameters?.validate()
+    }
+}
+
+public struct RoutingRule: Codable, Equatable {
+    public var condition: Condition?
+    public var redirect: Redirect
+
+    public init(condition: Condition? = nil,
+                redirect: Redirect) {
+        self.condition = condition
+        self.redirect = redirect
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case condition = "Condition"
+        case redirect = "Redirect"
+    }
+
+    public func validate() throws {
+        try condition?.validate()
+        try redirect.validate()
+    }
+}
+
+public struct Rule: Codable, Equatable {
+    public var abortIncompleteMultipartUpload: AbortIncompleteMultipartUpload?
+    public var expiration: LifecycleExpiration?
+    public var iD: ID?
+    public var noncurrentVersionExpiration: NoncurrentVersionExpiration?
+    public var noncurrentVersionTransition: NoncurrentVersionTransition?
+    public var prefix: Prefix
+    public var status: ExpirationStatus
+    public var transition: Transition?
+
+    public init(abortIncompleteMultipartUpload: AbortIncompleteMultipartUpload? = nil,
+                expiration: LifecycleExpiration? = nil,
+                iD: ID? = nil,
+                noncurrentVersionExpiration: NoncurrentVersionExpiration? = nil,
+                noncurrentVersionTransition: NoncurrentVersionTransition? = nil,
+                prefix: Prefix,
+                status: ExpirationStatus,
+                transition: Transition? = nil) {
+        self.abortIncompleteMultipartUpload = abortIncompleteMultipartUpload
+        self.expiration = expiration
+        self.iD = iD
+        self.noncurrentVersionExpiration = noncurrentVersionExpiration
+        self.noncurrentVersionTransition = noncurrentVersionTransition
+        self.prefix = prefix
+        self.status = status
+        self.transition = transition
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case abortIncompleteMultipartUpload = "AbortIncompleteMultipartUpload"
+        case expiration = "Expiration"
+        case iD = "ID"
+        case noncurrentVersionExpiration = "NoncurrentVersionExpiration"
+        case noncurrentVersionTransition = "NoncurrentVersionTransition"
+        case prefix = "Prefix"
+        case status = "Status"
+        case transition = "Transition"
+    }
+
+    public func validate() throws {
+        try abortIncompleteMultipartUpload?.validate()
+        try expiration?.validate()
+        try noncurrentVersionExpiration?.validate()
+        try noncurrentVersionTransition?.validate()
+        try transition?.validate()
+    }
+}
+
+public struct S3KeyFilter: Codable, Equatable {
+    public var filterRules: FilterRuleList?
+
+    public init(filterRules: FilterRuleList? = nil) {
+        self.filterRules = filterRules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case filterRules = "FilterRule"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct S3Location: Codable, Equatable {
+    public var accessControlList: Grants?
+    public var bucketName: BucketName
+    public var cannedACL: ObjectCannedACL?
+    public var encryption: Encryption?
+    public var prefix: LocationPrefix
+    public var storageClass: StorageClass?
+    public var tagging: Tagging?
+    public var userMetadata: UserMetadata?
+
+    public init(accessControlList: Grants? = nil,
+                bucketName: BucketName,
+                cannedACL: ObjectCannedACL? = nil,
+                encryption: Encryption? = nil,
+                prefix: LocationPrefix,
+                storageClass: StorageClass? = nil,
+                tagging: Tagging? = nil,
+                userMetadata: UserMetadata? = nil) {
+        self.accessControlList = accessControlList
+        self.bucketName = bucketName
+        self.cannedACL = cannedACL
+        self.encryption = encryption
+        self.prefix = prefix
+        self.storageClass = storageClass
+        self.tagging = tagging
+        self.userMetadata = userMetadata
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case accessControlList = "AccessControlList"
+        case bucketName = "BucketName"
+        case cannedACL = "CannedACL"
+        case encryption = "Encryption"
+        case prefix = "Prefix"
+        case storageClass = "StorageClass"
+        case tagging = "Tagging"
+        case userMetadata = "UserMetadata"
+    }
+
+    public func validate() throws {
+        try encryption?.validate()
+        try tagging?.validate()
+    }
+}
+
+public struct SSEKMS: Codable, Equatable {
+    public var keyId: SSEKMSKeyId
+
+    public init(keyId: SSEKMSKeyId) {
+        self.keyId = keyId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case keyId = "KeyId"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct SSES3: Codable, Equatable {
+
+    public init() {
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct SelectObjectContentEventStream: Codable, Equatable {
+    public var cont: ContinuationEvent?
+    public var end: EndEvent?
+    public var progress: ProgressEvent?
+    public var records: RecordsEvent?
+    public var stats: StatsEvent?
+
+    public init(cont: ContinuationEvent? = nil,
+                end: EndEvent? = nil,
+                progress: ProgressEvent? = nil,
+                records: RecordsEvent? = nil,
+                stats: StatsEvent? = nil) {
+        self.cont = cont
+        self.end = end
+        self.progress = progress
+        self.records = records
+        self.stats = stats
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case cont = "Cont"
+        case end = "End"
+        case progress = "Progress"
+        case records = "Records"
+        case stats = "Stats"
+    }
+
+    public func validate() throws {
+        try cont?.validate()
+        try end?.validate()
+        try progress?.validate()
+        try records?.validate()
+        try stats?.validate()
+    }
+}
+
+public struct SelectObjectContentOutput: Codable, Equatable {
+    public var payload: SelectObjectContentEventStream?
+
+    public init(payload: SelectObjectContentEventStream? = nil) {
+        self.payload = payload
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case payload = "Payload"
+    }
+
+    public func validate() throws {
+        try payload?.validate()
+    }
+}
+
+public struct SelectObjectContentRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var expression: Expression
+    public var expressionType: ExpressionType
+    public var inputSerialization: InputSerialization
+    public var key: ObjectKey
+    public var outputSerialization: OutputSerialization
+    public var requestProgress: RequestProgress?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+
+    public init(bucket: BucketName,
+                expression: Expression,
+                expressionType: ExpressionType,
+                inputSerialization: InputSerialization,
+                key: ObjectKey,
+                outputSerialization: OutputSerialization,
+                requestProgress: RequestProgress? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil) {
+        self.bucket = bucket
+        self.expression = expression
+        self.expressionType = expressionType
+        self.inputSerialization = inputSerialization
+        self.key = key
+        self.outputSerialization = outputSerialization
+        self.requestProgress = requestProgress
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case expression = "Expression"
+        case expressionType = "ExpressionType"
+        case inputSerialization = "InputSerialization"
+        case key = "Key"
+        case outputSerialization = "OutputSerialization"
+        case requestProgress = "RequestProgress"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+    }
+
+    public func validate() throws {
+        try inputSerialization.validate()
+        try key.validateAsObjectKey()
+        try outputSerialization.validate()
+        try requestProgress?.validate()
+    }
+}
+
+public struct SelectParameters: Codable, Equatable {
+    public var expression: Expression
+    public var expressionType: ExpressionType
+    public var inputSerialization: InputSerialization
+    public var outputSerialization: OutputSerialization
+
+    public init(expression: Expression,
+                expressionType: ExpressionType,
+                inputSerialization: InputSerialization,
+                outputSerialization: OutputSerialization) {
+        self.expression = expression
+        self.expressionType = expressionType
+        self.inputSerialization = inputSerialization
+        self.outputSerialization = outputSerialization
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case expression = "Expression"
+        case expressionType = "ExpressionType"
+        case inputSerialization = "InputSerialization"
+        case outputSerialization = "OutputSerialization"
+    }
+
+    public func validate() throws {
+        try inputSerialization.validate()
+        try outputSerialization.validate()
+    }
+}
+
+public struct ServerSideEncryptionByDefault: Codable, Equatable {
+    public var kMSMasterKeyID: SSEKMSKeyId?
+    public var sSEAlgorithm: ServerSideEncryption
+
+    public init(kMSMasterKeyID: SSEKMSKeyId? = nil,
+                sSEAlgorithm: ServerSideEncryption) {
+        self.kMSMasterKeyID = kMSMasterKeyID
+        self.sSEAlgorithm = sSEAlgorithm
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kMSMasterKeyID = "KMSMasterKeyID"
+        case sSEAlgorithm = "SSEAlgorithm"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ServerSideEncryptionConfiguration: Codable, Equatable {
+    public var rules: ServerSideEncryptionRules
+
+    public init(rules: ServerSideEncryptionRules) {
+        self.rules = rules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case rules = "Rule"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ServerSideEncryptionRule: Codable, Equatable {
+    public var applyServerSideEncryptionByDefault: ServerSideEncryptionByDefault?
+
+    public init(applyServerSideEncryptionByDefault: ServerSideEncryptionByDefault? = nil) {
+        self.applyServerSideEncryptionByDefault = applyServerSideEncryptionByDefault
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case applyServerSideEncryptionByDefault = "ApplyServerSideEncryptionByDefault"
+    }
+
+    public func validate() throws {
+        try applyServerSideEncryptionByDefault?.validate()
+    }
+}
+
+public struct SourceSelectionCriteria: Codable, Equatable {
+    public var sseKmsEncryptedObjects: SseKmsEncryptedObjects?
+
+    public init(sseKmsEncryptedObjects: SseKmsEncryptedObjects? = nil) {
+        self.sseKmsEncryptedObjects = sseKmsEncryptedObjects
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case sseKmsEncryptedObjects = "SseKmsEncryptedObjects"
+    }
+
+    public func validate() throws {
+        try sseKmsEncryptedObjects?.validate()
+    }
+}
+
+public struct SseKmsEncryptedObjects: Codable, Equatable {
+    public var status: SseKmsEncryptedObjectsStatus
+
+    public init(status: SseKmsEncryptedObjectsStatus) {
+        self.status = status
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case status = "Status"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct Stats: Codable, Equatable {
+    public var bytesProcessed: BytesProcessed?
+    public var bytesReturned: BytesReturned?
+    public var bytesScanned: BytesScanned?
+
+    public init(bytesProcessed: BytesProcessed? = nil,
+                bytesReturned: BytesReturned? = nil,
+                bytesScanned: BytesScanned? = nil) {
+        self.bytesProcessed = bytesProcessed
+        self.bytesReturned = bytesReturned
+        self.bytesScanned = bytesScanned
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bytesProcessed = "BytesProcessed"
+        case bytesReturned = "BytesReturned"
+        case bytesScanned = "BytesScanned"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct StatsEvent: Codable, Equatable {
+    public var details: Stats?
+
+    public init(details: Stats? = nil) {
+        self.details = details
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case details = "Details"
+    }
+
+    public func validate() throws {
+        try details?.validate()
+    }
+}
+
+public struct StorageClassAnalysis: Codable, Equatable {
+    public var dataExport: StorageClassAnalysisDataExport?
+
+    public init(dataExport: StorageClassAnalysisDataExport? = nil) {
+        self.dataExport = dataExport
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case dataExport = "DataExport"
+    }
+
+    public func validate() throws {
+        try dataExport?.validate()
+    }
+}
+
+public struct StorageClassAnalysisDataExport: Codable, Equatable {
+    public var destination: AnalyticsExportDestination
+    public var outputSchemaVersion: StorageClassAnalysisSchemaVersion
+
+    public init(destination: AnalyticsExportDestination,
+                outputSchemaVersion: StorageClassAnalysisSchemaVersion) {
+        self.destination = destination
+        self.outputSchemaVersion = outputSchemaVersion
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case destination = "Destination"
+        case outputSchemaVersion = "OutputSchemaVersion"
+    }
+
+    public func validate() throws {
+        try destination.validate()
+    }
+}
+
+public struct Tag: Codable, Equatable {
+    public var key: ObjectKey
+    public var value: Value
+
+    public init(key: ObjectKey,
+                value: Value) {
+        self.key = key
+        self.value = value
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case key = "Key"
+        case value = "Value"
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct Tagging: Codable, Equatable {
+    public var tagSet: TagSet
+
+    public init(tagSet: TagSet) {
+        self.tagSet = tagSet
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case tagSet = "TagSet"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct TargetGrant: Codable, Equatable {
+    public var grantee: Grantee?
+    public var permission: BucketLogsPermission?
+
+    public init(grantee: Grantee? = nil,
+                permission: BucketLogsPermission? = nil) {
+        self.grantee = grantee
+        self.permission = permission
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case grantee = "Grantee"
+        case permission = "Permission"
+    }
+
+    public func validate() throws {
+        try grantee?.validate()
+    }
+}
+
+public struct TopicConfiguration: Codable, Equatable {
+    public var events: EventList
+    public var filter: NotificationConfigurationFilter?
+    public var id: NotificationId?
+    public var topicArn: TopicArn
+
+    public init(events: EventList,
+                filter: NotificationConfigurationFilter? = nil,
+                id: NotificationId? = nil,
+                topicArn: TopicArn) {
+        self.events = events
+        self.filter = filter
+        self.id = id
+        self.topicArn = topicArn
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case events = "Event"
+        case filter = "Filter"
+        case id = "Id"
+        case topicArn = "Topic"
+    }
+
+    public func validate() throws {
+        try filter?.validate()
+    }
+}
+
+public struct TopicConfigurationDeprecated: Codable, Equatable {
+    public var events: EventList?
+    public var id: NotificationId?
+    public var topic: TopicArn?
+
+    public init(events: EventList? = nil,
+                id: NotificationId? = nil,
+                topic: TopicArn? = nil) {
+        self.events = events
+        self.id = id
+        self.topic = topic
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case events = "Event"
+        case id = "Id"
+        case topic = "Topic"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct Transition: Codable, Equatable {
+    public var date: Date?
+    public var days: Days?
+    public var storageClass: TransitionStorageClass?
+
+    public init(date: Date? = nil,
+                days: Days? = nil,
+                storageClass: TransitionStorageClass? = nil) {
+        self.date = date
+        self.days = days
+        self.storageClass = storageClass
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case date = "Date"
+        case days = "Days"
+        case storageClass = "StorageClass"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct UploadPartCopyOutput: Codable, Equatable {
+    public var copyPartResult: CopyPartResult?
+    public var copySourceVersionId: CopySourceVersionId?
+    public var requestCharged: RequestCharged?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+
+    public init(copyPartResult: CopyPartResult? = nil,
+                copySourceVersionId: CopySourceVersionId? = nil,
+                requestCharged: RequestCharged? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil) {
+        self.copyPartResult = copyPartResult
+        self.copySourceVersionId = copySourceVersionId
+        self.requestCharged = requestCharged
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case copyPartResult = "CopyPartResult"
+        case copySourceVersionId = "x-amz-copy-source-version-id"
+        case requestCharged = "x-amz-request-charged"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+    }
+
+    public func validate() throws {
+        try copyPartResult?.validate()
+    }
+}
+
+public struct UploadPartCopyRequest: Codable, Equatable {
+    public var bucket: BucketName
+    public var copySource: CopySource
+    public var copySourceIfMatch: CopySourceIfMatch?
+    public var copySourceIfModifiedSince: CopySourceIfModifiedSince?
+    public var copySourceIfNoneMatch: CopySourceIfNoneMatch?
+    public var copySourceIfUnmodifiedSince: CopySourceIfUnmodifiedSince?
+    public var copySourceRange: CopySourceRange?
+    public var copySourceSSECustomerAlgorithm: CopySourceSSECustomerAlgorithm?
+    public var copySourceSSECustomerKey: CopySourceSSECustomerKey?
+    public var copySourceSSECustomerKeyMD5: CopySourceSSECustomerKeyMD5?
+    public var key: ObjectKey
+    public var partNumber: PartNumber
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var uploadId: MultipartUploadId
+
+    public init(bucket: BucketName,
+                copySource: CopySource,
+                copySourceIfMatch: CopySourceIfMatch? = nil,
+                copySourceIfModifiedSince: CopySourceIfModifiedSince? = nil,
+                copySourceIfNoneMatch: CopySourceIfNoneMatch? = nil,
+                copySourceIfUnmodifiedSince: CopySourceIfUnmodifiedSince? = nil,
+                copySourceRange: CopySourceRange? = nil,
+                copySourceSSECustomerAlgorithm: CopySourceSSECustomerAlgorithm? = nil,
+                copySourceSSECustomerKey: CopySourceSSECustomerKey? = nil,
+                copySourceSSECustomerKeyMD5: CopySourceSSECustomerKeyMD5? = nil,
+                key: ObjectKey,
+                partNumber: PartNumber,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                uploadId: MultipartUploadId) {
+        self.bucket = bucket
+        self.copySource = copySource
+        self.copySourceIfMatch = copySourceIfMatch
+        self.copySourceIfModifiedSince = copySourceIfModifiedSince
+        self.copySourceIfNoneMatch = copySourceIfNoneMatch
+        self.copySourceIfUnmodifiedSince = copySourceIfUnmodifiedSince
+        self.copySourceRange = copySourceRange
+        self.copySourceSSECustomerAlgorithm = copySourceSSECustomerAlgorithm
+        self.copySourceSSECustomerKey = copySourceSSECustomerKey
+        self.copySourceSSECustomerKeyMD5 = copySourceSSECustomerKeyMD5
+        self.key = key
+        self.partNumber = partNumber
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bucket = "Bucket"
+        case copySource = "x-amz-copy-source"
+        case copySourceIfMatch = "x-amz-copy-source-if-match"
+        case copySourceIfModifiedSince = "x-amz-copy-source-if-modified-since"
+        case copySourceIfNoneMatch = "x-amz-copy-source-if-none-match"
+        case copySourceIfUnmodifiedSince = "x-amz-copy-source-if-unmodified-since"
+        case copySourceRange = "x-amz-copy-source-range"
+        case copySourceSSECustomerAlgorithm = "x-amz-copy-source-server-side-encryption-customer-algorithm"
+        case copySourceSSECustomerKey = "x-amz-copy-source-server-side-encryption-customer-key"
+        case copySourceSSECustomerKeyMD5 = "x-amz-copy-source-server-side-encryption-customer-key-MD5"
+        case key = "Key"
+        case partNumber
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case uploadId
+    }
+
+    public func validate() throws {
+        try copySource.validateAsCopySource()
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct UploadPartOutput: Codable, Equatable {
+    public var eTag: ETag?
+    public var requestCharged: RequestCharged?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var sSEKMSKeyId: SSEKMSKeyId?
+    public var serverSideEncryption: ServerSideEncryption?
+
+    public init(eTag: ETag? = nil,
+                requestCharged: RequestCharged? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                sSEKMSKeyId: SSEKMSKeyId? = nil,
+                serverSideEncryption: ServerSideEncryption? = nil) {
+        self.eTag = eTag
+        self.requestCharged = requestCharged
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.sSEKMSKeyId = sSEKMSKeyId
+        self.serverSideEncryption = serverSideEncryption
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case eTag = "ETag"
+        case requestCharged = "x-amz-request-charged"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case sSEKMSKeyId = "x-amz-server-side-encryption-aws-kms-key-id"
+        case serverSideEncryption = "x-amz-server-side-encryption"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct UploadPartRequest: Codable, Equatable {
+    public var body: Body?
+    public var bucket: BucketName
+    public var contentLength: ContentLength?
+    public var contentMD5: ContentMD5?
+    public var key: ObjectKey
+    public var partNumber: PartNumber
+    public var requestPayer: RequestPayer?
+    public var sSECustomerAlgorithm: SSECustomerAlgorithm?
+    public var sSECustomerKey: SSECustomerKey?
+    public var sSECustomerKeyMD5: SSECustomerKeyMD5?
+    public var uploadId: MultipartUploadId
+
+    public init(body: Body? = nil,
+                bucket: BucketName,
+                contentLength: ContentLength? = nil,
+                contentMD5: ContentMD5? = nil,
+                key: ObjectKey,
+                partNumber: PartNumber,
+                requestPayer: RequestPayer? = nil,
+                sSECustomerAlgorithm: SSECustomerAlgorithm? = nil,
+                sSECustomerKey: SSECustomerKey? = nil,
+                sSECustomerKeyMD5: SSECustomerKeyMD5? = nil,
+                uploadId: MultipartUploadId) {
+        self.body = body
+        self.bucket = bucket
+        self.contentLength = contentLength
+        self.contentMD5 = contentMD5
+        self.key = key
+        self.partNumber = partNumber
+        self.requestPayer = requestPayer
+        self.sSECustomerAlgorithm = sSECustomerAlgorithm
+        self.sSECustomerKey = sSECustomerKey
+        self.sSECustomerKeyMD5 = sSECustomerKeyMD5
+        self.uploadId = uploadId
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case body = "Body"
+        case bucket = "Bucket"
+        case contentLength = "Content-Length"
+        case contentMD5 = "Content-MD5"
+        case key = "Key"
+        case partNumber
+        case requestPayer = "x-amz-request-payer"
+        case sSECustomerAlgorithm = "x-amz-server-side-encryption-customer-algorithm"
+        case sSECustomerKey = "x-amz-server-side-encryption-customer-key"
+        case sSECustomerKeyMD5 = "x-amz-server-side-encryption-customer-key-MD5"
+        case uploadId
+    }
+
+    public func validate() throws {
+        try key.validateAsObjectKey()
+    }
+}
+
+public struct VersioningConfiguration: Codable, Equatable {
+    public var mFADelete: MFADelete?
+    public var status: BucketVersioningStatus?
+
+    public init(mFADelete: MFADelete? = nil,
+                status: BucketVersioningStatus? = nil) {
+        self.mFADelete = mFADelete
+        self.status = status
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case mFADelete = "MfaDelete"
+        case status = "Status"
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct WebsiteConfiguration: Codable, Equatable {
+    public var errorDocument: ErrorDocument?
+    public var indexDocument: IndexDocument?
+    public var redirectAllRequestsTo: RedirectAllRequestsTo?
+    public var routingRules: RoutingRules?
+
+    public init(errorDocument: ErrorDocument? = nil,
+                indexDocument: IndexDocument? = nil,
+                redirectAllRequestsTo: RedirectAllRequestsTo? = nil,
+                routingRules: RoutingRules? = nil) {
+        self.errorDocument = errorDocument
+        self.indexDocument = indexDocument
+        self.redirectAllRequestsTo = redirectAllRequestsTo
+        self.routingRules = routingRules
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case errorDocument = "ErrorDocument"
+        case indexDocument = "IndexDocument"
+        case redirectAllRequestsTo = "RedirectAllRequestsTo"
+        case routingRules = "RoutingRules"
+    }
+
+    public func validate() throws {
+        try errorDocument?.validate()
+        try indexDocument?.validate()
+        try redirectAllRequestsTo?.validate()
+    }
+}

--- a/Sources/S3Model/S3ModelTypes.swift
+++ b/Sources/S3Model/S3ModelTypes.swift
@@ -1,0 +1,1608 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// S3ModelTypes.swift
+// S3Model
+//
+
+import Foundation
+
+/**
+ Type definition for the AbortDate field.
+ */
+public typealias AbortDate = String
+
+/**
+ Type definition for the AbortRuleId field.
+ */
+public typealias AbortRuleId = String
+
+/**
+ Type definition for the AcceptRanges field.
+ */
+public typealias AcceptRanges = String
+
+/**
+ Type definition for the AccountId field.
+ */
+public typealias AccountId = String
+
+/**
+ Type definition for the AllowQuotedRecordDelimiter field.
+ */
+public typealias AllowQuotedRecordDelimiter = Bool
+
+/**
+ Type definition for the AllowedHeader field.
+ */
+public typealias AllowedHeader = String
+
+/**
+ Type definition for the AllowedHeaders field.
+ */
+public typealias AllowedHeaders = [AllowedHeader]
+
+/**
+ Type definition for the AllowedMethod field.
+ */
+public typealias AllowedMethod = String
+
+/**
+ Type definition for the AllowedMethods field.
+ */
+public typealias AllowedMethods = [AllowedMethod]
+
+/**
+ Type definition for the AllowedOrigin field.
+ */
+public typealias AllowedOrigin = String
+
+/**
+ Type definition for the AllowedOrigins field.
+ */
+public typealias AllowedOrigins = [AllowedOrigin]
+
+/**
+ Type definition for the AnalyticsConfigurationList field.
+ */
+public typealias AnalyticsConfigurationList = [AnalyticsConfiguration]
+
+/**
+ Type definition for the AnalyticsId field.
+ */
+public typealias AnalyticsId = String
+
+/**
+ Enumeration restricting the values of the AnalyticsS3ExportFileFormat field.
+ */
+public enum AnalyticsS3ExportFileFormat: String, Codable, CustomStringConvertible {
+    case csv = "CSV"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: AnalyticsS3ExportFileFormat = .csv
+}
+
+/**
+ Type definition for the Body field.
+ */
+public typealias Body = Data
+
+/**
+ Enumeration restricting the values of the BucketAccelerateStatus field.
+ */
+public enum BucketAccelerateStatus: String, Codable, CustomStringConvertible {
+    case enabled = "Enabled"
+    case suspended = "Suspended"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: BucketAccelerateStatus = .enabled
+}
+
+/**
+ Enumeration restricting the values of the BucketCannedACL field.
+ */
+public enum BucketCannedACL: String, Codable, CustomStringConvertible {
+    case authenticatedRead = "authenticated-read"
+    case `private` = "private"
+    case publicRead = "public-read"
+    case publicReadWrite = "public-read-write"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: BucketCannedACL = .authenticatedRead
+}
+
+/**
+ Enumeration restricting the values of the BucketLocationConstraint field.
+ */
+public enum BucketLocationConstraint: String, Codable, CustomStringConvertible {
+    case eu = "EU"
+    case apNortheast1 = "ap-northeast-1"
+    case apSouth1 = "ap-south-1"
+    case apSoutheast1 = "ap-southeast-1"
+    case apSoutheast2 = "ap-southeast-2"
+    case cnNorth1 = "cn-north-1"
+    case euCentral1 = "eu-central-1"
+    case euWest1 = "eu-west-1"
+    case saEast1 = "sa-east-1"
+    case usWest1 = "us-west-1"
+    case usWest2 = "us-west-2"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: BucketLocationConstraint = .eu
+}
+
+/**
+ Enumeration restricting the values of the BucketLogsPermission field.
+ */
+public enum BucketLogsPermission: String, Codable, CustomStringConvertible {
+    case fullControl = "FULL_CONTROL"
+    case read = "READ"
+    case write = "WRITE"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: BucketLogsPermission = .fullControl
+}
+
+/**
+ Type definition for the BucketName field.
+ */
+public typealias BucketName = String
+
+/**
+ Enumeration restricting the values of the BucketVersioningStatus field.
+ */
+public enum BucketVersioningStatus: String, Codable, CustomStringConvertible {
+    case enabled = "Enabled"
+    case suspended = "Suspended"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: BucketVersioningStatus = .enabled
+}
+
+/**
+ Type definition for the Buckets field.
+ */
+public typealias Buckets = [Bucket]
+
+/**
+ Type definition for the BytesProcessed field.
+ */
+public typealias BytesProcessed = Int
+
+/**
+ Type definition for the BytesReturned field.
+ */
+public typealias BytesReturned = Int
+
+/**
+ Type definition for the BytesScanned field.
+ */
+public typealias BytesScanned = Int
+
+/**
+ Type definition for the CORSRules field.
+ */
+public typealias CORSRules = [CORSRule]
+
+/**
+ Type definition for the CacheControl field.
+ */
+public typealias CacheControl = String
+
+/**
+ Type definition for the CloudFunction field.
+ */
+public typealias CloudFunction = String
+
+/**
+ Type definition for the CloudFunctionInvocationRole field.
+ */
+public typealias CloudFunctionInvocationRole = String
+
+/**
+ Type definition for the Code field.
+ */
+public typealias Code = String
+
+/**
+ Type definition for the Comments field.
+ */
+public typealias Comments = String
+
+/**
+ Type definition for the CommonPrefixList field.
+ */
+public typealias CommonPrefixList = [CommonPrefix]
+
+/**
+ Type definition for the CompletedPartList field.
+ */
+public typealias CompletedPartList = [CompletedPart]
+
+/**
+ Enumeration restricting the values of the CompressionType field.
+ */
+public enum CompressionType: String, Codable, CustomStringConvertible {
+    case bzip2 = "BZIP2"
+    case gzip = "GZIP"
+    case none = "NONE"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: CompressionType = .bzip2
+}
+
+/**
+ Type definition for the ConfirmRemoveSelfBucketAccess field.
+ */
+public typealias ConfirmRemoveSelfBucketAccess = Bool
+
+/**
+ Type definition for the ContentDisposition field.
+ */
+public typealias ContentDisposition = String
+
+/**
+ Type definition for the ContentEncoding field.
+ */
+public typealias ContentEncoding = String
+
+/**
+ Type definition for the ContentLanguage field.
+ */
+public typealias ContentLanguage = String
+
+/**
+ Type definition for the ContentLength field.
+ */
+public typealias ContentLength = Int
+
+/**
+ Type definition for the ContentMD5 field.
+ */
+public typealias ContentMD5 = String
+
+/**
+ Type definition for the ContentRange field.
+ */
+public typealias ContentRange = String
+
+/**
+ Type definition for the ContentType field.
+ */
+public typealias ContentType = String
+
+/**
+ Type definition for the CopySource field.
+ */
+public typealias CopySource = String
+
+/**
+ Type definition for the CopySourceIfMatch field.
+ */
+public typealias CopySourceIfMatch = String
+
+/**
+ Type definition for the CopySourceIfModifiedSince field.
+ */
+public typealias CopySourceIfModifiedSince = String
+
+/**
+ Type definition for the CopySourceIfNoneMatch field.
+ */
+public typealias CopySourceIfNoneMatch = String
+
+/**
+ Type definition for the CopySourceIfUnmodifiedSince field.
+ */
+public typealias CopySourceIfUnmodifiedSince = String
+
+/**
+ Type definition for the CopySourceRange field.
+ */
+public typealias CopySourceRange = String
+
+/**
+ Type definition for the CopySourceSSECustomerAlgorithm field.
+ */
+public typealias CopySourceSSECustomerAlgorithm = String
+
+/**
+ Type definition for the CopySourceSSECustomerKey field.
+ */
+public typealias CopySourceSSECustomerKey = String
+
+/**
+ Type definition for the CopySourceSSECustomerKeyMD5 field.
+ */
+public typealias CopySourceSSECustomerKeyMD5 = String
+
+/**
+ Type definition for the CopySourceVersionId field.
+ */
+public typealias CopySourceVersionId = String
+
+/**
+ Type definition for the CreationDate field.
+ */
+public typealias CreationDate = String
+
+/**
+ Type definition for the Date field.
+ */
+public typealias Date = String
+
+/**
+ Type definition for the Days field.
+ */
+public typealias Days = Int
+
+/**
+ Type definition for the DaysAfterInitiation field.
+ */
+public typealias DaysAfterInitiation = Int
+
+/**
+ Type definition for the DeleteMarker field.
+ */
+public typealias DeleteMarker = Bool
+
+/**
+ Enumeration restricting the values of the DeleteMarkerReplicationStatus field.
+ */
+public enum DeleteMarkerReplicationStatus: String, Codable, CustomStringConvertible {
+    case disabled = "Disabled"
+    case enabled = "Enabled"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: DeleteMarkerReplicationStatus = .disabled
+}
+
+/**
+ Type definition for the DeleteMarkerVersionId field.
+ */
+public typealias DeleteMarkerVersionId = String
+
+/**
+ Type definition for the DeleteMarkers field.
+ */
+public typealias DeleteMarkers = [DeleteMarkerEntry]
+
+/**
+ Type definition for the DeletedObjects field.
+ */
+public typealias DeletedObjects = [DeletedObject]
+
+/**
+ Type definition for the Delimiter field.
+ */
+public typealias Delimiter = String
+
+/**
+ Type definition for the Description field.
+ */
+public typealias Description = String
+
+/**
+ Type definition for the DisplayName field.
+ */
+public typealias DisplayName = String
+
+/**
+ Type definition for the ETag field.
+ */
+public typealias ETag = String
+
+/**
+ Type definition for the EmailAddress field.
+ */
+public typealias EmailAddress = String
+
+/**
+ Type definition for the EnableRequestProgress field.
+ */
+public typealias EnableRequestProgress = Bool
+
+/**
+ Enumeration restricting the values of the EncodingType field.
+ */
+public enum EncodingType: String, Codable, CustomStringConvertible {
+    case url
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: EncodingType = .url
+}
+
+/**
+ Type definition for the Errors field.
+ */
+public typealias Errors = [Error]
+
+/**
+ Enumeration restricting the values of the Event field.
+ */
+public enum Event: String, Codable, CustomStringConvertible {
+    case s3ObjectCreatedStar = "s3:ObjectCreated:*"
+    case s3ObjectCreatedCompleteMultipartUpload = "s3:ObjectCreated:CompleteMultipartUpload"
+    case s3ObjectCreatedCopy = "s3:ObjectCreated:Copy"
+    case s3ObjectCreatedPost = "s3:ObjectCreated:Post"
+    case s3ObjectCreatedPut = "s3:ObjectCreated:Put"
+    case s3ObjectRemovedStar = "s3:ObjectRemoved:*"
+    case s3ObjectRemovedDelete = "s3:ObjectRemoved:Delete"
+    case s3ObjectRemovedDeleteMarkerCreated = "s3:ObjectRemoved:DeleteMarkerCreated"
+    case s3ReducedRedundancyLostObject = "s3:ReducedRedundancyLostObject"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: Event = .s3ObjectCreatedStar
+}
+
+/**
+ Type definition for the EventList field.
+ */
+public typealias EventList = [Event]
+
+/**
+ Type definition for the Expiration field.
+ */
+public typealias Expiration = String
+
+/**
+ Enumeration restricting the values of the ExpirationStatus field.
+ */
+public enum ExpirationStatus: String, Codable, CustomStringConvertible {
+    case disabled = "Disabled"
+    case enabled = "Enabled"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: ExpirationStatus = .disabled
+}
+
+/**
+ Type definition for the ExpiredObjectDeleteMarker field.
+ */
+public typealias ExpiredObjectDeleteMarker = Bool
+
+/**
+ Type definition for the Expires field.
+ */
+public typealias Expires = String
+
+/**
+ Type definition for the ExposeHeader field.
+ */
+public typealias ExposeHeader = String
+
+/**
+ Type definition for the ExposeHeaders field.
+ */
+public typealias ExposeHeaders = [ExposeHeader]
+
+/**
+ Type definition for the Expression field.
+ */
+public typealias Expression = String
+
+/**
+ Enumeration restricting the values of the ExpressionType field.
+ */
+public enum ExpressionType: String, Codable, CustomStringConvertible {
+    case sql = "SQL"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: ExpressionType = .sql
+}
+
+/**
+ Type definition for the FetchOwner field.
+ */
+public typealias FetchOwner = Bool
+
+/**
+ Type definition for the FieldDelimiter field.
+ */
+public typealias FieldDelimiter = String
+
+/**
+ Enumeration restricting the values of the FileHeaderInfo field.
+ */
+public enum FileHeaderInfo: String, Codable, CustomStringConvertible {
+    case ignore = "IGNORE"
+    case none = "NONE"
+    case use = "USE"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: FileHeaderInfo = .ignore
+}
+
+/**
+ Type definition for the FilterRuleList field.
+ */
+public typealias FilterRuleList = [FilterRule]
+
+/**
+ Enumeration restricting the values of the FilterRuleName field.
+ */
+public enum FilterRuleName: String, Codable, CustomStringConvertible {
+    case prefix
+    case suffix
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: FilterRuleName = .prefix
+}
+
+/**
+ Type definition for the FilterRuleValue field.
+ */
+public typealias FilterRuleValue = String
+
+/**
+ Type definition for the GrantFullControl field.
+ */
+public typealias GrantFullControl = String
+
+/**
+ Type definition for the GrantRead field.
+ */
+public typealias GrantRead = String
+
+/**
+ Type definition for the GrantReadACP field.
+ */
+public typealias GrantReadACP = String
+
+/**
+ Type definition for the GrantWrite field.
+ */
+public typealias GrantWrite = String
+
+/**
+ Type definition for the GrantWriteACP field.
+ */
+public typealias GrantWriteACP = String
+
+/**
+ Type definition for the Grants field.
+ */
+public typealias Grants = [Grant]
+
+/**
+ Type definition for the HostName field.
+ */
+public typealias HostName = String
+
+/**
+ Type definition for the HttpErrorCodeReturnedEquals field.
+ */
+public typealias HttpErrorCodeReturnedEquals = String
+
+/**
+ Type definition for the HttpRedirectCode field.
+ */
+public typealias HttpRedirectCode = String
+
+/**
+ Type definition for the ID field.
+ */
+public typealias ID = String
+
+/**
+ Type definition for the IfMatch field.
+ */
+public typealias IfMatch = String
+
+/**
+ Type definition for the IfModifiedSince field.
+ */
+public typealias IfModifiedSince = String
+
+/**
+ Type definition for the IfNoneMatch field.
+ */
+public typealias IfNoneMatch = String
+
+/**
+ Type definition for the IfUnmodifiedSince field.
+ */
+public typealias IfUnmodifiedSince = String
+
+/**
+ Type definition for the Initiated field.
+ */
+public typealias Initiated = String
+
+/**
+ Type definition for the InventoryConfigurationList field.
+ */
+public typealias InventoryConfigurationList = [InventoryConfiguration]
+
+/**
+ Enumeration restricting the values of the InventoryFormat field.
+ */
+public enum InventoryFormat: String, Codable, CustomStringConvertible {
+    case csv = "CSV"
+    case orc = "ORC"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: InventoryFormat = .csv
+}
+
+/**
+ Enumeration restricting the values of the InventoryFrequency field.
+ */
+public enum InventoryFrequency: String, Codable, CustomStringConvertible {
+    case daily = "Daily"
+    case weekly = "Weekly"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: InventoryFrequency = .daily
+}
+
+/**
+ Type definition for the InventoryId field.
+ */
+public typealias InventoryId = String
+
+/**
+ Enumeration restricting the values of the InventoryIncludedObjectVersions field.
+ */
+public enum InventoryIncludedObjectVersions: String, Codable, CustomStringConvertible {
+    case all = "All"
+    case current = "Current"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: InventoryIncludedObjectVersions = .all
+}
+
+/**
+ Enumeration restricting the values of the InventoryOptionalField field.
+ */
+public enum InventoryOptionalField: String, Codable, CustomStringConvertible {
+    case etag = "ETag"
+    case encryptionstatus = "EncryptionStatus"
+    case ismultipartuploaded = "IsMultipartUploaded"
+    case lastmodifieddate = "LastModifiedDate"
+    case replicationstatus = "ReplicationStatus"
+    case size = "Size"
+    case storageclass = "StorageClass"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: InventoryOptionalField = .etag
+}
+
+/**
+ Type definition for the InventoryOptionalFields field.
+ */
+public typealias InventoryOptionalFields = [InventoryOptionalField]
+
+/**
+ Type definition for the IsEnabled field.
+ */
+public typealias IsEnabled = Bool
+
+/**
+ Type definition for the IsLatest field.
+ */
+public typealias IsLatest = Bool
+
+/**
+ Type definition for the IsPublic field.
+ */
+public typealias IsPublic = Bool
+
+/**
+ Type definition for the IsTruncated field.
+ */
+public typealias IsTruncated = Bool
+
+/**
+ Enumeration restricting the values of the JSONType field.
+ */
+public enum JSONType: String, Codable, CustomStringConvertible {
+    case document = "DOCUMENT"
+    case lines = "LINES"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: JSONType = .document
+}
+
+/**
+ Type definition for the KMSContext field.
+ */
+public typealias KMSContext = String
+
+/**
+ Type definition for the KeyCount field.
+ */
+public typealias KeyCount = Int
+
+/**
+ Type definition for the KeyMarker field.
+ */
+public typealias KeyMarker = String
+
+/**
+ Type definition for the KeyPrefixEquals field.
+ */
+public typealias KeyPrefixEquals = String
+
+/**
+ Type definition for the LambdaFunctionArn field.
+ */
+public typealias LambdaFunctionArn = String
+
+/**
+ Type definition for the LambdaFunctionConfigurationList field.
+ */
+public typealias LambdaFunctionConfigurationList = [LambdaFunctionConfiguration]
+
+/**
+ Type definition for the LastModified field.
+ */
+public typealias LastModified = String
+
+/**
+ Type definition for the LifecycleRules field.
+ */
+public typealias LifecycleRules = [LifecycleRule]
+
+/**
+ Type definition for the Location field.
+ */
+public typealias Location = String
+
+/**
+ Type definition for the LocationPrefix field.
+ */
+public typealias LocationPrefix = String
+
+/**
+ Type definition for the MFA field.
+ */
+public typealias MFA = String
+
+/**
+ Enumeration restricting the values of the MFADelete field.
+ */
+public enum MFADelete: String, Codable, CustomStringConvertible {
+    case disabled = "Disabled"
+    case enabled = "Enabled"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: MFADelete = .disabled
+}
+
+/**
+ Enumeration restricting the values of the MFADeleteStatus field.
+ */
+public enum MFADeleteStatus: String, Codable, CustomStringConvertible {
+    case disabled = "Disabled"
+    case enabled = "Enabled"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: MFADeleteStatus = .disabled
+}
+
+/**
+ Type definition for the Marker field.
+ */
+public typealias Marker = String
+
+/**
+ Type definition for the MaxAgeSeconds field.
+ */
+public typealias MaxAgeSeconds = Int
+
+/**
+ Type definition for the MaxKeys field.
+ */
+public typealias MaxKeys = Int
+
+/**
+ Type definition for the MaxParts field.
+ */
+public typealias MaxParts = Int
+
+/**
+ Type definition for the MaxUploads field.
+ */
+public typealias MaxUploads = Int
+
+/**
+ Type definition for the Message field.
+ */
+public typealias Message = String
+
+/**
+ Type definition for the Metadata field.
+ */
+public typealias Metadata = [MetadataKey: MetadataValue]
+
+/**
+ Enumeration restricting the values of the MetadataDirective field.
+ */
+public enum MetadataDirective: String, Codable, CustomStringConvertible {
+    case copy = "COPY"
+    case replace = "REPLACE"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: MetadataDirective = .copy
+}
+
+/**
+ Type definition for the MetadataKey field.
+ */
+public typealias MetadataKey = String
+
+/**
+ Type definition for the MetadataValue field.
+ */
+public typealias MetadataValue = String
+
+/**
+ Type definition for the MetricsConfigurationList field.
+ */
+public typealias MetricsConfigurationList = [MetricsConfiguration]
+
+/**
+ Type definition for the MetricsId field.
+ */
+public typealias MetricsId = String
+
+/**
+ Type definition for the MissingMeta field.
+ */
+public typealias MissingMeta = Int
+
+/**
+ Type definition for the MultipartUploadId field.
+ */
+public typealias MultipartUploadId = String
+
+/**
+ Type definition for the MultipartUploadList field.
+ */
+public typealias MultipartUploadList = [MultipartUpload]
+
+/**
+ Type definition for the NextKeyMarker field.
+ */
+public typealias NextKeyMarker = String
+
+/**
+ Type definition for the NextMarker field.
+ */
+public typealias NextMarker = String
+
+/**
+ Type definition for the NextPartNumberMarker field.
+ */
+public typealias NextPartNumberMarker = Int
+
+/**
+ Type definition for the NextToken field.
+ */
+public typealias NextToken = String
+
+/**
+ Type definition for the NextUploadIdMarker field.
+ */
+public typealias NextUploadIdMarker = String
+
+/**
+ Type definition for the NextVersionIdMarker field.
+ */
+public typealias NextVersionIdMarker = String
+
+/**
+ Type definition for the NoncurrentVersionTransitionList field.
+ */
+public typealias NoncurrentVersionTransitionList = [NoncurrentVersionTransition]
+
+/**
+ Type definition for the NotificationId field.
+ */
+public typealias NotificationId = String
+
+/**
+ Enumeration restricting the values of the ObjectCannedACL field.
+ */
+public enum ObjectCannedACL: String, Codable, CustomStringConvertible {
+    case authenticatedRead = "authenticated-read"
+    case awsExecRead = "aws-exec-read"
+    case bucketOwnerFullControl = "bucket-owner-full-control"
+    case bucketOwnerRead = "bucket-owner-read"
+    case `private` = "private"
+    case publicRead = "public-read"
+    case publicReadWrite = "public-read-write"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: ObjectCannedACL = .authenticatedRead
+}
+
+/**
+ Type definition for the ObjectIdentifierList field.
+ */
+public typealias ObjectIdentifierList = [ObjectIdentifier]
+
+/**
+ Type definition for the ObjectKey field.
+ */
+public typealias ObjectKey = String
+
+/**
+ Type definition for the ObjectList field.
+ */
+public typealias ObjectList = [Object]
+
+/**
+ Enumeration restricting the values of the ObjectStorageClass field.
+ */
+public enum ObjectStorageClass: String, Codable, CustomStringConvertible {
+    case glacier = "GLACIER"
+    case onezoneIa = "ONEZONE_IA"
+    case reducedRedundancy = "REDUCED_REDUNDANCY"
+    case standard = "STANDARD"
+    case standardIa = "STANDARD_IA"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: ObjectStorageClass = .glacier
+}
+
+/**
+ Type definition for the ObjectVersionId field.
+ */
+public typealias ObjectVersionId = String
+
+/**
+ Type definition for the ObjectVersionList field.
+ */
+public typealias ObjectVersionList = [ObjectVersion]
+
+/**
+ Enumeration restricting the values of the ObjectVersionStorageClass field.
+ */
+public enum ObjectVersionStorageClass: String, Codable, CustomStringConvertible {
+    case standard = "STANDARD"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: ObjectVersionStorageClass = .standard
+}
+
+/**
+ Enumeration restricting the values of the OwnerOverride field.
+ */
+public enum OwnerOverride: String, Codable, CustomStringConvertible {
+    case destination = "Destination"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: OwnerOverride = .destination
+}
+
+/**
+ Type definition for the PartNumber field.
+ */
+public typealias PartNumber = Int
+
+/**
+ Type definition for the PartNumberMarker field.
+ */
+public typealias PartNumberMarker = Int
+
+/**
+ Type definition for the Parts field.
+ */
+public typealias Parts = [Part]
+
+/**
+ Type definition for the PartsCount field.
+ */
+public typealias PartsCount = Int
+
+/**
+ Enumeration restricting the values of the Payer field.
+ */
+public enum Payer: String, Codable, CustomStringConvertible {
+    case bucketowner = "BucketOwner"
+    case requester = "Requester"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: Payer = .bucketowner
+}
+
+/**
+ Enumeration restricting the values of the Permission field.
+ */
+public enum Permission: String, Codable, CustomStringConvertible {
+    case fullControl = "FULL_CONTROL"
+    case read = "READ"
+    case readAcp = "READ_ACP"
+    case write = "WRITE"
+    case writeAcp = "WRITE_ACP"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: Permission = .fullControl
+}
+
+/**
+ Type definition for the Policy field.
+ */
+public typealias Policy = String
+
+/**
+ Type definition for the Prefix field.
+ */
+public typealias Prefix = String
+
+/**
+ Type definition for the Priority field.
+ */
+public typealias Priority = Int
+
+/**
+ Enumeration restricting the values of the Protocol field.
+ */
+public enum Protocol: String, Codable, CustomStringConvertible {
+    case http
+    case https
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: Protocol = .http
+}
+
+/**
+ Type definition for the QueueArn field.
+ */
+public typealias QueueArn = String
+
+/**
+ Type definition for the QueueConfigurationList field.
+ */
+public typealias QueueConfigurationList = [QueueConfiguration]
+
+/**
+ Type definition for the Quiet field.
+ */
+public typealias Quiet = Bool
+
+/**
+ Type definition for the QuoteCharacter field.
+ */
+public typealias QuoteCharacter = String
+
+/**
+ Type definition for the QuoteEscapeCharacter field.
+ */
+public typealias QuoteEscapeCharacter = String
+
+/**
+ Enumeration restricting the values of the QuoteFields field.
+ */
+public enum QuoteFields: String, Codable, CustomStringConvertible {
+    case always = "ALWAYS"
+    case asneeded = "ASNEEDED"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: QuoteFields = .always
+}
+
+/**
+ Type definition for the Range field.
+ */
+public typealias Range = String
+
+/**
+ Type definition for the RecordDelimiter field.
+ */
+public typealias RecordDelimiter = String
+
+/**
+ Type definition for the ReplaceKeyPrefixWith field.
+ */
+public typealias ReplaceKeyPrefixWith = String
+
+/**
+ Type definition for the ReplaceKeyWith field.
+ */
+public typealias ReplaceKeyWith = String
+
+/**
+ Type definition for the ReplicaKmsKeyID field.
+ */
+public typealias ReplicaKmsKeyID = String
+
+/**
+ Enumeration restricting the values of the ReplicationRuleStatus field.
+ */
+public enum ReplicationRuleStatus: String, Codable, CustomStringConvertible {
+    case disabled = "Disabled"
+    case enabled = "Enabled"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: ReplicationRuleStatus = .disabled
+}
+
+/**
+ Type definition for the ReplicationRules field.
+ */
+public typealias ReplicationRules = [ReplicationRule]
+
+/**
+ Enumeration restricting the values of the ReplicationStatus field.
+ */
+public enum ReplicationStatus: String, Codable, CustomStringConvertible {
+    case complete = "COMPLETE"
+    case failed = "FAILED"
+    case pending = "PENDING"
+    case replica = "REPLICA"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: ReplicationStatus = .complete
+}
+
+/**
+ Enumeration restricting the values of the RequestCharged field.
+ */
+public enum RequestCharged: String, Codable, CustomStringConvertible {
+    case requester
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: RequestCharged = .requester
+}
+
+/**
+ Enumeration restricting the values of the RequestPayer field.
+ */
+public enum RequestPayer: String, Codable, CustomStringConvertible {
+    case requester
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: RequestPayer = .requester
+}
+
+/**
+ Type definition for the ResponseCacheControl field.
+ */
+public typealias ResponseCacheControl = String
+
+/**
+ Type definition for the ResponseContentDisposition field.
+ */
+public typealias ResponseContentDisposition = String
+
+/**
+ Type definition for the ResponseContentEncoding field.
+ */
+public typealias ResponseContentEncoding = String
+
+/**
+ Type definition for the ResponseContentLanguage field.
+ */
+public typealias ResponseContentLanguage = String
+
+/**
+ Type definition for the ResponseContentType field.
+ */
+public typealias ResponseContentType = String
+
+/**
+ Type definition for the ResponseExpires field.
+ */
+public typealias ResponseExpires = String
+
+/**
+ Type definition for the Restore field.
+ */
+public typealias Restore = String
+
+/**
+ Type definition for the RestoreOutputPath field.
+ */
+public typealias RestoreOutputPath = String
+
+/**
+ Enumeration restricting the values of the RestoreRequestType field.
+ */
+public enum RestoreRequestType: String, Codable, CustomStringConvertible {
+    case select = "SELECT"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: RestoreRequestType = .select
+}
+
+/**
+ Type definition for the Role field.
+ */
+public typealias Role = String
+
+/**
+ Type definition for the RoutingRules field.
+ */
+public typealias RoutingRules = [RoutingRule]
+
+/**
+ Type definition for the Rules field.
+ */
+public typealias Rules = [Rule]
+
+/**
+ Type definition for the SSECustomerAlgorithm field.
+ */
+public typealias SSECustomerAlgorithm = String
+
+/**
+ Type definition for the SSECustomerKey field.
+ */
+public typealias SSECustomerKey = String
+
+/**
+ Type definition for the SSECustomerKeyMD5 field.
+ */
+public typealias SSECustomerKeyMD5 = String
+
+/**
+ Type definition for the SSEKMSKeyId field.
+ */
+public typealias SSEKMSKeyId = String
+
+/**
+ Enumeration restricting the values of the ServerSideEncryption field.
+ */
+public enum ServerSideEncryption: String, Codable, CustomStringConvertible {
+    case aes256 = "AES256"
+    case awsKms = "aws:kms"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: ServerSideEncryption = .aes256
+}
+
+/**
+ Type definition for the ServerSideEncryptionRules field.
+ */
+public typealias ServerSideEncryptionRules = [ServerSideEncryptionRule]
+
+/**
+ Type definition for the Setting field.
+ */
+public typealias Setting = Bool
+
+/**
+ Type definition for the Size field.
+ */
+public typealias Size = Int
+
+/**
+ Enumeration restricting the values of the SseKmsEncryptedObjectsStatus field.
+ */
+public enum SseKmsEncryptedObjectsStatus: String, Codable, CustomStringConvertible {
+    case disabled = "Disabled"
+    case enabled = "Enabled"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: SseKmsEncryptedObjectsStatus = .disabled
+}
+
+/**
+ Type definition for the StartAfter field.
+ */
+public typealias StartAfter = String
+
+/**
+ Enumeration restricting the values of the StorageClass field.
+ */
+public enum StorageClass: String, Codable, CustomStringConvertible {
+    case onezoneIa = "ONEZONE_IA"
+    case reducedRedundancy = "REDUCED_REDUNDANCY"
+    case standard = "STANDARD"
+    case standardIa = "STANDARD_IA"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: StorageClass = .onezoneIa
+}
+
+/**
+ Enumeration restricting the values of the StorageClassAnalysisSchemaVersion field.
+ */
+public enum StorageClassAnalysisSchemaVersion: String, Codable, CustomStringConvertible {
+    case v1 = "V_1"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: StorageClassAnalysisSchemaVersion = .v1
+}
+
+/**
+ Type definition for the Suffix field.
+ */
+public typealias Suffix = String
+
+/**
+ Type definition for the TagCount field.
+ */
+public typealias TagCount = Int
+
+/**
+ Type definition for the TagSet field.
+ */
+public typealias TagSet = [Tag]
+
+/**
+ Enumeration restricting the values of the TaggingDirective field.
+ */
+public enum TaggingDirective: String, Codable, CustomStringConvertible {
+    case copy = "COPY"
+    case replace = "REPLACE"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: TaggingDirective = .copy
+}
+
+/**
+ Type definition for the TaggingHeader field.
+ */
+public typealias TaggingHeader = String
+
+/**
+ Type definition for the TargetBucket field.
+ */
+public typealias TargetBucket = String
+
+/**
+ Type definition for the TargetGrants field.
+ */
+public typealias TargetGrants = [TargetGrant]
+
+/**
+ Type definition for the TargetPrefix field.
+ */
+public typealias TargetPrefix = String
+
+/**
+ Enumeration restricting the values of the Tier field.
+ */
+public enum Tier: String, Codable, CustomStringConvertible {
+    case bulk = "Bulk"
+    case expedited = "Expedited"
+    case standard = "Standard"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: Tier = .bulk
+}
+
+/**
+ Type definition for the Token field.
+ */
+public typealias Token = String
+
+/**
+ Type definition for the TopicArn field.
+ */
+public typealias TopicArn = String
+
+/**
+ Type definition for the TopicConfigurationList field.
+ */
+public typealias TopicConfigurationList = [TopicConfiguration]
+
+/**
+ Type definition for the TransitionList field.
+ */
+public typealias TransitionList = [Transition]
+
+/**
+ Enumeration restricting the values of the TransitionStorageClass field.
+ */
+public enum TransitionStorageClass: String, Codable, CustomStringConvertible {
+    case glacier = "GLACIER"
+    case onezoneIa = "ONEZONE_IA"
+    case standardIa = "STANDARD_IA"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: TransitionStorageClass = .glacier
+}
+
+/**
+ Enumeration restricting the values of the Type field.
+ */
+public enum Type: String, Codable, CustomStringConvertible {
+    case amazoncustomerbyemail = "AmazonCustomerByEmail"
+    case canonicaluser = "CanonicalUser"
+    case group = "Group"
+
+    public var description: String {
+        return rawValue
+    }
+    
+    public static let __default: Type = .amazoncustomerbyemail
+}
+
+/**
+ Type definition for the URI field.
+ */
+public typealias URI = String
+
+/**
+ Type definition for the UploadIdMarker field.
+ */
+public typealias UploadIdMarker = String
+
+/**
+ Type definition for the UserMetadata field.
+ */
+public typealias UserMetadata = [MetadataEntry]
+
+/**
+ Type definition for the Value field.
+ */
+public typealias Value = String
+
+/**
+ Type definition for the VersionIdMarker field.
+ */
+public typealias VersionIdMarker = String
+
+/**
+ Type definition for the WebsiteRedirectLocation field.
+ */
+public typealias WebsiteRedirectLocation = String
+
+/**
+ Validation for the CopySource field.
+*/
+extension S3Model.CopySource {
+    public func validateAsCopySource() throws {
+        guard let matchingRange = self.range(of: "\\/.+\\/.+", options: .regularExpression),
+            matchingRange == startIndex..<endIndex else {
+                throw S3CodingError.validationError(reason: "The provided value to CopySource violated the regular expression constraint.")
+        }
+    }
+}
+
+/**
+ Validation for the ObjectKey field.
+*/
+extension S3Model.ObjectKey {
+    public func validateAsObjectKey() throws {
+        if self.count < 1 {
+            throw S3CodingError.validationError(reason: "The provided value to ObjectKey violated the minimum length constraint.")
+        }
+
+    }
+}

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
@@ -66,6 +66,22 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
     }
 
     /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times.
+     */
+    public func close() {
+        httpClient.close()
+    }
+
+    /**
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
+     */
+    public func wait() {
+        httpClient.wait()
+    }
+
+    /**
      Invokes the AssumeRole operation returning immediately and passing the response to a callback.
 
      - Parameters:
@@ -82,7 +98,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssumeRoleOperationHTTPRequestInput<SecurityTokenModel.AssumeRoleRequest>(encodable: input)
+        let wrappedInput = AssumeRoleOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -113,7 +129,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssumeRoleOperationHTTPRequestInput<SecurityTokenModel.AssumeRoleRequest>(encodable: input)
+        let wrappedInput = AssumeRoleOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -144,7 +160,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssumeRoleWithSAMLOperationHTTPRequestInput<SecurityTokenModel.AssumeRoleWithSAMLRequest>(encodable: input)
+        let wrappedInput = AssumeRoleWithSAMLOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -175,7 +191,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssumeRoleWithSAMLOperationHTTPRequestInput<SecurityTokenModel.AssumeRoleWithSAMLRequest>(encodable: input)
+        let wrappedInput = AssumeRoleWithSAMLOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -206,7 +222,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssumeRoleWithWebIdentityOperationHTTPRequestInput<SecurityTokenModel.AssumeRoleWithWebIdentityRequest>(encodable: input)
+        let wrappedInput = AssumeRoleWithWebIdentityOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -237,7 +253,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AssumeRoleWithWebIdentityOperationHTTPRequestInput<SecurityTokenModel.AssumeRoleWithWebIdentityRequest>(encodable: input)
+        let wrappedInput = AssumeRoleWithWebIdentityOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -268,7 +284,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DecodeAuthorizationMessageOperationHTTPRequestInput<SecurityTokenModel.DecodeAuthorizationMessageRequest>(encodable: input)
+        let wrappedInput = DecodeAuthorizationMessageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -299,7 +315,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DecodeAuthorizationMessageOperationHTTPRequestInput<SecurityTokenModel.DecodeAuthorizationMessageRequest>(encodable: input)
+        let wrappedInput = DecodeAuthorizationMessageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -329,7 +345,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetCallerIdentityOperationHTTPRequestInput<SecurityTokenModel.GetCallerIdentityRequest>(encodable: input)
+        let wrappedInput = GetCallerIdentityOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -359,7 +375,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetCallerIdentityOperationHTTPRequestInput<SecurityTokenModel.GetCallerIdentityRequest>(encodable: input)
+        let wrappedInput = GetCallerIdentityOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -390,7 +406,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetFederationTokenOperationHTTPRequestInput<SecurityTokenModel.GetFederationTokenRequest>(encodable: input)
+        let wrappedInput = GetFederationTokenOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -421,7 +437,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetFederationTokenOperationHTTPRequestInput<SecurityTokenModel.GetFederationTokenRequest>(encodable: input)
+        let wrappedInput = GetFederationTokenOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -452,7 +468,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetSessionTokenOperationHTTPRequestInput<SecurityTokenModel.GetSessionTokenRequest>(encodable: input)
+        let wrappedInput = GetSessionTokenOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -483,7 +499,7 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetSessionTokenOperationHTTPRequestInput<SecurityTokenModel.GetSessionTokenRequest>(encodable: input)
+        let wrappedInput = GetSessionTokenOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,

--- a/Sources/SecurityTokenClient/SecurityTokenOperationsClientOutput.swift
+++ b/Sources/SecurityTokenClient/SecurityTokenOperationsClientOutput.swift
@@ -1,0 +1,116 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// SecurityTokenOperationsClientOutput.swift
+// SecurityTokenClient
+//
+
+import Foundation
+import SmokeHTTPClient
+import SecurityTokenModel
+
+/**
+ Type to handle the output from the AssumeRole operation in a HTTP client.
+ */
+extension AssumeRoleResponseForAssumeRole: HTTPResponseOutputProtocol {
+    public typealias BodyType = AssumeRoleResponseForAssumeRole
+    public typealias HeadersType = AssumeRoleResponseForAssumeRole
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AssumeRoleResponseForAssumeRole {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AssumeRoleWithSAML operation in a HTTP client.
+ */
+extension AssumeRoleWithSAMLResponseForAssumeRoleWithSAML: HTTPResponseOutputProtocol {
+    public typealias BodyType = AssumeRoleWithSAMLResponseForAssumeRoleWithSAML
+    public typealias HeadersType = AssumeRoleWithSAMLResponseForAssumeRoleWithSAML
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AssumeRoleWithSAMLResponseForAssumeRoleWithSAML {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the AssumeRoleWithWebIdentity operation in a HTTP client.
+ */
+extension AssumeRoleWithWebIdentityResponseForAssumeRoleWithWebIdentity: HTTPResponseOutputProtocol {
+    public typealias BodyType = AssumeRoleWithWebIdentityResponseForAssumeRoleWithWebIdentity
+    public typealias HeadersType = AssumeRoleWithWebIdentityResponseForAssumeRoleWithWebIdentity
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> AssumeRoleWithWebIdentityResponseForAssumeRoleWithWebIdentity {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DecodeAuthorizationMessage operation in a HTTP client.
+ */
+extension DecodeAuthorizationMessageResponseForDecodeAuthorizationMessage: HTTPResponseOutputProtocol {
+    public typealias BodyType = DecodeAuthorizationMessageResponseForDecodeAuthorizationMessage
+    public typealias HeadersType = DecodeAuthorizationMessageResponseForDecodeAuthorizationMessage
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DecodeAuthorizationMessageResponseForDecodeAuthorizationMessage {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetCallerIdentity operation in a HTTP client.
+ */
+extension GetCallerIdentityResponseForGetCallerIdentity: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetCallerIdentityResponseForGetCallerIdentity
+    public typealias HeadersType = GetCallerIdentityResponseForGetCallerIdentity
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetCallerIdentityResponseForGetCallerIdentity {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetFederationToken operation in a HTTP client.
+ */
+extension GetFederationTokenResponseForGetFederationToken: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetFederationTokenResponseForGetFederationToken
+    public typealias HeadersType = GetFederationTokenResponseForGetFederationToken
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetFederationTokenResponseForGetFederationToken {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetSessionToken operation in a HTTP client.
+ */
+extension GetSessionTokenResponseForGetSessionToken: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetSessionTokenResponseForGetSessionToken
+    public typealias HeadersType = GetSessionTokenResponseForGetSessionToken
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetSessionTokenResponseForGetSessionToken {
+        return try bodyDecodableProvider()
+    }
+}
+

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
@@ -66,6 +66,22 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
     }
 
     /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times.
+     */
+    public func close() {
+        httpClient.close()
+    }
+
+    /**
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
+     */
+    public func wait() {
+        httpClient.wait()
+    }
+
+    /**
      Invokes the AddPermission operation returning immediately and passing the response to a callback.
 
      - Parameters:
@@ -74,14 +90,14 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func addPermissionAsync(input: SimpleNotificationModel.AddPermissionInput, completion: @escaping (Error?) -> ()) throws {
+    public func addPermissionAsync(input: SimpleNotificationModel.AddPermissionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = AddPermissionOperationHTTPRequestInput<SimpleNotificationModel.AddPermissionInput>(encodable: input)
+        let wrappedInput = AddPermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -110,7 +126,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AddPermissionOperationHTTPRequestInput<SimpleNotificationModel.AddPermissionInput>(encodable: input)
+        let wrappedInput = AddPermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -141,7 +157,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CheckIfPhoneNumberIsOptedOutOperationHTTPRequestInput<SimpleNotificationModel.CheckIfPhoneNumberIsOptedOutInput>(encodable: input)
+        let wrappedInput = CheckIfPhoneNumberIsOptedOutOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -172,7 +188,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CheckIfPhoneNumberIsOptedOutOperationHTTPRequestInput<SimpleNotificationModel.CheckIfPhoneNumberIsOptedOutInput>(encodable: input)
+        let wrappedInput = CheckIfPhoneNumberIsOptedOutOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -203,7 +219,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ConfirmSubscriptionOperationHTTPRequestInput<SimpleNotificationModel.ConfirmSubscriptionInput>(encodable: input)
+        let wrappedInput = ConfirmSubscriptionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -234,7 +250,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ConfirmSubscriptionOperationHTTPRequestInput<SimpleNotificationModel.ConfirmSubscriptionInput>(encodable: input)
+        let wrappedInput = ConfirmSubscriptionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -265,7 +281,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreatePlatformApplicationOperationHTTPRequestInput<SimpleNotificationModel.CreatePlatformApplicationInput>(encodable: input)
+        let wrappedInput = CreatePlatformApplicationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -296,7 +312,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreatePlatformApplicationOperationHTTPRequestInput<SimpleNotificationModel.CreatePlatformApplicationInput>(encodable: input)
+        let wrappedInput = CreatePlatformApplicationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -327,7 +343,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreatePlatformEndpointOperationHTTPRequestInput<SimpleNotificationModel.CreatePlatformEndpointInput>(encodable: input)
+        let wrappedInput = CreatePlatformEndpointOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -358,7 +374,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreatePlatformEndpointOperationHTTPRequestInput<SimpleNotificationModel.CreatePlatformEndpointInput>(encodable: input)
+        let wrappedInput = CreatePlatformEndpointOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -389,7 +405,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateTopicOperationHTTPRequestInput<SimpleNotificationModel.CreateTopicInput>(encodable: input)
+        let wrappedInput = CreateTopicOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -420,7 +436,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateTopicOperationHTTPRequestInput<SimpleNotificationModel.CreateTopicInput>(encodable: input)
+        let wrappedInput = CreateTopicOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -443,14 +459,14 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter.
      */
-    public func deleteEndpointAsync(input: SimpleNotificationModel.DeleteEndpointInput, completion: @escaping (Error?) -> ()) throws {
+    public func deleteEndpointAsync(input: SimpleNotificationModel.DeleteEndpointInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteEndpointOperationHTTPRequestInput<SimpleNotificationModel.DeleteEndpointInput>(encodable: input)
+        let wrappedInput = DeleteEndpointOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -479,7 +495,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteEndpointOperationHTTPRequestInput<SimpleNotificationModel.DeleteEndpointInput>(encodable: input)
+        let wrappedInput = DeleteEndpointOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -502,14 +518,14 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter.
      */
-    public func deletePlatformApplicationAsync(input: SimpleNotificationModel.DeletePlatformApplicationInput, completion: @escaping (Error?) -> ()) throws {
+    public func deletePlatformApplicationAsync(input: SimpleNotificationModel.DeletePlatformApplicationInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeletePlatformApplicationOperationHTTPRequestInput<SimpleNotificationModel.DeletePlatformApplicationInput>(encodable: input)
+        let wrappedInput = DeletePlatformApplicationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -538,7 +554,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeletePlatformApplicationOperationHTTPRequestInput<SimpleNotificationModel.DeletePlatformApplicationInput>(encodable: input)
+        let wrappedInput = DeletePlatformApplicationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -561,14 +577,14 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func deleteTopicAsync(input: SimpleNotificationModel.DeleteTopicInput, completion: @escaping (Error?) -> ()) throws {
+    public func deleteTopicAsync(input: SimpleNotificationModel.DeleteTopicInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteTopicOperationHTTPRequestInput<SimpleNotificationModel.DeleteTopicInput>(encodable: input)
+        let wrappedInput = DeleteTopicOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -597,7 +613,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteTopicOperationHTTPRequestInput<SimpleNotificationModel.DeleteTopicInput>(encodable: input)
+        let wrappedInput = DeleteTopicOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -628,7 +644,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetEndpointAttributesOperationHTTPRequestInput<SimpleNotificationModel.GetEndpointAttributesInput>(encodable: input)
+        let wrappedInput = GetEndpointAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -659,7 +675,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetEndpointAttributesOperationHTTPRequestInput<SimpleNotificationModel.GetEndpointAttributesInput>(encodable: input)
+        let wrappedInput = GetEndpointAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -690,7 +706,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetPlatformApplicationAttributesOperationHTTPRequestInput<SimpleNotificationModel.GetPlatformApplicationAttributesInput>(encodable: input)
+        let wrappedInput = GetPlatformApplicationAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -721,7 +737,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetPlatformApplicationAttributesOperationHTTPRequestInput<SimpleNotificationModel.GetPlatformApplicationAttributesInput>(encodable: input)
+        let wrappedInput = GetPlatformApplicationAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -752,7 +768,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetSMSAttributesOperationHTTPRequestInput<SimpleNotificationModel.GetSMSAttributesInput>(encodable: input)
+        let wrappedInput = GetSMSAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -783,7 +799,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetSMSAttributesOperationHTTPRequestInput<SimpleNotificationModel.GetSMSAttributesInput>(encodable: input)
+        let wrappedInput = GetSMSAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -814,7 +830,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetSubscriptionAttributesOperationHTTPRequestInput<SimpleNotificationModel.GetSubscriptionAttributesInput>(encodable: input)
+        let wrappedInput = GetSubscriptionAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -845,7 +861,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetSubscriptionAttributesOperationHTTPRequestInput<SimpleNotificationModel.GetSubscriptionAttributesInput>(encodable: input)
+        let wrappedInput = GetSubscriptionAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -876,7 +892,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetTopicAttributesOperationHTTPRequestInput<SimpleNotificationModel.GetTopicAttributesInput>(encodable: input)
+        let wrappedInput = GetTopicAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -907,7 +923,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetTopicAttributesOperationHTTPRequestInput<SimpleNotificationModel.GetTopicAttributesInput>(encodable: input)
+        let wrappedInput = GetTopicAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -938,7 +954,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListEndpointsByPlatformApplicationOperationHTTPRequestInput<SimpleNotificationModel.ListEndpointsByPlatformApplicationInput>(encodable: input)
+        let wrappedInput = ListEndpointsByPlatformApplicationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -969,7 +985,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListEndpointsByPlatformApplicationOperationHTTPRequestInput<SimpleNotificationModel.ListEndpointsByPlatformApplicationInput>(encodable: input)
+        let wrappedInput = ListEndpointsByPlatformApplicationOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1000,7 +1016,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListPhoneNumbersOptedOutOperationHTTPRequestInput<SimpleNotificationModel.ListPhoneNumbersOptedOutInput>(encodable: input)
+        let wrappedInput = ListPhoneNumbersOptedOutOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1031,7 +1047,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListPhoneNumbersOptedOutOperationHTTPRequestInput<SimpleNotificationModel.ListPhoneNumbersOptedOutInput>(encodable: input)
+        let wrappedInput = ListPhoneNumbersOptedOutOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1062,7 +1078,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListPlatformApplicationsOperationHTTPRequestInput<SimpleNotificationModel.ListPlatformApplicationsInput>(encodable: input)
+        let wrappedInput = ListPlatformApplicationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1093,7 +1109,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListPlatformApplicationsOperationHTTPRequestInput<SimpleNotificationModel.ListPlatformApplicationsInput>(encodable: input)
+        let wrappedInput = ListPlatformApplicationsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1124,7 +1140,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListSubscriptionsOperationHTTPRequestInput<SimpleNotificationModel.ListSubscriptionsInput>(encodable: input)
+        let wrappedInput = ListSubscriptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1155,7 +1171,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListSubscriptionsOperationHTTPRequestInput<SimpleNotificationModel.ListSubscriptionsInput>(encodable: input)
+        let wrappedInput = ListSubscriptionsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1186,7 +1202,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListSubscriptionsByTopicOperationHTTPRequestInput<SimpleNotificationModel.ListSubscriptionsByTopicInput>(encodable: input)
+        let wrappedInput = ListSubscriptionsByTopicOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1217,7 +1233,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListSubscriptionsByTopicOperationHTTPRequestInput<SimpleNotificationModel.ListSubscriptionsByTopicInput>(encodable: input)
+        let wrappedInput = ListSubscriptionsByTopicOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1248,7 +1264,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListTopicsOperationHTTPRequestInput<SimpleNotificationModel.ListTopicsInput>(encodable: input)
+        let wrappedInput = ListTopicsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1279,7 +1295,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListTopicsOperationHTTPRequestInput<SimpleNotificationModel.ListTopicsInput>(encodable: input)
+        let wrappedInput = ListTopicsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1310,7 +1326,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = OptInPhoneNumberOperationHTTPRequestInput<SimpleNotificationModel.OptInPhoneNumberInput>(encodable: input)
+        let wrappedInput = OptInPhoneNumberOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1341,7 +1357,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = OptInPhoneNumberOperationHTTPRequestInput<SimpleNotificationModel.OptInPhoneNumberInput>(encodable: input)
+        let wrappedInput = OptInPhoneNumberOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1372,7 +1388,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PublishOperationHTTPRequestInput<SimpleNotificationModel.PublishInput>(encodable: input)
+        let wrappedInput = PublishOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1403,7 +1419,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PublishOperationHTTPRequestInput<SimpleNotificationModel.PublishInput>(encodable: input)
+        let wrappedInput = PublishOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1426,14 +1442,14 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func removePermissionAsync(input: SimpleNotificationModel.RemovePermissionInput, completion: @escaping (Error?) -> ()) throws {
+    public func removePermissionAsync(input: SimpleNotificationModel.RemovePermissionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = RemovePermissionOperationHTTPRequestInput<SimpleNotificationModel.RemovePermissionInput>(encodable: input)
+        let wrappedInput = RemovePermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1462,7 +1478,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RemovePermissionOperationHTTPRequestInput<SimpleNotificationModel.RemovePermissionInput>(encodable: input)
+        let wrappedInput = RemovePermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1485,14 +1501,14 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func setEndpointAttributesAsync(input: SimpleNotificationModel.SetEndpointAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setEndpointAttributesAsync(input: SimpleNotificationModel.SetEndpointAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = SetEndpointAttributesOperationHTTPRequestInput<SimpleNotificationModel.SetEndpointAttributesInput>(encodable: input)
+        let wrappedInput = SetEndpointAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1521,7 +1537,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SetEndpointAttributesOperationHTTPRequestInput<SimpleNotificationModel.SetEndpointAttributesInput>(encodable: input)
+        let wrappedInput = SetEndpointAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1544,14 +1560,14 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func setPlatformApplicationAttributesAsync(input: SimpleNotificationModel.SetPlatformApplicationAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setPlatformApplicationAttributesAsync(input: SimpleNotificationModel.SetPlatformApplicationAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = SetPlatformApplicationAttributesOperationHTTPRequestInput<SimpleNotificationModel.SetPlatformApplicationAttributesInput>(encodable: input)
+        let wrappedInput = SetPlatformApplicationAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1580,7 +1596,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SetPlatformApplicationAttributesOperationHTTPRequestInput<SimpleNotificationModel.SetPlatformApplicationAttributesInput>(encodable: input)
+        let wrappedInput = SetPlatformApplicationAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1611,7 +1627,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SetSMSAttributesOperationHTTPRequestInput<SimpleNotificationModel.SetSMSAttributesInput>(encodable: input)
+        let wrappedInput = SetSMSAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1642,7 +1658,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SetSMSAttributesOperationHTTPRequestInput<SimpleNotificationModel.SetSMSAttributesInput>(encodable: input)
+        let wrappedInput = SetSMSAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1665,14 +1681,14 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, filterPolicyLimitExceeded, internalError, invalidParameter, notFound.
      */
-    public func setSubscriptionAttributesAsync(input: SimpleNotificationModel.SetSubscriptionAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setSubscriptionAttributesAsync(input: SimpleNotificationModel.SetSubscriptionAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = SetSubscriptionAttributesOperationHTTPRequestInput<SimpleNotificationModel.SetSubscriptionAttributesInput>(encodable: input)
+        let wrappedInput = SetSubscriptionAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1701,7 +1717,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SetSubscriptionAttributesOperationHTTPRequestInput<SimpleNotificationModel.SetSubscriptionAttributesInput>(encodable: input)
+        let wrappedInput = SetSubscriptionAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1724,14 +1740,14 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, invalidSecurity, notFound.
      */
-    public func setTopicAttributesAsync(input: SimpleNotificationModel.SetTopicAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setTopicAttributesAsync(input: SimpleNotificationModel.SetTopicAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = SetTopicAttributesOperationHTTPRequestInput<SimpleNotificationModel.SetTopicAttributesInput>(encodable: input)
+        let wrappedInput = SetTopicAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1760,7 +1776,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SetTopicAttributesOperationHTTPRequestInput<SimpleNotificationModel.SetTopicAttributesInput>(encodable: input)
+        let wrappedInput = SetTopicAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1791,7 +1807,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SubscribeOperationHTTPRequestInput<SimpleNotificationModel.SubscribeInput>(encodable: input)
+        let wrappedInput = SubscribeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1822,7 +1838,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SubscribeOperationHTTPRequestInput<SimpleNotificationModel.SubscribeInput>(encodable: input)
+        let wrappedInput = SubscribeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1845,14 +1861,14 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, invalidSecurity, notFound.
      */
-    public func unsubscribeAsync(input: SimpleNotificationModel.UnsubscribeInput, completion: @escaping (Error?) -> ()) throws {
+    public func unsubscribeAsync(input: SimpleNotificationModel.UnsubscribeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = UnsubscribeOperationHTTPRequestInput<SimpleNotificationModel.UnsubscribeInput>(encodable: input)
+        let wrappedInput = UnsubscribeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1881,7 +1897,7 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UnsubscribeOperationHTTPRequestInput<SimpleNotificationModel.UnsubscribeInput>(encodable: input)
+        let wrappedInput = UnsubscribeOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,

--- a/Sources/SimpleNotificationClient/MockSimpleNotificationClient.swift
+++ b/Sources/SimpleNotificationClient/MockSimpleNotificationClient.swift
@@ -224,7 +224,7 @@ public struct MockSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func addPermissionAsync(input: SimpleNotificationModel.AddPermissionInput, completion: @escaping (Error?) -> ()) throws {
+    public func addPermissionAsync(input: SimpleNotificationModel.AddPermissionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let addPermissionAsyncOverride = addPermissionAsyncOverride {
             return try addPermissionAsyncOverride(input, completion)
         }
@@ -440,7 +440,7 @@ public struct MockSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter.
      */
-    public func deleteEndpointAsync(input: SimpleNotificationModel.DeleteEndpointInput, completion: @escaping (Error?) -> ()) throws {
+    public func deleteEndpointAsync(input: SimpleNotificationModel.DeleteEndpointInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteEndpointAsyncOverride = deleteEndpointAsyncOverride {
             return try deleteEndpointAsyncOverride(input, completion)
         }
@@ -471,7 +471,7 @@ public struct MockSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter.
      */
-    public func deletePlatformApplicationAsync(input: SimpleNotificationModel.DeletePlatformApplicationInput, completion: @escaping (Error?) -> ()) throws {
+    public func deletePlatformApplicationAsync(input: SimpleNotificationModel.DeletePlatformApplicationInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deletePlatformApplicationAsyncOverride = deletePlatformApplicationAsyncOverride {
             return try deletePlatformApplicationAsyncOverride(input, completion)
         }
@@ -502,7 +502,7 @@ public struct MockSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func deleteTopicAsync(input: SimpleNotificationModel.DeleteTopicInput, completion: @escaping (Error?) -> ()) throws {
+    public func deleteTopicAsync(input: SimpleNotificationModel.DeleteTopicInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteTopicAsyncOverride = deleteTopicAsyncOverride {
             return try deleteTopicAsyncOverride(input, completion)
         }
@@ -1014,7 +1014,7 @@ public struct MockSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func removePermissionAsync(input: SimpleNotificationModel.RemovePermissionInput, completion: @escaping (Error?) -> ()) throws {
+    public func removePermissionAsync(input: SimpleNotificationModel.RemovePermissionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let removePermissionAsyncOverride = removePermissionAsyncOverride {
             return try removePermissionAsyncOverride(input, completion)
         }
@@ -1045,7 +1045,7 @@ public struct MockSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func setEndpointAttributesAsync(input: SimpleNotificationModel.SetEndpointAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setEndpointAttributesAsync(input: SimpleNotificationModel.SetEndpointAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setEndpointAttributesAsyncOverride = setEndpointAttributesAsyncOverride {
             return try setEndpointAttributesAsyncOverride(input, completion)
         }
@@ -1076,7 +1076,7 @@ public struct MockSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func setPlatformApplicationAttributesAsync(input: SimpleNotificationModel.SetPlatformApplicationAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setPlatformApplicationAttributesAsync(input: SimpleNotificationModel.SetPlatformApplicationAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setPlatformApplicationAttributesAsyncOverride = setPlatformApplicationAttributesAsyncOverride {
             return try setPlatformApplicationAttributesAsyncOverride(input, completion)
         }
@@ -1144,7 +1144,7 @@ public struct MockSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, filterPolicyLimitExceeded, internalError, invalidParameter, notFound.
      */
-    public func setSubscriptionAttributesAsync(input: SimpleNotificationModel.SetSubscriptionAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setSubscriptionAttributesAsync(input: SimpleNotificationModel.SetSubscriptionAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setSubscriptionAttributesAsyncOverride = setSubscriptionAttributesAsyncOverride {
             return try setSubscriptionAttributesAsyncOverride(input, completion)
         }
@@ -1175,7 +1175,7 @@ public struct MockSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, invalidSecurity, notFound.
      */
-    public func setTopicAttributesAsync(input: SimpleNotificationModel.SetTopicAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setTopicAttributesAsync(input: SimpleNotificationModel.SetTopicAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setTopicAttributesAsyncOverride = setTopicAttributesAsyncOverride {
             return try setTopicAttributesAsyncOverride(input, completion)
         }
@@ -1243,7 +1243,7 @@ public struct MockSimpleNotificationClient: SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, invalidSecurity, notFound.
      */
-    public func unsubscribeAsync(input: SimpleNotificationModel.UnsubscribeInput, completion: @escaping (Error?) -> ()) throws {
+    public func unsubscribeAsync(input: SimpleNotificationModel.UnsubscribeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let unsubscribeAsyncOverride = unsubscribeAsyncOverride {
             return try unsubscribeAsyncOverride(input, completion)
         }

--- a/Sources/SimpleNotificationClient/SimpleNotificationClientProtocol.swift
+++ b/Sources/SimpleNotificationClient/SimpleNotificationClientProtocol.swift
@@ -28,7 +28,7 @@ import SmokeHTTPClient
  */
 public protocol SimpleNotificationClientProtocol {
     typealias AddPermissionSyncType = (_ input: SimpleNotificationModel.AddPermissionInput) throws -> ()
-    typealias AddPermissionAsyncType = (_ input: SimpleNotificationModel.AddPermissionInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias AddPermissionAsyncType = (_ input: SimpleNotificationModel.AddPermissionInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias CheckIfPhoneNumberIsOptedOutSyncType = (_ input: SimpleNotificationModel.CheckIfPhoneNumberIsOptedOutInput) throws -> SimpleNotificationModel.CheckIfPhoneNumberIsOptedOutResponseForCheckIfPhoneNumberIsOptedOut
     typealias CheckIfPhoneNumberIsOptedOutAsyncType = (_ input: SimpleNotificationModel.CheckIfPhoneNumberIsOptedOutInput, _ completion: @escaping (HTTPResult<SimpleNotificationModel.CheckIfPhoneNumberIsOptedOutResponseForCheckIfPhoneNumberIsOptedOut>) -> ()) throws -> ()
     typealias ConfirmSubscriptionSyncType = (_ input: SimpleNotificationModel.ConfirmSubscriptionInput) throws -> SimpleNotificationModel.ConfirmSubscriptionResponseForConfirmSubscription
@@ -40,11 +40,11 @@ public protocol SimpleNotificationClientProtocol {
     typealias CreateTopicSyncType = (_ input: SimpleNotificationModel.CreateTopicInput) throws -> SimpleNotificationModel.CreateTopicResponseForCreateTopic
     typealias CreateTopicAsyncType = (_ input: SimpleNotificationModel.CreateTopicInput, _ completion: @escaping (HTTPResult<SimpleNotificationModel.CreateTopicResponseForCreateTopic>) -> ()) throws -> ()
     typealias DeleteEndpointSyncType = (_ input: SimpleNotificationModel.DeleteEndpointInput) throws -> ()
-    typealias DeleteEndpointAsyncType = (_ input: SimpleNotificationModel.DeleteEndpointInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteEndpointAsyncType = (_ input: SimpleNotificationModel.DeleteEndpointInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeletePlatformApplicationSyncType = (_ input: SimpleNotificationModel.DeletePlatformApplicationInput) throws -> ()
-    typealias DeletePlatformApplicationAsyncType = (_ input: SimpleNotificationModel.DeletePlatformApplicationInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeletePlatformApplicationAsyncType = (_ input: SimpleNotificationModel.DeletePlatformApplicationInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteTopicSyncType = (_ input: SimpleNotificationModel.DeleteTopicInput) throws -> ()
-    typealias DeleteTopicAsyncType = (_ input: SimpleNotificationModel.DeleteTopicInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteTopicAsyncType = (_ input: SimpleNotificationModel.DeleteTopicInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias GetEndpointAttributesSyncType = (_ input: SimpleNotificationModel.GetEndpointAttributesInput) throws -> SimpleNotificationModel.GetEndpointAttributesResponseForGetEndpointAttributes
     typealias GetEndpointAttributesAsyncType = (_ input: SimpleNotificationModel.GetEndpointAttributesInput, _ completion: @escaping (HTTPResult<SimpleNotificationModel.GetEndpointAttributesResponseForGetEndpointAttributes>) -> ()) throws -> ()
     typealias GetPlatformApplicationAttributesSyncType = (_ input: SimpleNotificationModel.GetPlatformApplicationAttributesInput) throws -> SimpleNotificationModel.GetPlatformApplicationAttributesResponseForGetPlatformApplicationAttributes
@@ -72,21 +72,21 @@ public protocol SimpleNotificationClientProtocol {
     typealias PublishSyncType = (_ input: SimpleNotificationModel.PublishInput) throws -> SimpleNotificationModel.PublishResponseForPublish
     typealias PublishAsyncType = (_ input: SimpleNotificationModel.PublishInput, _ completion: @escaping (HTTPResult<SimpleNotificationModel.PublishResponseForPublish>) -> ()) throws -> ()
     typealias RemovePermissionSyncType = (_ input: SimpleNotificationModel.RemovePermissionInput) throws -> ()
-    typealias RemovePermissionAsyncType = (_ input: SimpleNotificationModel.RemovePermissionInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RemovePermissionAsyncType = (_ input: SimpleNotificationModel.RemovePermissionInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias SetEndpointAttributesSyncType = (_ input: SimpleNotificationModel.SetEndpointAttributesInput) throws -> ()
-    typealias SetEndpointAttributesAsyncType = (_ input: SimpleNotificationModel.SetEndpointAttributesInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias SetEndpointAttributesAsyncType = (_ input: SimpleNotificationModel.SetEndpointAttributesInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias SetPlatformApplicationAttributesSyncType = (_ input: SimpleNotificationModel.SetPlatformApplicationAttributesInput) throws -> ()
-    typealias SetPlatformApplicationAttributesAsyncType = (_ input: SimpleNotificationModel.SetPlatformApplicationAttributesInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias SetPlatformApplicationAttributesAsyncType = (_ input: SimpleNotificationModel.SetPlatformApplicationAttributesInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias SetSMSAttributesSyncType = (_ input: SimpleNotificationModel.SetSMSAttributesInput) throws -> SimpleNotificationModel.SetSMSAttributesResponseForSetSMSAttributes
     typealias SetSMSAttributesAsyncType = (_ input: SimpleNotificationModel.SetSMSAttributesInput, _ completion: @escaping (HTTPResult<SimpleNotificationModel.SetSMSAttributesResponseForSetSMSAttributes>) -> ()) throws -> ()
     typealias SetSubscriptionAttributesSyncType = (_ input: SimpleNotificationModel.SetSubscriptionAttributesInput) throws -> ()
-    typealias SetSubscriptionAttributesAsyncType = (_ input: SimpleNotificationModel.SetSubscriptionAttributesInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias SetSubscriptionAttributesAsyncType = (_ input: SimpleNotificationModel.SetSubscriptionAttributesInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias SetTopicAttributesSyncType = (_ input: SimpleNotificationModel.SetTopicAttributesInput) throws -> ()
-    typealias SetTopicAttributesAsyncType = (_ input: SimpleNotificationModel.SetTopicAttributesInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias SetTopicAttributesAsyncType = (_ input: SimpleNotificationModel.SetTopicAttributesInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias SubscribeSyncType = (_ input: SimpleNotificationModel.SubscribeInput) throws -> SimpleNotificationModel.SubscribeResponseForSubscribe
     typealias SubscribeAsyncType = (_ input: SimpleNotificationModel.SubscribeInput, _ completion: @escaping (HTTPResult<SimpleNotificationModel.SubscribeResponseForSubscribe>) -> ()) throws -> ()
     typealias UnsubscribeSyncType = (_ input: SimpleNotificationModel.UnsubscribeInput) throws -> ()
-    typealias UnsubscribeAsyncType = (_ input: SimpleNotificationModel.UnsubscribeInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias UnsubscribeAsyncType = (_ input: SimpleNotificationModel.UnsubscribeInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
 
     /**
      Invokes the AddPermission operation returning immediately and passing the response to a callback.
@@ -97,7 +97,7 @@ public protocol SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    func addPermissionAsync(input: SimpleNotificationModel.AddPermissionInput, completion: @escaping (Error?) -> ()) throws
+    func addPermissionAsync(input: SimpleNotificationModel.AddPermissionInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the AddPermission operation waiting for the response before returning.
@@ -232,7 +232,7 @@ public protocol SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter.
      */
-    func deleteEndpointAsync(input: SimpleNotificationModel.DeleteEndpointInput, completion: @escaping (Error?) -> ()) throws
+    func deleteEndpointAsync(input: SimpleNotificationModel.DeleteEndpointInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteEndpoint operation waiting for the response before returning.
@@ -252,7 +252,7 @@ public protocol SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter.
      */
-    func deletePlatformApplicationAsync(input: SimpleNotificationModel.DeletePlatformApplicationInput, completion: @escaping (Error?) -> ()) throws
+    func deletePlatformApplicationAsync(input: SimpleNotificationModel.DeletePlatformApplicationInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeletePlatformApplication operation waiting for the response before returning.
@@ -272,7 +272,7 @@ public protocol SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    func deleteTopicAsync(input: SimpleNotificationModel.DeleteTopicInput, completion: @escaping (Error?) -> ()) throws
+    func deleteTopicAsync(input: SimpleNotificationModel.DeleteTopicInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteTopic operation waiting for the response before returning.
@@ -591,7 +591,7 @@ public protocol SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    func removePermissionAsync(input: SimpleNotificationModel.RemovePermissionInput, completion: @escaping (Error?) -> ()) throws
+    func removePermissionAsync(input: SimpleNotificationModel.RemovePermissionInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RemovePermission operation waiting for the response before returning.
@@ -611,7 +611,7 @@ public protocol SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    func setEndpointAttributesAsync(input: SimpleNotificationModel.SetEndpointAttributesInput, completion: @escaping (Error?) -> ()) throws
+    func setEndpointAttributesAsync(input: SimpleNotificationModel.SetEndpointAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the SetEndpointAttributes operation waiting for the response before returning.
@@ -631,7 +631,7 @@ public protocol SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    func setPlatformApplicationAttributesAsync(input: SimpleNotificationModel.SetPlatformApplicationAttributesInput, completion: @escaping (Error?) -> ()) throws
+    func setPlatformApplicationAttributesAsync(input: SimpleNotificationModel.SetPlatformApplicationAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the SetPlatformApplicationAttributes operation waiting for the response before returning.
@@ -674,7 +674,7 @@ public protocol SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, filterPolicyLimitExceeded, internalError, invalidParameter, notFound.
      */
-    func setSubscriptionAttributesAsync(input: SimpleNotificationModel.SetSubscriptionAttributesInput, completion: @escaping (Error?) -> ()) throws
+    func setSubscriptionAttributesAsync(input: SimpleNotificationModel.SetSubscriptionAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the SetSubscriptionAttributes operation waiting for the response before returning.
@@ -694,7 +694,7 @@ public protocol SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, invalidSecurity, notFound.
      */
-    func setTopicAttributesAsync(input: SimpleNotificationModel.SetTopicAttributesInput, completion: @escaping (Error?) -> ()) throws
+    func setTopicAttributesAsync(input: SimpleNotificationModel.SetTopicAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the SetTopicAttributes operation waiting for the response before returning.
@@ -737,7 +737,7 @@ public protocol SimpleNotificationClientProtocol {
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, invalidSecurity, notFound.
      */
-    func unsubscribeAsync(input: SimpleNotificationModel.UnsubscribeInput, completion: @escaping (Error?) -> ()) throws
+    func unsubscribeAsync(input: SimpleNotificationModel.UnsubscribeInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the Unsubscribe operation waiting for the response before returning.

--- a/Sources/SimpleNotificationClient/SimpleNotificationOperationsClientOutput.swift
+++ b/Sources/SimpleNotificationClient/SimpleNotificationOperationsClientOutput.swift
@@ -1,0 +1,285 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// SimpleNotificationOperationsClientOutput.swift
+// SimpleNotificationClient
+//
+
+import Foundation
+import SmokeHTTPClient
+import SimpleNotificationModel
+
+/**
+ Type to handle the output from the CheckIfPhoneNumberIsOptedOut operation in a HTTP client.
+ */
+extension CheckIfPhoneNumberIsOptedOutResponseForCheckIfPhoneNumberIsOptedOut: HTTPResponseOutputProtocol {
+    public typealias BodyType = CheckIfPhoneNumberIsOptedOutResponseForCheckIfPhoneNumberIsOptedOut
+    public typealias HeadersType = CheckIfPhoneNumberIsOptedOutResponseForCheckIfPhoneNumberIsOptedOut
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CheckIfPhoneNumberIsOptedOutResponseForCheckIfPhoneNumberIsOptedOut {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ConfirmSubscription operation in a HTTP client.
+ */
+extension ConfirmSubscriptionResponseForConfirmSubscription: HTTPResponseOutputProtocol {
+    public typealias BodyType = ConfirmSubscriptionResponseForConfirmSubscription
+    public typealias HeadersType = ConfirmSubscriptionResponseForConfirmSubscription
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ConfirmSubscriptionResponseForConfirmSubscription {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreatePlatformApplication operation in a HTTP client.
+ */
+extension CreatePlatformApplicationResponseForCreatePlatformApplication: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreatePlatformApplicationResponseForCreatePlatformApplication
+    public typealias HeadersType = CreatePlatformApplicationResponseForCreatePlatformApplication
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreatePlatformApplicationResponseForCreatePlatformApplication {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreatePlatformEndpoint operation in a HTTP client.
+ */
+extension CreateEndpointResponseForCreatePlatformEndpoint: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateEndpointResponseForCreatePlatformEndpoint
+    public typealias HeadersType = CreateEndpointResponseForCreatePlatformEndpoint
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateEndpointResponseForCreatePlatformEndpoint {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateTopic operation in a HTTP client.
+ */
+extension CreateTopicResponseForCreateTopic: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateTopicResponseForCreateTopic
+    public typealias HeadersType = CreateTopicResponseForCreateTopic
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateTopicResponseForCreateTopic {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetEndpointAttributes operation in a HTTP client.
+ */
+extension GetEndpointAttributesResponseForGetEndpointAttributes: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetEndpointAttributesResponseForGetEndpointAttributes
+    public typealias HeadersType = GetEndpointAttributesResponseForGetEndpointAttributes
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetEndpointAttributesResponseForGetEndpointAttributes {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetPlatformApplicationAttributes operation in a HTTP client.
+ */
+extension GetPlatformApplicationAttributesResponseForGetPlatformApplicationAttributes: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetPlatformApplicationAttributesResponseForGetPlatformApplicationAttributes
+    public typealias HeadersType = GetPlatformApplicationAttributesResponseForGetPlatformApplicationAttributes
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetPlatformApplicationAttributesResponseForGetPlatformApplicationAttributes {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetSMSAttributes operation in a HTTP client.
+ */
+extension GetSMSAttributesResponseForGetSMSAttributes: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetSMSAttributesResponseForGetSMSAttributes
+    public typealias HeadersType = GetSMSAttributesResponseForGetSMSAttributes
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetSMSAttributesResponseForGetSMSAttributes {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetSubscriptionAttributes operation in a HTTP client.
+ */
+extension GetSubscriptionAttributesResponseForGetSubscriptionAttributes: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetSubscriptionAttributesResponseForGetSubscriptionAttributes
+    public typealias HeadersType = GetSubscriptionAttributesResponseForGetSubscriptionAttributes
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetSubscriptionAttributesResponseForGetSubscriptionAttributes {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetTopicAttributes operation in a HTTP client.
+ */
+extension GetTopicAttributesResponseForGetTopicAttributes: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetTopicAttributesResponseForGetTopicAttributes
+    public typealias HeadersType = GetTopicAttributesResponseForGetTopicAttributes
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetTopicAttributesResponseForGetTopicAttributes {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListEndpointsByPlatformApplication operation in a HTTP client.
+ */
+extension ListEndpointsByPlatformApplicationResponseForListEndpointsByPlatformApplication: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListEndpointsByPlatformApplicationResponseForListEndpointsByPlatformApplication
+    public typealias HeadersType = ListEndpointsByPlatformApplicationResponseForListEndpointsByPlatformApplication
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListEndpointsByPlatformApplicationResponseForListEndpointsByPlatformApplication {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListPhoneNumbersOptedOut operation in a HTTP client.
+ */
+extension ListPhoneNumbersOptedOutResponseForListPhoneNumbersOptedOut: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListPhoneNumbersOptedOutResponseForListPhoneNumbersOptedOut
+    public typealias HeadersType = ListPhoneNumbersOptedOutResponseForListPhoneNumbersOptedOut
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListPhoneNumbersOptedOutResponseForListPhoneNumbersOptedOut {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListPlatformApplications operation in a HTTP client.
+ */
+extension ListPlatformApplicationsResponseForListPlatformApplications: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListPlatformApplicationsResponseForListPlatformApplications
+    public typealias HeadersType = ListPlatformApplicationsResponseForListPlatformApplications
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListPlatformApplicationsResponseForListPlatformApplications {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListSubscriptions operation in a HTTP client.
+ */
+extension ListSubscriptionsResponseForListSubscriptions: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListSubscriptionsResponseForListSubscriptions
+    public typealias HeadersType = ListSubscriptionsResponseForListSubscriptions
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListSubscriptionsResponseForListSubscriptions {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListSubscriptionsByTopic operation in a HTTP client.
+ */
+extension ListSubscriptionsByTopicResponseForListSubscriptionsByTopic: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListSubscriptionsByTopicResponseForListSubscriptionsByTopic
+    public typealias HeadersType = ListSubscriptionsByTopicResponseForListSubscriptionsByTopic
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListSubscriptionsByTopicResponseForListSubscriptionsByTopic {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListTopics operation in a HTTP client.
+ */
+extension ListTopicsResponseForListTopics: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListTopicsResponseForListTopics
+    public typealias HeadersType = ListTopicsResponseForListTopics
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListTopicsResponseForListTopics {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the OptInPhoneNumber operation in a HTTP client.
+ */
+extension OptInPhoneNumberResponseForOptInPhoneNumber: HTTPResponseOutputProtocol {
+    public typealias BodyType = OptInPhoneNumberResponseForOptInPhoneNumber
+    public typealias HeadersType = OptInPhoneNumberResponseForOptInPhoneNumber
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> OptInPhoneNumberResponseForOptInPhoneNumber {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the Publish operation in a HTTP client.
+ */
+extension PublishResponseForPublish: HTTPResponseOutputProtocol {
+    public typealias BodyType = PublishResponseForPublish
+    public typealias HeadersType = PublishResponseForPublish
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PublishResponseForPublish {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the SetSMSAttributes operation in a HTTP client.
+ */
+extension SetSMSAttributesResponseForSetSMSAttributes: HTTPResponseOutputProtocol {
+    public typealias BodyType = SetSMSAttributesResponseForSetSMSAttributes
+    public typealias HeadersType = SetSMSAttributesResponseForSetSMSAttributes
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> SetSMSAttributesResponseForSetSMSAttributes {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the Subscribe operation in a HTTP client.
+ */
+extension SubscribeResponseForSubscribe: HTTPResponseOutputProtocol {
+    public typealias BodyType = SubscribeResponseForSubscribe
+    public typealias HeadersType = SubscribeResponseForSubscribe
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> SubscribeResponseForSubscribe {
+        return try bodyDecodableProvider()
+    }
+}
+

--- a/Sources/SimpleNotificationClient/ThrowingSimpleNotificationClient.swift
+++ b/Sources/SimpleNotificationClient/ThrowingSimpleNotificationClient.swift
@@ -226,7 +226,7 @@ public struct ThrowingSimpleNotificationClient: SimpleNotificationClientProtocol
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func addPermissionAsync(input: SimpleNotificationModel.AddPermissionInput, completion: @escaping (Error?) -> ()) throws {
+    public func addPermissionAsync(input: SimpleNotificationModel.AddPermissionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let addPermissionAsyncOverride = addPermissionAsyncOverride {
             return try addPermissionAsyncOverride(input, completion)
         }
@@ -433,7 +433,7 @@ public struct ThrowingSimpleNotificationClient: SimpleNotificationClientProtocol
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter.
      */
-    public func deleteEndpointAsync(input: SimpleNotificationModel.DeleteEndpointInput, completion: @escaping (Error?) -> ()) throws {
+    public func deleteEndpointAsync(input: SimpleNotificationModel.DeleteEndpointInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteEndpointAsyncOverride = deleteEndpointAsyncOverride {
             return try deleteEndpointAsyncOverride(input, completion)
         }
@@ -465,7 +465,7 @@ public struct ThrowingSimpleNotificationClient: SimpleNotificationClientProtocol
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter.
      */
-    public func deletePlatformApplicationAsync(input: SimpleNotificationModel.DeletePlatformApplicationInput, completion: @escaping (Error?) -> ()) throws {
+    public func deletePlatformApplicationAsync(input: SimpleNotificationModel.DeletePlatformApplicationInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deletePlatformApplicationAsyncOverride = deletePlatformApplicationAsyncOverride {
             return try deletePlatformApplicationAsyncOverride(input, completion)
         }
@@ -497,7 +497,7 @@ public struct ThrowingSimpleNotificationClient: SimpleNotificationClientProtocol
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func deleteTopicAsync(input: SimpleNotificationModel.DeleteTopicInput, completion: @escaping (Error?) -> ()) throws {
+    public func deleteTopicAsync(input: SimpleNotificationModel.DeleteTopicInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteTopicAsyncOverride = deleteTopicAsyncOverride {
             return try deleteTopicAsyncOverride(input, completion)
         }
@@ -984,7 +984,7 @@ public struct ThrowingSimpleNotificationClient: SimpleNotificationClientProtocol
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func removePermissionAsync(input: SimpleNotificationModel.RemovePermissionInput, completion: @escaping (Error?) -> ()) throws {
+    public func removePermissionAsync(input: SimpleNotificationModel.RemovePermissionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let removePermissionAsyncOverride = removePermissionAsyncOverride {
             return try removePermissionAsyncOverride(input, completion)
         }
@@ -1016,7 +1016,7 @@ public struct ThrowingSimpleNotificationClient: SimpleNotificationClientProtocol
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func setEndpointAttributesAsync(input: SimpleNotificationModel.SetEndpointAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setEndpointAttributesAsync(input: SimpleNotificationModel.SetEndpointAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setEndpointAttributesAsyncOverride = setEndpointAttributesAsyncOverride {
             return try setEndpointAttributesAsyncOverride(input, completion)
         }
@@ -1048,7 +1048,7 @@ public struct ThrowingSimpleNotificationClient: SimpleNotificationClientProtocol
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, notFound.
      */
-    public func setPlatformApplicationAttributesAsync(input: SimpleNotificationModel.SetPlatformApplicationAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setPlatformApplicationAttributesAsync(input: SimpleNotificationModel.SetPlatformApplicationAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setPlatformApplicationAttributesAsyncOverride = setPlatformApplicationAttributesAsyncOverride {
             return try setPlatformApplicationAttributesAsyncOverride(input, completion)
         }
@@ -1115,7 +1115,7 @@ public struct ThrowingSimpleNotificationClient: SimpleNotificationClientProtocol
            is complete.
            The possible errors are: authorizationError, filterPolicyLimitExceeded, internalError, invalidParameter, notFound.
      */
-    public func setSubscriptionAttributesAsync(input: SimpleNotificationModel.SetSubscriptionAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setSubscriptionAttributesAsync(input: SimpleNotificationModel.SetSubscriptionAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setSubscriptionAttributesAsyncOverride = setSubscriptionAttributesAsyncOverride {
             return try setSubscriptionAttributesAsyncOverride(input, completion)
         }
@@ -1147,7 +1147,7 @@ public struct ThrowingSimpleNotificationClient: SimpleNotificationClientProtocol
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, invalidSecurity, notFound.
      */
-    public func setTopicAttributesAsync(input: SimpleNotificationModel.SetTopicAttributesInput, completion: @escaping (Error?) -> ()) throws {
+    public func setTopicAttributesAsync(input: SimpleNotificationModel.SetTopicAttributesInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setTopicAttributesAsyncOverride = setTopicAttributesAsyncOverride {
             return try setTopicAttributesAsyncOverride(input, completion)
         }
@@ -1214,7 +1214,7 @@ public struct ThrowingSimpleNotificationClient: SimpleNotificationClientProtocol
            is complete.
            The possible errors are: authorizationError, internalError, invalidParameter, invalidSecurity, notFound.
      */
-    public func unsubscribeAsync(input: SimpleNotificationModel.UnsubscribeInput, completion: @escaping (Error?) -> ()) throws {
+    public func unsubscribeAsync(input: SimpleNotificationModel.UnsubscribeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let unsubscribeAsyncOverride = unsubscribeAsyncOverride {
             return try unsubscribeAsyncOverride(input, completion)
         }

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
@@ -76,6 +76,24 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
     }
 
     /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times.
+     */
+    public func close() {
+        httpClient.close()
+        listHttpClient.close()
+    }
+
+    /**
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
+     */
+    public func wait() {
+        httpClient.wait()
+        listHttpClient.wait()
+    }
+
+    /**
      Invokes the AddPermission operation returning immediately and passing the response to a callback.
 
      - Parameters:
@@ -84,14 +102,14 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: overLimit.
      */
-    public func addPermissionAsync(input: SimpleQueueModel.AddPermissionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func addPermissionAsync(input: SimpleQueueModel.AddPermissionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = AddPermissionOperationHTTPRequestInput<SimpleQueueModel.AddPermissionRequest>(encodable: input)
+        let wrappedInput = AddPermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -120,7 +138,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = AddPermissionOperationHTTPRequestInput<SimpleQueueModel.AddPermissionRequest>(encodable: input)
+        let wrappedInput = AddPermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -143,14 +161,14 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: messageNotInflight, receiptHandleIsInvalid.
      */
-    public func changeMessageVisibilityAsync(input: SimpleQueueModel.ChangeMessageVisibilityRequest, completion: @escaping (Error?) -> ()) throws {
+    public func changeMessageVisibilityAsync(input: SimpleQueueModel.ChangeMessageVisibilityRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = ChangeMessageVisibilityOperationHTTPRequestInput<SimpleQueueModel.ChangeMessageVisibilityRequest>(encodable: input)
+        let wrappedInput = ChangeMessageVisibilityOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -179,7 +197,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ChangeMessageVisibilityOperationHTTPRequestInput<SimpleQueueModel.ChangeMessageVisibilityRequest>(encodable: input)
+        let wrappedInput = ChangeMessageVisibilityOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -210,7 +228,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ChangeMessageVisibilityBatchOperationHTTPRequestInput<SimpleQueueModel.ChangeMessageVisibilityBatchRequest>(encodable: input)
+        let wrappedInput = ChangeMessageVisibilityBatchOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -241,7 +259,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ChangeMessageVisibilityBatchOperationHTTPRequestInput<SimpleQueueModel.ChangeMessageVisibilityBatchRequest>(encodable: input)
+        let wrappedInput = ChangeMessageVisibilityBatchOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -272,7 +290,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateQueueOperationHTTPRequestInput<SimpleQueueModel.CreateQueueRequest>(encodable: input)
+        let wrappedInput = CreateQueueOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -303,7 +321,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = CreateQueueOperationHTTPRequestInput<SimpleQueueModel.CreateQueueRequest>(encodable: input)
+        let wrappedInput = CreateQueueOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -326,14 +344,14 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: invalidIdFormat, receiptHandleIsInvalid.
      */
-    public func deleteMessageAsync(input: SimpleQueueModel.DeleteMessageRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteMessageAsync(input: SimpleQueueModel.DeleteMessageRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteMessageOperationHTTPRequestInput<SimpleQueueModel.DeleteMessageRequest>(encodable: input)
+        let wrappedInput = DeleteMessageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -362,7 +380,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteMessageOperationHTTPRequestInput<SimpleQueueModel.DeleteMessageRequest>(encodable: input)
+        let wrappedInput = DeleteMessageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -393,7 +411,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteMessageBatchOperationHTTPRequestInput<SimpleQueueModel.DeleteMessageBatchRequest>(encodable: input)
+        let wrappedInput = DeleteMessageBatchOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -424,7 +442,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteMessageBatchOperationHTTPRequestInput<SimpleQueueModel.DeleteMessageBatchRequest>(encodable: input)
+        let wrappedInput = DeleteMessageBatchOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -446,14 +464,14 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteQueueAsync(input: SimpleQueueModel.DeleteQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteQueueAsync(input: SimpleQueueModel.DeleteQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteQueueOperationHTTPRequestInput<SimpleQueueModel.DeleteQueueRequest>(encodable: input)
+        let wrappedInput = DeleteQueueOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -481,7 +499,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = DeleteQueueOperationHTTPRequestInput<SimpleQueueModel.DeleteQueueRequest>(encodable: input)
+        let wrappedInput = DeleteQueueOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -512,7 +530,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetQueueAttributesOperationHTTPRequestInput<SimpleQueueModel.GetQueueAttributesRequest>(encodable: input)
+        let wrappedInput = GetQueueAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -543,7 +561,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetQueueAttributesOperationHTTPRequestInput<SimpleQueueModel.GetQueueAttributesRequest>(encodable: input)
+        let wrappedInput = GetQueueAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -574,7 +592,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetQueueUrlOperationHTTPRequestInput<SimpleQueueModel.GetQueueUrlRequest>(encodable: input)
+        let wrappedInput = GetQueueUrlOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -605,7 +623,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = GetQueueUrlOperationHTTPRequestInput<SimpleQueueModel.GetQueueUrlRequest>(encodable: input)
+        let wrappedInput = GetQueueUrlOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -636,7 +654,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListDeadLetterSourceQueuesOperationHTTPRequestInput<SimpleQueueModel.ListDeadLetterSourceQueuesRequest>(encodable: input)
+        let wrappedInput = ListDeadLetterSourceQueuesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -667,7 +685,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListDeadLetterSourceQueuesOperationHTTPRequestInput<SimpleQueueModel.ListDeadLetterSourceQueuesRequest>(encodable: input)
+        let wrappedInput = ListDeadLetterSourceQueuesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -697,7 +715,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListQueueTagsOperationHTTPRequestInput<SimpleQueueModel.ListQueueTagsRequest>(encodable: input)
+        let wrappedInput = ListQueueTagsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -727,7 +745,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListQueueTagsOperationHTTPRequestInput<SimpleQueueModel.ListQueueTagsRequest>(encodable: input)
+        let wrappedInput = ListQueueTagsOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -757,7 +775,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListQueuesOperationHTTPRequestInput<SimpleQueueModel.ListQueuesRequest>(encodable: input)
+        let wrappedInput = ListQueuesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -787,7 +805,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ListQueuesOperationHTTPRequestInput<SimpleQueueModel.ListQueuesRequest>(encodable: input)
+        let wrappedInput = ListQueuesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -810,14 +828,14 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: purgeQueueInProgress, queueDoesNotExist.
      */
-    public func purgeQueueAsync(input: SimpleQueueModel.PurgeQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func purgeQueueAsync(input: SimpleQueueModel.PurgeQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = PurgeQueueOperationHTTPRequestInput<SimpleQueueModel.PurgeQueueRequest>(encodable: input)
+        let wrappedInput = PurgeQueueOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -846,7 +864,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = PurgeQueueOperationHTTPRequestInput<SimpleQueueModel.PurgeQueueRequest>(encodable: input)
+        let wrappedInput = PurgeQueueOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -877,7 +895,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReceiveMessageOperationHTTPRequestInput<SimpleQueueModel.ReceiveMessageRequest>(encodable: input)
+        let wrappedInput = ReceiveMessageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -908,7 +926,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = ReceiveMessageOperationHTTPRequestInput<SimpleQueueModel.ReceiveMessageRequest>(encodable: input)
+        let wrappedInput = ReceiveMessageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -930,14 +948,14 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func removePermissionAsync(input: SimpleQueueModel.RemovePermissionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func removePermissionAsync(input: SimpleQueueModel.RemovePermissionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = RemovePermissionOperationHTTPRequestInput<SimpleQueueModel.RemovePermissionRequest>(encodable: input)
+        let wrappedInput = RemovePermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -965,7 +983,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = RemovePermissionOperationHTTPRequestInput<SimpleQueueModel.RemovePermissionRequest>(encodable: input)
+        let wrappedInput = RemovePermissionOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -996,7 +1014,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SendMessageOperationHTTPRequestInput<SimpleQueueModel.SendMessageRequest>(encodable: input)
+        let wrappedInput = SendMessageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1027,7 +1045,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SendMessageOperationHTTPRequestInput<SimpleQueueModel.SendMessageRequest>(encodable: input)
+        let wrappedInput = SendMessageOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1058,7 +1076,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SendMessageBatchOperationHTTPRequestInput<SimpleQueueModel.SendMessageBatchRequest>(encodable: input)
+        let wrappedInput = SendMessageBatchOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1089,7 +1107,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SendMessageBatchOperationHTTPRequestInput<SimpleQueueModel.SendMessageBatchRequest>(encodable: input)
+        let wrappedInput = SendMessageBatchOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1112,14 +1130,14 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: invalidAttributeName.
      */
-    public func setQueueAttributesAsync(input: SimpleQueueModel.SetQueueAttributesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func setQueueAttributesAsync(input: SimpleQueueModel.SetQueueAttributesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = SetQueueAttributesOperationHTTPRequestInput<SimpleQueueModel.SetQueueAttributesRequest>(encodable: input)
+        let wrappedInput = SetQueueAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1148,7 +1166,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = SetQueueAttributesOperationHTTPRequestInput<SimpleQueueModel.SetQueueAttributesRequest>(encodable: input)
+        let wrappedInput = SetQueueAttributesOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1170,14 +1188,14 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func tagQueueAsync(input: SimpleQueueModel.TagQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func tagQueueAsync(input: SimpleQueueModel.TagQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = TagQueueOperationHTTPRequestInput<SimpleQueueModel.TagQueueRequest>(encodable: input)
+        let wrappedInput = TagQueueOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1205,7 +1223,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = TagQueueOperationHTTPRequestInput<SimpleQueueModel.TagQueueRequest>(encodable: input)
+        let wrappedInput = TagQueueOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1227,14 +1245,14 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func untagQueueAsync(input: SimpleQueueModel.UntagQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func untagQueueAsync(input: SimpleQueueModel.UntagQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     target: target)
         
-        let wrappedInput = UntagQueueOperationHTTPRequestInput<SimpleQueueModel.UntagQueueRequest>(encodable: input)
+        let wrappedInput = UntagQueueOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,
@@ -1262,7 +1280,7 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                     service: service,
                     target: target)
         
-        let wrappedInput = UntagQueueOperationHTTPRequestInput<SimpleQueueModel.UntagQueueRequest>(encodable: input)
+        let wrappedInput = UntagQueueOperationHTTPRequestInput(encodable: input)
         
         let requestInput = QueryWrapperHTTPRequestInput(
             wrappedInput: wrappedInput,

--- a/Sources/SimpleQueueClient/MockSimpleQueueClient.swift
+++ b/Sources/SimpleQueueClient/MockSimpleQueueClient.swift
@@ -164,7 +164,7 @@ public struct MockSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: overLimit.
      */
-    public func addPermissionAsync(input: SimpleQueueModel.AddPermissionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func addPermissionAsync(input: SimpleQueueModel.AddPermissionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let addPermissionAsyncOverride = addPermissionAsyncOverride {
             return try addPermissionAsyncOverride(input, completion)
         }
@@ -195,7 +195,7 @@ public struct MockSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: messageNotInflight, receiptHandleIsInvalid.
      */
-    public func changeMessageVisibilityAsync(input: SimpleQueueModel.ChangeMessageVisibilityRequest, completion: @escaping (Error?) -> ()) throws {
+    public func changeMessageVisibilityAsync(input: SimpleQueueModel.ChangeMessageVisibilityRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let changeMessageVisibilityAsyncOverride = changeMessageVisibilityAsyncOverride {
             return try changeMessageVisibilityAsyncOverride(input, completion)
         }
@@ -300,7 +300,7 @@ public struct MockSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: invalidIdFormat, receiptHandleIsInvalid.
      */
-    public func deleteMessageAsync(input: SimpleQueueModel.DeleteMessageRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteMessageAsync(input: SimpleQueueModel.DeleteMessageRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteMessageAsyncOverride = deleteMessageAsyncOverride {
             return try deleteMessageAsyncOverride(input, completion)
         }
@@ -367,7 +367,7 @@ public struct MockSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteQueueAsync(input: SimpleQueueModel.DeleteQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteQueueAsync(input: SimpleQueueModel.DeleteQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteQueueAsyncOverride = deleteQueueAsyncOverride {
             return try deleteQueueAsyncOverride(input, completion)
         }
@@ -578,7 +578,7 @@ public struct MockSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: purgeQueueInProgress, queueDoesNotExist.
      */
-    public func purgeQueueAsync(input: SimpleQueueModel.PurgeQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func purgeQueueAsync(input: SimpleQueueModel.PurgeQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let purgeQueueAsyncOverride = purgeQueueAsyncOverride {
             return try purgeQueueAsyncOverride(input, completion)
         }
@@ -645,7 +645,7 @@ public struct MockSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func removePermissionAsync(input: SimpleQueueModel.RemovePermissionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func removePermissionAsync(input: SimpleQueueModel.RemovePermissionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let removePermissionAsyncOverride = removePermissionAsyncOverride {
             return try removePermissionAsyncOverride(input, completion)
         }
@@ -749,7 +749,7 @@ public struct MockSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: invalidAttributeName.
      */
-    public func setQueueAttributesAsync(input: SimpleQueueModel.SetQueueAttributesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func setQueueAttributesAsync(input: SimpleQueueModel.SetQueueAttributesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setQueueAttributesAsyncOverride = setQueueAttributesAsyncOverride {
             return try setQueueAttributesAsyncOverride(input, completion)
         }
@@ -779,7 +779,7 @@ public struct MockSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func tagQueueAsync(input: SimpleQueueModel.TagQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func tagQueueAsync(input: SimpleQueueModel.TagQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let tagQueueAsyncOverride = tagQueueAsyncOverride {
             return try tagQueueAsyncOverride(input, completion)
         }
@@ -808,7 +808,7 @@ public struct MockSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func untagQueueAsync(input: SimpleQueueModel.UntagQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func untagQueueAsync(input: SimpleQueueModel.UntagQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let untagQueueAsyncOverride = untagQueueAsyncOverride {
             return try untagQueueAsyncOverride(input, completion)
         }

--- a/Sources/SimpleQueueClient/SimpleQueueClientProtocol.swift
+++ b/Sources/SimpleQueueClient/SimpleQueueClientProtocol.swift
@@ -28,19 +28,19 @@ import SmokeHTTPClient
  */
 public protocol SimpleQueueClientProtocol {
     typealias AddPermissionSyncType = (_ input: SimpleQueueModel.AddPermissionRequest) throws -> ()
-    typealias AddPermissionAsyncType = (_ input: SimpleQueueModel.AddPermissionRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias AddPermissionAsyncType = (_ input: SimpleQueueModel.AddPermissionRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ChangeMessageVisibilitySyncType = (_ input: SimpleQueueModel.ChangeMessageVisibilityRequest) throws -> ()
-    typealias ChangeMessageVisibilityAsyncType = (_ input: SimpleQueueModel.ChangeMessageVisibilityRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias ChangeMessageVisibilityAsyncType = (_ input: SimpleQueueModel.ChangeMessageVisibilityRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ChangeMessageVisibilityBatchSyncType = (_ input: SimpleQueueModel.ChangeMessageVisibilityBatchRequest) throws -> SimpleQueueModel.ChangeMessageVisibilityBatchResultForChangeMessageVisibilityBatch
     typealias ChangeMessageVisibilityBatchAsyncType = (_ input: SimpleQueueModel.ChangeMessageVisibilityBatchRequest, _ completion: @escaping (HTTPResult<SimpleQueueModel.ChangeMessageVisibilityBatchResultForChangeMessageVisibilityBatch>) -> ()) throws -> ()
     typealias CreateQueueSyncType = (_ input: SimpleQueueModel.CreateQueueRequest) throws -> SimpleQueueModel.CreateQueueResultForCreateQueue
     typealias CreateQueueAsyncType = (_ input: SimpleQueueModel.CreateQueueRequest, _ completion: @escaping (HTTPResult<SimpleQueueModel.CreateQueueResultForCreateQueue>) -> ()) throws -> ()
     typealias DeleteMessageSyncType = (_ input: SimpleQueueModel.DeleteMessageRequest) throws -> ()
-    typealias DeleteMessageAsyncType = (_ input: SimpleQueueModel.DeleteMessageRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteMessageAsyncType = (_ input: SimpleQueueModel.DeleteMessageRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeleteMessageBatchSyncType = (_ input: SimpleQueueModel.DeleteMessageBatchRequest) throws -> SimpleQueueModel.DeleteMessageBatchResultForDeleteMessageBatch
     typealias DeleteMessageBatchAsyncType = (_ input: SimpleQueueModel.DeleteMessageBatchRequest, _ completion: @escaping (HTTPResult<SimpleQueueModel.DeleteMessageBatchResultForDeleteMessageBatch>) -> ()) throws -> ()
     typealias DeleteQueueSyncType = (_ input: SimpleQueueModel.DeleteQueueRequest) throws -> ()
-    typealias DeleteQueueAsyncType = (_ input: SimpleQueueModel.DeleteQueueRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeleteQueueAsyncType = (_ input: SimpleQueueModel.DeleteQueueRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias GetQueueAttributesSyncType = (_ input: SimpleQueueModel.GetQueueAttributesRequest) throws -> SimpleQueueModel.GetQueueAttributesResultForGetQueueAttributes
     typealias GetQueueAttributesAsyncType = (_ input: SimpleQueueModel.GetQueueAttributesRequest, _ completion: @escaping (HTTPResult<SimpleQueueModel.GetQueueAttributesResultForGetQueueAttributes>) -> ()) throws -> ()
     typealias GetQueueUrlSyncType = (_ input: SimpleQueueModel.GetQueueUrlRequest) throws -> SimpleQueueModel.GetQueueUrlResultForGetQueueUrl
@@ -52,21 +52,21 @@ public protocol SimpleQueueClientProtocol {
     typealias ListQueuesSyncType = (_ input: SimpleQueueModel.ListQueuesRequest) throws -> SimpleQueueModel.ListQueuesResultForListQueues
     typealias ListQueuesAsyncType = (_ input: SimpleQueueModel.ListQueuesRequest, _ completion: @escaping (HTTPResult<SimpleQueueModel.ListQueuesResultForListQueues>) -> ()) throws -> ()
     typealias PurgeQueueSyncType = (_ input: SimpleQueueModel.PurgeQueueRequest) throws -> ()
-    typealias PurgeQueueAsyncType = (_ input: SimpleQueueModel.PurgeQueueRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias PurgeQueueAsyncType = (_ input: SimpleQueueModel.PurgeQueueRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias ReceiveMessageSyncType = (_ input: SimpleQueueModel.ReceiveMessageRequest) throws -> SimpleQueueModel.ReceiveMessageResultForReceiveMessage
     typealias ReceiveMessageAsyncType = (_ input: SimpleQueueModel.ReceiveMessageRequest, _ completion: @escaping (HTTPResult<SimpleQueueModel.ReceiveMessageResultForReceiveMessage>) -> ()) throws -> ()
     typealias RemovePermissionSyncType = (_ input: SimpleQueueModel.RemovePermissionRequest) throws -> ()
-    typealias RemovePermissionAsyncType = (_ input: SimpleQueueModel.RemovePermissionRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RemovePermissionAsyncType = (_ input: SimpleQueueModel.RemovePermissionRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias SendMessageSyncType = (_ input: SimpleQueueModel.SendMessageRequest) throws -> SimpleQueueModel.SendMessageResultForSendMessage
     typealias SendMessageAsyncType = (_ input: SimpleQueueModel.SendMessageRequest, _ completion: @escaping (HTTPResult<SimpleQueueModel.SendMessageResultForSendMessage>) -> ()) throws -> ()
     typealias SendMessageBatchSyncType = (_ input: SimpleQueueModel.SendMessageBatchRequest) throws -> SimpleQueueModel.SendMessageBatchResultForSendMessageBatch
     typealias SendMessageBatchAsyncType = (_ input: SimpleQueueModel.SendMessageBatchRequest, _ completion: @escaping (HTTPResult<SimpleQueueModel.SendMessageBatchResultForSendMessageBatch>) -> ()) throws -> ()
     typealias SetQueueAttributesSyncType = (_ input: SimpleQueueModel.SetQueueAttributesRequest) throws -> ()
-    typealias SetQueueAttributesAsyncType = (_ input: SimpleQueueModel.SetQueueAttributesRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias SetQueueAttributesAsyncType = (_ input: SimpleQueueModel.SetQueueAttributesRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias TagQueueSyncType = (_ input: SimpleQueueModel.TagQueueRequest) throws -> ()
-    typealias TagQueueAsyncType = (_ input: SimpleQueueModel.TagQueueRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias TagQueueAsyncType = (_ input: SimpleQueueModel.TagQueueRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias UntagQueueSyncType = (_ input: SimpleQueueModel.UntagQueueRequest) throws -> ()
-    typealias UntagQueueAsyncType = (_ input: SimpleQueueModel.UntagQueueRequest, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias UntagQueueAsyncType = (_ input: SimpleQueueModel.UntagQueueRequest, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
 
     /**
      Invokes the AddPermission operation returning immediately and passing the response to a callback.
@@ -77,7 +77,7 @@ public protocol SimpleQueueClientProtocol {
            is complete.
            The possible errors are: overLimit.
      */
-    func addPermissionAsync(input: SimpleQueueModel.AddPermissionRequest, completion: @escaping (Error?) -> ()) throws
+    func addPermissionAsync(input: SimpleQueueModel.AddPermissionRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the AddPermission operation waiting for the response before returning.
@@ -97,7 +97,7 @@ public protocol SimpleQueueClientProtocol {
            is complete.
            The possible errors are: messageNotInflight, receiptHandleIsInvalid.
      */
-    func changeMessageVisibilityAsync(input: SimpleQueueModel.ChangeMessageVisibilityRequest, completion: @escaping (Error?) -> ()) throws
+    func changeMessageVisibilityAsync(input: SimpleQueueModel.ChangeMessageVisibilityRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the ChangeMessageVisibility operation waiting for the response before returning.
@@ -163,7 +163,7 @@ public protocol SimpleQueueClientProtocol {
            is complete.
            The possible errors are: invalidIdFormat, receiptHandleIsInvalid.
      */
-    func deleteMessageAsync(input: SimpleQueueModel.DeleteMessageRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteMessageAsync(input: SimpleQueueModel.DeleteMessageRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteMessage operation waiting for the response before returning.
@@ -205,7 +205,7 @@ public protocol SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func deleteQueueAsync(input: SimpleQueueModel.DeleteQueueRequest, completion: @escaping (Error?) -> ()) throws
+    func deleteQueueAsync(input: SimpleQueueModel.DeleteQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeleteQueue operation waiting for the response before returning.
@@ -335,7 +335,7 @@ public protocol SimpleQueueClientProtocol {
            is complete.
            The possible errors are: purgeQueueInProgress, queueDoesNotExist.
      */
-    func purgeQueueAsync(input: SimpleQueueModel.PurgeQueueRequest, completion: @escaping (Error?) -> ()) throws
+    func purgeQueueAsync(input: SimpleQueueModel.PurgeQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the PurgeQueue operation waiting for the response before returning.
@@ -377,7 +377,7 @@ public protocol SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func removePermissionAsync(input: SimpleQueueModel.RemovePermissionRequest, completion: @escaping (Error?) -> ()) throws
+    func removePermissionAsync(input: SimpleQueueModel.RemovePermissionRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RemovePermission operation waiting for the response before returning.
@@ -442,7 +442,7 @@ public protocol SimpleQueueClientProtocol {
            is complete.
            The possible errors are: invalidAttributeName.
      */
-    func setQueueAttributesAsync(input: SimpleQueueModel.SetQueueAttributesRequest, completion: @escaping (Error?) -> ()) throws
+    func setQueueAttributesAsync(input: SimpleQueueModel.SetQueueAttributesRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the SetQueueAttributes operation waiting for the response before returning.
@@ -461,7 +461,7 @@ public protocol SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func tagQueueAsync(input: SimpleQueueModel.TagQueueRequest, completion: @escaping (Error?) -> ()) throws
+    func tagQueueAsync(input: SimpleQueueModel.TagQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the TagQueue operation waiting for the response before returning.
@@ -479,7 +479,7 @@ public protocol SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    func untagQueueAsync(input: SimpleQueueModel.UntagQueueRequest, completion: @escaping (Error?) -> ()) throws
+    func untagQueueAsync(input: SimpleQueueModel.UntagQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the UntagQueue operation waiting for the response before returning.

--- a/Sources/SimpleQueueClient/SimpleQueueOperationsClientInput.swift
+++ b/Sources/SimpleQueueClient/SimpleQueueOperationsClientInput.swift
@@ -26,57 +26,57 @@ import SimpleQueueModel
 /**
  Type to handle the input to the AddPermission operation in a HTTP client.
  */
-public struct AddPermissionOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: AddPermissionRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct AddPermissionOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: AddPermissionOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: AddPermissionRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelAddPermissionRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: AddPermissionRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelAddPermissionOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the ChangeMessageVisibility operation in a HTTP client.
  */
-public struct ChangeMessageVisibilityOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: ChangeMessageVisibilityRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct ChangeMessageVisibilityOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ChangeMessageVisibilityOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: ChangeMessageVisibilityRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelChangeMessageVisibilityRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: ChangeMessageVisibilityRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelChangeMessageVisibilityOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the ChangeMessageVisibilityBatch operation in a HTTP client.
  */
-public struct ChangeMessageVisibilityBatchOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: ChangeMessageVisibilityBatchRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct ChangeMessageVisibilityBatchOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ChangeMessageVisibilityBatchOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: ChangeMessageVisibilityBatchRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelChangeMessageVisibilityBatchRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: ChangeMessageVisibilityBatchRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelChangeMessageVisibilityBatchOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the CreateQueue operation in a HTTP client.
  */
@@ -85,75 +85,75 @@ public typealias CreateQueueOperationHTTPRequestInput = QueryHTTPRequestInput
 /**
  Type to handle the input to the DeleteMessage operation in a HTTP client.
  */
-public struct DeleteMessageOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: DeleteMessageRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct DeleteMessageOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: DeleteMessageOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: DeleteMessageRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelDeleteMessageRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: DeleteMessageRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelDeleteMessageOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the DeleteMessageBatch operation in a HTTP client.
  */
-public struct DeleteMessageBatchOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: DeleteMessageBatchRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct DeleteMessageBatchOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: DeleteMessageBatchOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: DeleteMessageBatchRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelDeleteMessageBatchRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: DeleteMessageBatchRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelDeleteMessageBatchOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the DeleteQueue operation in a HTTP client.
  */
-public struct DeleteQueueOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: String?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct DeleteQueueOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: DeleteQueueRequest) {
-            self.queryEncodable = nil
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: DeleteQueueRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the GetQueueAttributes operation in a HTTP client.
  */
-public struct GetQueueAttributesOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: GetQueueAttributesRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct GetQueueAttributesOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: GetQueueAttributesOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: GetQueueAttributesRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelGetQueueAttributesRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: GetQueueAttributesRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelGetQueueAttributesOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the GetQueueUrl operation in a HTTP client.
  */
@@ -162,39 +162,39 @@ public typealias GetQueueUrlOperationHTTPRequestInput = QueryHTTPRequestInput
 /**
  Type to handle the input to the ListDeadLetterSourceQueues operation in a HTTP client.
  */
-public struct ListDeadLetterSourceQueuesOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: String?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct ListDeadLetterSourceQueuesOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: ListDeadLetterSourceQueuesRequest) {
-            self.queryEncodable = nil
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: ListDeadLetterSourceQueuesRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the ListQueueTags operation in a HTTP client.
  */
-public struct ListQueueTagsOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: String?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct ListQueueTagsOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: ListQueueTagsRequest) {
-            self.queryEncodable = nil
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: ListQueueTagsRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the ListQueues operation in a HTTP client.
  */
@@ -203,144 +203,144 @@ public typealias ListQueuesOperationHTTPRequestInput = QueryHTTPRequestInput
 /**
  Type to handle the input to the PurgeQueue operation in a HTTP client.
  */
-public struct PurgeQueueOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: String?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct PurgeQueueOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: String?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: PurgeQueueRequest) {
-            self.queryEncodable = nil
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: PurgeQueueRequest) {
+        self.queryEncodable = nil
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the ReceiveMessage operation in a HTTP client.
  */
-public struct ReceiveMessageOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: ReceiveMessageRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct ReceiveMessageOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: ReceiveMessageOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: ReceiveMessageRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelReceiveMessageRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: ReceiveMessageRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelReceiveMessageOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the RemovePermission operation in a HTTP client.
  */
-public struct RemovePermissionOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: RemovePermissionRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct RemovePermissionOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: RemovePermissionOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: RemovePermissionRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelRemovePermissionRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: RemovePermissionRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelRemovePermissionOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the SendMessage operation in a HTTP client.
  */
-public struct SendMessageOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: SendMessageRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct SendMessageOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: SendMessageOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: SendMessageRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelSendMessageRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: SendMessageRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelSendMessageOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the SendMessageBatch operation in a HTTP client.
  */
-public struct SendMessageBatchOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: SendMessageBatchRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct SendMessageBatchOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: SendMessageBatchOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: SendMessageBatchRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelSendMessageBatchRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: SendMessageBatchRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelSendMessageBatchOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the SetQueueAttributes operation in a HTTP client.
  */
-public struct SetQueueAttributesOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: SetQueueAttributesRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct SetQueueAttributesOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: SetQueueAttributesOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: SetQueueAttributesRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelSetQueueAttributesRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: SetQueueAttributesRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelSetQueueAttributesOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the TagQueue operation in a HTTP client.
  */
-public struct TagQueueOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: TagQueueRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct TagQueueOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: TagQueueOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: TagQueueRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelTagQueueRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: TagQueueRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelTagQueueOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}
 /**
  Type to handle the input to the UntagQueue operation in a HTTP client.
  */
-public struct UntagQueueOperationHTTPRequestInput<InputType: Encodable> : HTTPRequestInputProtocol {
-        public let queryEncodable: UntagQueueRequestQuery?
-        public let pathEncodable: String?
-        public let bodyEncodable: String?
-        public let additionalHeadersEncodable: String?
-        public let pathPostfix: String?
+public struct UntagQueueOperationHTTPRequestInput: HTTPRequestInputProtocol {
+    public let queryEncodable: UntagQueueOperationInputQuery?
+    public let pathEncodable: String?
+    public let bodyEncodable: String?
+    public let additionalHeadersEncodable: String?
+    public let pathPostfix: String?
 
-        public init(encodable: UntagQueueRequest) {
-            self.queryEncodable = encodable.asSimpleQueueModelUntagQueueRequestQuery()
-            self.pathEncodable = nil
-            self.bodyEncodable = nil
-            self.additionalHeadersEncodable = nil
-            self.pathPostfix = encodable.queueUrl
-        }
+    public init(encodable: UntagQueueRequest) {
+        self.queryEncodable = encodable.asSimpleQueueModelUntagQueueOperationInputQuery()
+        self.pathEncodable = nil
+        self.bodyEncodable = nil
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = encodable.queueUrl
     }
+}

--- a/Sources/SimpleQueueClient/SimpleQueueOperationsClientOutput.swift
+++ b/Sources/SimpleQueueClient/SimpleQueueOperationsClientOutput.swift
@@ -1,0 +1,168 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// SimpleQueueOperationsClientOutput.swift
+// SimpleQueueClient
+//
+
+import Foundation
+import SmokeHTTPClient
+import SimpleQueueModel
+
+/**
+ Type to handle the output from the ChangeMessageVisibilityBatch operation in a HTTP client.
+ */
+extension ChangeMessageVisibilityBatchResultForChangeMessageVisibilityBatch: HTTPResponseOutputProtocol {
+    public typealias BodyType = ChangeMessageVisibilityBatchResultForChangeMessageVisibilityBatch
+    public typealias HeadersType = ChangeMessageVisibilityBatchResultForChangeMessageVisibilityBatch
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ChangeMessageVisibilityBatchResultForChangeMessageVisibilityBatch {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateQueue operation in a HTTP client.
+ */
+extension CreateQueueResultForCreateQueue: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateQueueResultForCreateQueue
+    public typealias HeadersType = CreateQueueResultForCreateQueue
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateQueueResultForCreateQueue {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteMessageBatch operation in a HTTP client.
+ */
+extension DeleteMessageBatchResultForDeleteMessageBatch: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteMessageBatchResultForDeleteMessageBatch
+    public typealias HeadersType = DeleteMessageBatchResultForDeleteMessageBatch
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteMessageBatchResultForDeleteMessageBatch {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetQueueAttributes operation in a HTTP client.
+ */
+extension GetQueueAttributesResultForGetQueueAttributes: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetQueueAttributesResultForGetQueueAttributes
+    public typealias HeadersType = GetQueueAttributesResultForGetQueueAttributes
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetQueueAttributesResultForGetQueueAttributes {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetQueueUrl operation in a HTTP client.
+ */
+extension GetQueueUrlResultForGetQueueUrl: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetQueueUrlResultForGetQueueUrl
+    public typealias HeadersType = GetQueueUrlResultForGetQueueUrl
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetQueueUrlResultForGetQueueUrl {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListDeadLetterSourceQueues operation in a HTTP client.
+ */
+extension ListDeadLetterSourceQueuesResultForListDeadLetterSourceQueues: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListDeadLetterSourceQueuesResultForListDeadLetterSourceQueues
+    public typealias HeadersType = ListDeadLetterSourceQueuesResultForListDeadLetterSourceQueues
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListDeadLetterSourceQueuesResultForListDeadLetterSourceQueues {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListQueueTags operation in a HTTP client.
+ */
+extension ListQueueTagsResultForListQueueTags: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListQueueTagsResultForListQueueTags
+    public typealias HeadersType = ListQueueTagsResultForListQueueTags
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListQueueTagsResultForListQueueTags {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListQueues operation in a HTTP client.
+ */
+extension ListQueuesResultForListQueues: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListQueuesResultForListQueues
+    public typealias HeadersType = ListQueuesResultForListQueues
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListQueuesResultForListQueues {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ReceiveMessage operation in a HTTP client.
+ */
+extension ReceiveMessageResultForReceiveMessage: HTTPResponseOutputProtocol {
+    public typealias BodyType = ReceiveMessageResultForReceiveMessage
+    public typealias HeadersType = ReceiveMessageResultForReceiveMessage
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ReceiveMessageResultForReceiveMessage {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the SendMessage operation in a HTTP client.
+ */
+extension SendMessageResultForSendMessage: HTTPResponseOutputProtocol {
+    public typealias BodyType = SendMessageResultForSendMessage
+    public typealias HeadersType = SendMessageResultForSendMessage
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> SendMessageResultForSendMessage {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the SendMessageBatch operation in a HTTP client.
+ */
+extension SendMessageBatchResultForSendMessageBatch: HTTPResponseOutputProtocol {
+    public typealias BodyType = SendMessageBatchResultForSendMessageBatch
+    public typealias HeadersType = SendMessageBatchResultForSendMessageBatch
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> SendMessageBatchResultForSendMessageBatch {
+        return try bodyDecodableProvider()
+    }
+}
+

--- a/Sources/SimpleQueueClient/ThrowingSimpleQueueClient.swift
+++ b/Sources/SimpleQueueClient/ThrowingSimpleQueueClient.swift
@@ -166,7 +166,7 @@ public struct ThrowingSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: overLimit.
      */
-    public func addPermissionAsync(input: SimpleQueueModel.AddPermissionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func addPermissionAsync(input: SimpleQueueModel.AddPermissionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let addPermissionAsyncOverride = addPermissionAsyncOverride {
             return try addPermissionAsyncOverride(input, completion)
         }
@@ -198,7 +198,7 @@ public struct ThrowingSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: messageNotInflight, receiptHandleIsInvalid.
      */
-    public func changeMessageVisibilityAsync(input: SimpleQueueModel.ChangeMessageVisibilityRequest, completion: @escaping (Error?) -> ()) throws {
+    public func changeMessageVisibilityAsync(input: SimpleQueueModel.ChangeMessageVisibilityRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let changeMessageVisibilityAsyncOverride = changeMessageVisibilityAsyncOverride {
             return try changeMessageVisibilityAsyncOverride(input, completion)
         }
@@ -300,7 +300,7 @@ public struct ThrowingSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: invalidIdFormat, receiptHandleIsInvalid.
      */
-    public func deleteMessageAsync(input: SimpleQueueModel.DeleteMessageRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteMessageAsync(input: SimpleQueueModel.DeleteMessageRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteMessageAsyncOverride = deleteMessageAsyncOverride {
             return try deleteMessageAsyncOverride(input, completion)
         }
@@ -366,7 +366,7 @@ public struct ThrowingSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func deleteQueueAsync(input: SimpleQueueModel.DeleteQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func deleteQueueAsync(input: SimpleQueueModel.DeleteQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deleteQueueAsyncOverride = deleteQueueAsyncOverride {
             return try deleteQueueAsyncOverride(input, completion)
         }
@@ -568,7 +568,7 @@ public struct ThrowingSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: purgeQueueInProgress, queueDoesNotExist.
      */
-    public func purgeQueueAsync(input: SimpleQueueModel.PurgeQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func purgeQueueAsync(input: SimpleQueueModel.PurgeQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let purgeQueueAsyncOverride = purgeQueueAsyncOverride {
             return try purgeQueueAsyncOverride(input, completion)
         }
@@ -634,7 +634,7 @@ public struct ThrowingSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func removePermissionAsync(input: SimpleQueueModel.RemovePermissionRequest, completion: @escaping (Error?) -> ()) throws {
+    public func removePermissionAsync(input: SimpleQueueModel.RemovePermissionRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let removePermissionAsyncOverride = removePermissionAsyncOverride {
             return try removePermissionAsyncOverride(input, completion)
         }
@@ -735,7 +735,7 @@ public struct ThrowingSimpleQueueClient: SimpleQueueClientProtocol {
            is complete.
            The possible errors are: invalidAttributeName.
      */
-    public func setQueueAttributesAsync(input: SimpleQueueModel.SetQueueAttributesRequest, completion: @escaping (Error?) -> ()) throws {
+    public func setQueueAttributesAsync(input: SimpleQueueModel.SetQueueAttributesRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let setQueueAttributesAsyncOverride = setQueueAttributesAsyncOverride {
             return try setQueueAttributesAsyncOverride(input, completion)
         }
@@ -766,7 +766,7 @@ public struct ThrowingSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func tagQueueAsync(input: SimpleQueueModel.TagQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func tagQueueAsync(input: SimpleQueueModel.TagQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let tagQueueAsyncOverride = tagQueueAsyncOverride {
             return try tagQueueAsyncOverride(input, completion)
         }
@@ -796,7 +796,7 @@ public struct ThrowingSimpleQueueClient: SimpleQueueClientProtocol {
          - completion: Nil or an error will be passed to this callback when the operation
            is complete.
      */
-    public func untagQueueAsync(input: SimpleQueueModel.UntagQueueRequest, completion: @escaping (Error?) -> ()) throws {
+    public func untagQueueAsync(input: SimpleQueueModel.UntagQueueRequest, completion: @escaping (Swift.Error?) -> ()) throws {
         if let untagQueueAsyncOverride = untagQueueAsyncOverride {
             return try untagQueueAsyncOverride(input, completion)
         }

--- a/Sources/SimpleQueueModel/SimpleQueueModelOperations.swift
+++ b/Sources/SimpleQueueModel/SimpleQueueModelOperations.swift
@@ -97,7 +97,7 @@ public enum SimpleQueueModelOperations: String {
  Structure to encode the query input for the AddPermission
  operation.
  */
-public struct AddPermissionRequestQuery: Codable, Equatable {
+public struct AddPermissionOperationInputQuery: Codable, Equatable {
     public var aWSAccountIds: AWSAccountIdList
     public var actions: ActionNameList
     public var label: String
@@ -121,8 +121,8 @@ public struct AddPermissionRequestQuery: Codable, Equatable {
 }
 
 public extension AddPermissionRequest {
-    public func asSimpleQueueModelAddPermissionRequestQuery() -> AddPermissionRequestQuery {
-        return AddPermissionRequestQuery(
+    public func asSimpleQueueModelAddPermissionOperationInputQuery() -> AddPermissionOperationInputQuery {
+        return AddPermissionOperationInputQuery(
             aWSAccountIds: aWSAccountIds,
             actions: actions,
             label: label)
@@ -134,7 +134,7 @@ public extension AddPermissionRequest {
  Structure to encode the query input for the ChangeMessageVisibility
  operation.
  */
-public struct ChangeMessageVisibilityRequestQuery: Codable, Equatable {
+public struct ChangeMessageVisibilityOperationInputQuery: Codable, Equatable {
     public var receiptHandle: String
     public var visibilityTimeout: Integer
 
@@ -154,8 +154,8 @@ public struct ChangeMessageVisibilityRequestQuery: Codable, Equatable {
 }
 
 public extension ChangeMessageVisibilityRequest {
-    public func asSimpleQueueModelChangeMessageVisibilityRequestQuery() -> ChangeMessageVisibilityRequestQuery {
-        return ChangeMessageVisibilityRequestQuery(
+    public func asSimpleQueueModelChangeMessageVisibilityOperationInputQuery() -> ChangeMessageVisibilityOperationInputQuery {
+        return ChangeMessageVisibilityOperationInputQuery(
             receiptHandle: receiptHandle,
             visibilityTimeout: visibilityTimeout)
     }
@@ -166,7 +166,7 @@ public extension ChangeMessageVisibilityRequest {
  Structure to encode the query input for the ChangeMessageVisibilityBatch
  operation.
  */
-public struct ChangeMessageVisibilityBatchRequestQuery: Codable, Equatable {
+public struct ChangeMessageVisibilityBatchOperationInputQuery: Codable, Equatable {
     public var entries: ChangeMessageVisibilityBatchRequestEntryList
 
     public init(entries: ChangeMessageVisibilityBatchRequestEntryList) {
@@ -182,8 +182,8 @@ public struct ChangeMessageVisibilityBatchRequestQuery: Codable, Equatable {
 }
 
 public extension ChangeMessageVisibilityBatchRequest {
-    public func asSimpleQueueModelChangeMessageVisibilityBatchRequestQuery() -> ChangeMessageVisibilityBatchRequestQuery {
-        return ChangeMessageVisibilityBatchRequestQuery(
+    public func asSimpleQueueModelChangeMessageVisibilityBatchOperationInputQuery() -> ChangeMessageVisibilityBatchOperationInputQuery {
+        return ChangeMessageVisibilityBatchOperationInputQuery(
             entries: entries)
     }
 }
@@ -193,7 +193,7 @@ public extension ChangeMessageVisibilityBatchRequest {
  Structure to encode the query input for the DeleteMessage
  operation.
  */
-public struct DeleteMessageRequestQuery: Codable, Equatable {
+public struct DeleteMessageOperationInputQuery: Codable, Equatable {
     public var receiptHandle: String
 
     public init(receiptHandle: String) {
@@ -209,8 +209,8 @@ public struct DeleteMessageRequestQuery: Codable, Equatable {
 }
 
 public extension DeleteMessageRequest {
-    public func asSimpleQueueModelDeleteMessageRequestQuery() -> DeleteMessageRequestQuery {
-        return DeleteMessageRequestQuery(
+    public func asSimpleQueueModelDeleteMessageOperationInputQuery() -> DeleteMessageOperationInputQuery {
+        return DeleteMessageOperationInputQuery(
             receiptHandle: receiptHandle)
     }
 }
@@ -220,7 +220,7 @@ public extension DeleteMessageRequest {
  Structure to encode the query input for the DeleteMessageBatch
  operation.
  */
-public struct DeleteMessageBatchRequestQuery: Codable, Equatable {
+public struct DeleteMessageBatchOperationInputQuery: Codable, Equatable {
     public var entries: DeleteMessageBatchRequestEntryList
 
     public init(entries: DeleteMessageBatchRequestEntryList) {
@@ -236,8 +236,8 @@ public struct DeleteMessageBatchRequestQuery: Codable, Equatable {
 }
 
 public extension DeleteMessageBatchRequest {
-    public func asSimpleQueueModelDeleteMessageBatchRequestQuery() -> DeleteMessageBatchRequestQuery {
-        return DeleteMessageBatchRequestQuery(
+    public func asSimpleQueueModelDeleteMessageBatchOperationInputQuery() -> DeleteMessageBatchOperationInputQuery {
+        return DeleteMessageBatchOperationInputQuery(
             entries: entries)
     }
 }
@@ -247,7 +247,7 @@ public extension DeleteMessageBatchRequest {
  Structure to encode the query input for the GetQueueAttributes
  operation.
  */
-public struct GetQueueAttributesRequestQuery: Codable, Equatable {
+public struct GetQueueAttributesOperationInputQuery: Codable, Equatable {
     public var attributeNames: AttributeNameList?
 
     public init(attributeNames: AttributeNameList? = nil) {
@@ -263,8 +263,8 @@ public struct GetQueueAttributesRequestQuery: Codable, Equatable {
 }
 
 public extension GetQueueAttributesRequest {
-    public func asSimpleQueueModelGetQueueAttributesRequestQuery() -> GetQueueAttributesRequestQuery {
-        return GetQueueAttributesRequestQuery(
+    public func asSimpleQueueModelGetQueueAttributesOperationInputQuery() -> GetQueueAttributesOperationInputQuery {
+        return GetQueueAttributesOperationInputQuery(
             attributeNames: attributeNames)
     }
 }
@@ -274,7 +274,7 @@ public extension GetQueueAttributesRequest {
  Structure to encode the query input for the ReceiveMessage
  operation.
  */
-public struct ReceiveMessageRequestQuery: Codable, Equatable {
+public struct ReceiveMessageOperationInputQuery: Codable, Equatable {
     public var attributeNames: AttributeNameList?
     public var maxNumberOfMessages: Integer?
     public var messageAttributeNames: MessageAttributeNameList?
@@ -310,8 +310,8 @@ public struct ReceiveMessageRequestQuery: Codable, Equatable {
 }
 
 public extension ReceiveMessageRequest {
-    public func asSimpleQueueModelReceiveMessageRequestQuery() -> ReceiveMessageRequestQuery {
-        return ReceiveMessageRequestQuery(
+    public func asSimpleQueueModelReceiveMessageOperationInputQuery() -> ReceiveMessageOperationInputQuery {
+        return ReceiveMessageOperationInputQuery(
             attributeNames: attributeNames,
             maxNumberOfMessages: maxNumberOfMessages,
             messageAttributeNames: messageAttributeNames,
@@ -326,7 +326,7 @@ public extension ReceiveMessageRequest {
  Structure to encode the query input for the RemovePermission
  operation.
  */
-public struct RemovePermissionRequestQuery: Codable, Equatable {
+public struct RemovePermissionOperationInputQuery: Codable, Equatable {
     public var label: String
 
     public init(label: String) {
@@ -342,8 +342,8 @@ public struct RemovePermissionRequestQuery: Codable, Equatable {
 }
 
 public extension RemovePermissionRequest {
-    public func asSimpleQueueModelRemovePermissionRequestQuery() -> RemovePermissionRequestQuery {
-        return RemovePermissionRequestQuery(
+    public func asSimpleQueueModelRemovePermissionOperationInputQuery() -> RemovePermissionOperationInputQuery {
+        return RemovePermissionOperationInputQuery(
             label: label)
     }
 }
@@ -353,7 +353,7 @@ public extension RemovePermissionRequest {
  Structure to encode the query input for the SendMessage
  operation.
  */
-public struct SendMessageRequestQuery: Codable, Equatable {
+public struct SendMessageOperationInputQuery: Codable, Equatable {
     public var delaySeconds: Integer?
     public var messageAttributes: MessageBodyAttributeMap?
     public var messageBody: String
@@ -385,8 +385,8 @@ public struct SendMessageRequestQuery: Codable, Equatable {
 }
 
 public extension SendMessageRequest {
-    public func asSimpleQueueModelSendMessageRequestQuery() -> SendMessageRequestQuery {
-        return SendMessageRequestQuery(
+    public func asSimpleQueueModelSendMessageOperationInputQuery() -> SendMessageOperationInputQuery {
+        return SendMessageOperationInputQuery(
             delaySeconds: delaySeconds,
             messageAttributes: messageAttributes,
             messageBody: messageBody,
@@ -400,7 +400,7 @@ public extension SendMessageRequest {
  Structure to encode the query input for the SendMessageBatch
  operation.
  */
-public struct SendMessageBatchRequestQuery: Codable, Equatable {
+public struct SendMessageBatchOperationInputQuery: Codable, Equatable {
     public var entries: SendMessageBatchRequestEntryList
 
     public init(entries: SendMessageBatchRequestEntryList) {
@@ -416,8 +416,8 @@ public struct SendMessageBatchRequestQuery: Codable, Equatable {
 }
 
 public extension SendMessageBatchRequest {
-    public func asSimpleQueueModelSendMessageBatchRequestQuery() -> SendMessageBatchRequestQuery {
-        return SendMessageBatchRequestQuery(
+    public func asSimpleQueueModelSendMessageBatchOperationInputQuery() -> SendMessageBatchOperationInputQuery {
+        return SendMessageBatchOperationInputQuery(
             entries: entries)
     }
 }
@@ -427,7 +427,7 @@ public extension SendMessageBatchRequest {
  Structure to encode the query input for the SetQueueAttributes
  operation.
  */
-public struct SetQueueAttributesRequestQuery: Codable, Equatable {
+public struct SetQueueAttributesOperationInputQuery: Codable, Equatable {
     public var attributes: QueueAttributeMap
 
     public init(attributes: QueueAttributeMap) {
@@ -443,8 +443,8 @@ public struct SetQueueAttributesRequestQuery: Codable, Equatable {
 }
 
 public extension SetQueueAttributesRequest {
-    public func asSimpleQueueModelSetQueueAttributesRequestQuery() -> SetQueueAttributesRequestQuery {
-        return SetQueueAttributesRequestQuery(
+    public func asSimpleQueueModelSetQueueAttributesOperationInputQuery() -> SetQueueAttributesOperationInputQuery {
+        return SetQueueAttributesOperationInputQuery(
             attributes: attributes)
     }
 }
@@ -454,7 +454,7 @@ public extension SetQueueAttributesRequest {
  Structure to encode the query input for the TagQueue
  operation.
  */
-public struct TagQueueRequestQuery: Codable, Equatable {
+public struct TagQueueOperationInputQuery: Codable, Equatable {
     public var tags: TagMap
 
     public init(tags: TagMap) {
@@ -470,8 +470,8 @@ public struct TagQueueRequestQuery: Codable, Equatable {
 }
 
 public extension TagQueueRequest {
-    public func asSimpleQueueModelTagQueueRequestQuery() -> TagQueueRequestQuery {
-        return TagQueueRequestQuery(
+    public func asSimpleQueueModelTagQueueOperationInputQuery() -> TagQueueOperationInputQuery {
+        return TagQueueOperationInputQuery(
             tags: tags)
     }
 }
@@ -481,7 +481,7 @@ public extension TagQueueRequest {
  Structure to encode the query input for the UntagQueue
  operation.
  */
-public struct UntagQueueRequestQuery: Codable, Equatable {
+public struct UntagQueueOperationInputQuery: Codable, Equatable {
     public var tagKeys: TagKeyList
 
     public init(tagKeys: TagKeyList) {
@@ -497,8 +497,8 @@ public struct UntagQueueRequestQuery: Codable, Equatable {
 }
 
 public extension UntagQueueRequest {
-    public func asSimpleQueueModelUntagQueueRequestQuery() -> UntagQueueRequestQuery {
-        return UntagQueueRequestQuery(
+    public func asSimpleQueueModelUntagQueueOperationInputQuery() -> UntagQueueOperationInputQuery {
+        return UntagQueueOperationInputQuery(
             tagKeys: tagKeys)
     }
 }

--- a/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
+++ b/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
@@ -64,6 +64,22 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
     }
 
     /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times.
+     */
+    public func close() {
+        httpClient.close()
+    }
+
+    /**
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
+     */
+    public func wait() {
+        httpClient.wait()
+    }
+
+    /**
      Invokes the CountClosedWorkflowExecutions operation returning immediately and passing the response to a callback.
 
      - Parameters:
@@ -80,7 +96,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.countClosedWorkflowExecutions.rawValue,
                     target: target)
-        
+
         let requestInput = CountClosedWorkflowExecutionsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -107,7 +123,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.countClosedWorkflowExecutions.rawValue,
                     target: target)
-        
+
         let requestInput = CountClosedWorkflowExecutionsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -134,7 +150,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.countOpenWorkflowExecutions.rawValue,
                     target: target)
-        
+
         let requestInput = CountOpenWorkflowExecutionsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -161,7 +177,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.countOpenWorkflowExecutions.rawValue,
                     target: target)
-        
+
         let requestInput = CountOpenWorkflowExecutionsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -188,7 +204,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.countPendingActivityTasks.rawValue,
                     target: target)
-        
+
         let requestInput = CountPendingActivityTasksOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -215,7 +231,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.countPendingActivityTasks.rawValue,
                     target: target)
-        
+
         let requestInput = CountPendingActivityTasksOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -242,7 +258,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.countPendingDecisionTasks.rawValue,
                     target: target)
-        
+
         let requestInput = CountPendingDecisionTasksOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -269,7 +285,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.countPendingDecisionTasks.rawValue,
                     target: target)
-        
+
         let requestInput = CountPendingDecisionTasksOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -288,14 +304,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, typeDeprecated, unknownResource.
      */
-    public func deprecateActivityTypeAsync(input: SimpleWorkflowModel.DeprecateActivityTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func deprecateActivityTypeAsync(input: SimpleWorkflowModel.DeprecateActivityTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.deprecateActivityType.rawValue,
                     target: target)
-        
+
         let requestInput = DeprecateActivityTypeOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -320,7 +336,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.deprecateActivityType.rawValue,
                     target: target)
-        
+
         let requestInput = DeprecateActivityTypeOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -339,14 +355,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: domainDeprecated, operationNotPermitted, unknownResource.
      */
-    public func deprecateDomainAsync(input: SimpleWorkflowModel.DeprecateDomainInput, completion: @escaping (Error?) -> ()) throws {
+    public func deprecateDomainAsync(input: SimpleWorkflowModel.DeprecateDomainInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.deprecateDomain.rawValue,
                     target: target)
-        
+
         let requestInput = DeprecateDomainOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -371,7 +387,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.deprecateDomain.rawValue,
                     target: target)
-        
+
         let requestInput = DeprecateDomainOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -390,14 +406,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, typeDeprecated, unknownResource.
      */
-    public func deprecateWorkflowTypeAsync(input: SimpleWorkflowModel.DeprecateWorkflowTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func deprecateWorkflowTypeAsync(input: SimpleWorkflowModel.DeprecateWorkflowTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.deprecateWorkflowType.rawValue,
                     target: target)
-        
+
         let requestInput = DeprecateWorkflowTypeOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -422,7 +438,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.deprecateWorkflowType.rawValue,
                     target: target)
-        
+
         let requestInput = DeprecateWorkflowTypeOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -449,7 +465,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.describeActivityType.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeActivityTypeOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -476,7 +492,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.describeActivityType.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeActivityTypeOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -503,7 +519,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.describeDomain.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeDomainOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -530,7 +546,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.describeDomain.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeDomainOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -557,7 +573,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.describeWorkflowExecution.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeWorkflowExecutionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -584,7 +600,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.describeWorkflowExecution.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeWorkflowExecutionOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -611,7 +627,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.describeWorkflowType.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeWorkflowTypeOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -638,7 +654,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.describeWorkflowType.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeWorkflowTypeOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -665,7 +681,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.getWorkflowExecutionHistory.rawValue,
                     target: target)
-        
+
         let requestInput = GetWorkflowExecutionHistoryOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -692,7 +708,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.getWorkflowExecutionHistory.rawValue,
                     target: target)
-        
+
         let requestInput = GetWorkflowExecutionHistoryOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -719,7 +735,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.listActivityTypes.rawValue,
                     target: target)
-        
+
         let requestInput = ListActivityTypesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -746,7 +762,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.listActivityTypes.rawValue,
                     target: target)
-        
+
         let requestInput = ListActivityTypesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -773,7 +789,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.listClosedWorkflowExecutions.rawValue,
                     target: target)
-        
+
         let requestInput = ListClosedWorkflowExecutionsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -800,7 +816,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.listClosedWorkflowExecutions.rawValue,
                     target: target)
-        
+
         let requestInput = ListClosedWorkflowExecutionsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -827,7 +843,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.listDomains.rawValue,
                     target: target)
-        
+
         let requestInput = ListDomainsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -854,7 +870,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.listDomains.rawValue,
                     target: target)
-        
+
         let requestInput = ListDomainsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -881,7 +897,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.listOpenWorkflowExecutions.rawValue,
                     target: target)
-        
+
         let requestInput = ListOpenWorkflowExecutionsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -908,7 +924,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.listOpenWorkflowExecutions.rawValue,
                     target: target)
-        
+
         let requestInput = ListOpenWorkflowExecutionsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -935,7 +951,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.listWorkflowTypes.rawValue,
                     target: target)
-        
+
         let requestInput = ListWorkflowTypesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -962,7 +978,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.listWorkflowTypes.rawValue,
                     target: target)
-        
+
         let requestInput = ListWorkflowTypesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -989,7 +1005,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.pollForActivityTask.rawValue,
                     target: target)
-        
+
         let requestInput = PollForActivityTaskOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1016,7 +1032,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.pollForActivityTask.rawValue,
                     target: target)
-        
+
         let requestInput = PollForActivityTaskOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1043,7 +1059,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.pollForDecisionTask.rawValue,
                     target: target)
-        
+
         let requestInput = PollForDecisionTaskOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1070,7 +1086,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.pollForDecisionTask.rawValue,
                     target: target)
-        
+
         let requestInput = PollForDecisionTaskOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1097,7 +1113,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.recordActivityTaskHeartbeat.rawValue,
                     target: target)
-        
+
         let requestInput = RecordActivityTaskHeartbeatOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1124,7 +1140,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.recordActivityTaskHeartbeat.rawValue,
                     target: target)
-        
+
         let requestInput = RecordActivityTaskHeartbeatOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1143,14 +1159,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: limitExceeded, operationNotPermitted, typeAlreadyExists, unknownResource.
      */
-    public func registerActivityTypeAsync(input: SimpleWorkflowModel.RegisterActivityTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func registerActivityTypeAsync(input: SimpleWorkflowModel.RegisterActivityTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.registerActivityType.rawValue,
                     target: target)
-        
+
         let requestInput = RegisterActivityTypeOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1175,7 +1191,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.registerActivityType.rawValue,
                     target: target)
-        
+
         let requestInput = RegisterActivityTypeOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1194,14 +1210,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: domainAlreadyExists, limitExceeded, operationNotPermitted.
      */
-    public func registerDomainAsync(input: SimpleWorkflowModel.RegisterDomainInput, completion: @escaping (Error?) -> ()) throws {
+    public func registerDomainAsync(input: SimpleWorkflowModel.RegisterDomainInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.registerDomain.rawValue,
                     target: target)
-        
+
         let requestInput = RegisterDomainOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1226,7 +1242,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.registerDomain.rawValue,
                     target: target)
-        
+
         let requestInput = RegisterDomainOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1245,14 +1261,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: limitExceeded, operationNotPermitted, typeAlreadyExists, unknownResource.
      */
-    public func registerWorkflowTypeAsync(input: SimpleWorkflowModel.RegisterWorkflowTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func registerWorkflowTypeAsync(input: SimpleWorkflowModel.RegisterWorkflowTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.registerWorkflowType.rawValue,
                     target: target)
-        
+
         let requestInput = RegisterWorkflowTypeOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1277,7 +1293,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.registerWorkflowType.rawValue,
                     target: target)
-        
+
         let requestInput = RegisterWorkflowTypeOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1296,14 +1312,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func requestCancelWorkflowExecutionAsync(input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws {
+    public func requestCancelWorkflowExecutionAsync(input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.requestCancelWorkflowExecution.rawValue,
                     target: target)
-        
+
         let requestInput = RequestCancelWorkflowExecutionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1328,7 +1344,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.requestCancelWorkflowExecution.rawValue,
                     target: target)
-        
+
         let requestInput = RequestCancelWorkflowExecutionOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1347,14 +1363,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondActivityTaskCanceledAsync(input: SimpleWorkflowModel.RespondActivityTaskCanceledInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondActivityTaskCanceledAsync(input: SimpleWorkflowModel.RespondActivityTaskCanceledInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.respondActivityTaskCanceled.rawValue,
                     target: target)
-        
+
         let requestInput = RespondActivityTaskCanceledOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1379,7 +1395,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.respondActivityTaskCanceled.rawValue,
                     target: target)
-        
+
         let requestInput = RespondActivityTaskCanceledOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1398,14 +1414,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondActivityTaskCompletedAsync(input: SimpleWorkflowModel.RespondActivityTaskCompletedInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondActivityTaskCompletedAsync(input: SimpleWorkflowModel.RespondActivityTaskCompletedInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.respondActivityTaskCompleted.rawValue,
                     target: target)
-        
+
         let requestInput = RespondActivityTaskCompletedOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1430,7 +1446,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.respondActivityTaskCompleted.rawValue,
                     target: target)
-        
+
         let requestInput = RespondActivityTaskCompletedOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1449,14 +1465,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondActivityTaskFailedAsync(input: SimpleWorkflowModel.RespondActivityTaskFailedInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondActivityTaskFailedAsync(input: SimpleWorkflowModel.RespondActivityTaskFailedInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.respondActivityTaskFailed.rawValue,
                     target: target)
-        
+
         let requestInput = RespondActivityTaskFailedOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1481,7 +1497,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.respondActivityTaskFailed.rawValue,
                     target: target)
-        
+
         let requestInput = RespondActivityTaskFailedOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1500,14 +1516,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondDecisionTaskCompletedAsync(input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondDecisionTaskCompletedAsync(input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.respondDecisionTaskCompleted.rawValue,
                     target: target)
-        
+
         let requestInput = RespondDecisionTaskCompletedOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1532,7 +1548,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.respondDecisionTaskCompleted.rawValue,
                     target: target)
-        
+
         let requestInput = RespondDecisionTaskCompletedOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1551,14 +1567,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func signalWorkflowExecutionAsync(input: SimpleWorkflowModel.SignalWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws {
+    public func signalWorkflowExecutionAsync(input: SimpleWorkflowModel.SignalWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.signalWorkflowExecution.rawValue,
                     target: target)
-        
+
         let requestInput = SignalWorkflowExecutionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1583,7 +1599,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.signalWorkflowExecution.rawValue,
                     target: target)
-        
+
         let requestInput = SignalWorkflowExecutionOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(
@@ -1610,7 +1626,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.startWorkflowExecution.rawValue,
                     target: target)
-        
+
         let requestInput = StartWorkflowExecutionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1637,7 +1653,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.startWorkflowExecution.rawValue,
                     target: target)
-        
+
         let requestInput = StartWorkflowExecutionOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1656,14 +1672,14 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func terminateWorkflowExecutionAsync(input: SimpleWorkflowModel.TerminateWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws {
+    public func terminateWorkflowExecutionAsync(input: SimpleWorkflowModel.TerminateWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         let handlerDelegate = AWSClientChannelInboundHandlerDelegate(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
                     operation: SimpleWorkflowModelOperations.terminateWorkflowExecution.rawValue,
                     target: target)
-        
+
         let requestInput = TerminateWorkflowExecutionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithoutOutput(
@@ -1688,7 +1704,7 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                     service: service,
                     operation: SimpleWorkflowModelOperations.terminateWorkflowExecution.rawValue,
                     target: target)
-        
+
         let requestInput = TerminateWorkflowExecutionOperationHTTPRequestInput(encodable: input)
 
         try httpClient.executeSyncWithoutOutput(

--- a/Sources/SimpleWorkflowClient/MockSimpleWorkflowClient.swift
+++ b/Sources/SimpleWorkflowClient/MockSimpleWorkflowClient.swift
@@ -378,7 +378,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, typeDeprecated, unknownResource.
      */
-    public func deprecateActivityTypeAsync(input: SimpleWorkflowModel.DeprecateActivityTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func deprecateActivityTypeAsync(input: SimpleWorkflowModel.DeprecateActivityTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deprecateActivityTypeAsyncOverride = deprecateActivityTypeAsyncOverride {
             return try deprecateActivityTypeAsyncOverride(input, completion)
         }
@@ -409,7 +409,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: domainDeprecated, operationNotPermitted, unknownResource.
      */
-    public func deprecateDomainAsync(input: SimpleWorkflowModel.DeprecateDomainInput, completion: @escaping (Error?) -> ()) throws {
+    public func deprecateDomainAsync(input: SimpleWorkflowModel.DeprecateDomainInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deprecateDomainAsyncOverride = deprecateDomainAsyncOverride {
             return try deprecateDomainAsyncOverride(input, completion)
         }
@@ -440,7 +440,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, typeDeprecated, unknownResource.
      */
-    public func deprecateWorkflowTypeAsync(input: SimpleWorkflowModel.DeprecateWorkflowTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func deprecateWorkflowTypeAsync(input: SimpleWorkflowModel.DeprecateWorkflowTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deprecateWorkflowTypeAsyncOverride = deprecateWorkflowTypeAsyncOverride {
             return try deprecateWorkflowTypeAsyncOverride(input, completion)
         }
@@ -952,7 +952,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: limitExceeded, operationNotPermitted, typeAlreadyExists, unknownResource.
      */
-    public func registerActivityTypeAsync(input: SimpleWorkflowModel.RegisterActivityTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func registerActivityTypeAsync(input: SimpleWorkflowModel.RegisterActivityTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let registerActivityTypeAsyncOverride = registerActivityTypeAsyncOverride {
             return try registerActivityTypeAsyncOverride(input, completion)
         }
@@ -983,7 +983,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: domainAlreadyExists, limitExceeded, operationNotPermitted.
      */
-    public func registerDomainAsync(input: SimpleWorkflowModel.RegisterDomainInput, completion: @escaping (Error?) -> ()) throws {
+    public func registerDomainAsync(input: SimpleWorkflowModel.RegisterDomainInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let registerDomainAsyncOverride = registerDomainAsyncOverride {
             return try registerDomainAsyncOverride(input, completion)
         }
@@ -1014,7 +1014,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: limitExceeded, operationNotPermitted, typeAlreadyExists, unknownResource.
      */
-    public func registerWorkflowTypeAsync(input: SimpleWorkflowModel.RegisterWorkflowTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func registerWorkflowTypeAsync(input: SimpleWorkflowModel.RegisterWorkflowTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let registerWorkflowTypeAsyncOverride = registerWorkflowTypeAsyncOverride {
             return try registerWorkflowTypeAsyncOverride(input, completion)
         }
@@ -1045,7 +1045,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func requestCancelWorkflowExecutionAsync(input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws {
+    public func requestCancelWorkflowExecutionAsync(input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let requestCancelWorkflowExecutionAsyncOverride = requestCancelWorkflowExecutionAsyncOverride {
             return try requestCancelWorkflowExecutionAsyncOverride(input, completion)
         }
@@ -1076,7 +1076,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondActivityTaskCanceledAsync(input: SimpleWorkflowModel.RespondActivityTaskCanceledInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondActivityTaskCanceledAsync(input: SimpleWorkflowModel.RespondActivityTaskCanceledInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let respondActivityTaskCanceledAsyncOverride = respondActivityTaskCanceledAsyncOverride {
             return try respondActivityTaskCanceledAsyncOverride(input, completion)
         }
@@ -1107,7 +1107,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondActivityTaskCompletedAsync(input: SimpleWorkflowModel.RespondActivityTaskCompletedInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondActivityTaskCompletedAsync(input: SimpleWorkflowModel.RespondActivityTaskCompletedInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let respondActivityTaskCompletedAsyncOverride = respondActivityTaskCompletedAsyncOverride {
             return try respondActivityTaskCompletedAsyncOverride(input, completion)
         }
@@ -1138,7 +1138,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondActivityTaskFailedAsync(input: SimpleWorkflowModel.RespondActivityTaskFailedInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondActivityTaskFailedAsync(input: SimpleWorkflowModel.RespondActivityTaskFailedInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let respondActivityTaskFailedAsyncOverride = respondActivityTaskFailedAsyncOverride {
             return try respondActivityTaskFailedAsyncOverride(input, completion)
         }
@@ -1169,7 +1169,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondDecisionTaskCompletedAsync(input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondDecisionTaskCompletedAsync(input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let respondDecisionTaskCompletedAsyncOverride = respondDecisionTaskCompletedAsyncOverride {
             return try respondDecisionTaskCompletedAsyncOverride(input, completion)
         }
@@ -1200,7 +1200,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func signalWorkflowExecutionAsync(input: SimpleWorkflowModel.SignalWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws {
+    public func signalWorkflowExecutionAsync(input: SimpleWorkflowModel.SignalWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let signalWorkflowExecutionAsyncOverride = signalWorkflowExecutionAsyncOverride {
             return try signalWorkflowExecutionAsyncOverride(input, completion)
         }
@@ -1268,7 +1268,7 @@ public struct MockSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func terminateWorkflowExecutionAsync(input: SimpleWorkflowModel.TerminateWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws {
+    public func terminateWorkflowExecutionAsync(input: SimpleWorkflowModel.TerminateWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let terminateWorkflowExecutionAsyncOverride = terminateWorkflowExecutionAsyncOverride {
             return try terminateWorkflowExecutionAsyncOverride(input, completion)
         }

--- a/Sources/SimpleWorkflowClient/SimpleWorkflowClientProtocol.swift
+++ b/Sources/SimpleWorkflowClient/SimpleWorkflowClientProtocol.swift
@@ -36,11 +36,11 @@ public protocol SimpleWorkflowClientProtocol {
     typealias CountPendingDecisionTasksSyncType = (_ input: SimpleWorkflowModel.CountPendingDecisionTasksInput) throws -> SimpleWorkflowModel.PendingTaskCount
     typealias CountPendingDecisionTasksAsyncType = (_ input: SimpleWorkflowModel.CountPendingDecisionTasksInput, _ completion: @escaping (HTTPResult<SimpleWorkflowModel.PendingTaskCount>) -> ()) throws -> ()
     typealias DeprecateActivityTypeSyncType = (_ input: SimpleWorkflowModel.DeprecateActivityTypeInput) throws -> ()
-    typealias DeprecateActivityTypeAsyncType = (_ input: SimpleWorkflowModel.DeprecateActivityTypeInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeprecateActivityTypeAsyncType = (_ input: SimpleWorkflowModel.DeprecateActivityTypeInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeprecateDomainSyncType = (_ input: SimpleWorkflowModel.DeprecateDomainInput) throws -> ()
-    typealias DeprecateDomainAsyncType = (_ input: SimpleWorkflowModel.DeprecateDomainInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeprecateDomainAsyncType = (_ input: SimpleWorkflowModel.DeprecateDomainInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DeprecateWorkflowTypeSyncType = (_ input: SimpleWorkflowModel.DeprecateWorkflowTypeInput) throws -> ()
-    typealias DeprecateWorkflowTypeAsyncType = (_ input: SimpleWorkflowModel.DeprecateWorkflowTypeInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias DeprecateWorkflowTypeAsyncType = (_ input: SimpleWorkflowModel.DeprecateWorkflowTypeInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias DescribeActivityTypeSyncType = (_ input: SimpleWorkflowModel.DescribeActivityTypeInput) throws -> SimpleWorkflowModel.ActivityTypeDetail
     typealias DescribeActivityTypeAsyncType = (_ input: SimpleWorkflowModel.DescribeActivityTypeInput, _ completion: @escaping (HTTPResult<SimpleWorkflowModel.ActivityTypeDetail>) -> ()) throws -> ()
     typealias DescribeDomainSyncType = (_ input: SimpleWorkflowModel.DescribeDomainInput) throws -> SimpleWorkflowModel.DomainDetail
@@ -68,27 +68,27 @@ public protocol SimpleWorkflowClientProtocol {
     typealias RecordActivityTaskHeartbeatSyncType = (_ input: SimpleWorkflowModel.RecordActivityTaskHeartbeatInput) throws -> SimpleWorkflowModel.ActivityTaskStatus
     typealias RecordActivityTaskHeartbeatAsyncType = (_ input: SimpleWorkflowModel.RecordActivityTaskHeartbeatInput, _ completion: @escaping (HTTPResult<SimpleWorkflowModel.ActivityTaskStatus>) -> ()) throws -> ()
     typealias RegisterActivityTypeSyncType = (_ input: SimpleWorkflowModel.RegisterActivityTypeInput) throws -> ()
-    typealias RegisterActivityTypeAsyncType = (_ input: SimpleWorkflowModel.RegisterActivityTypeInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RegisterActivityTypeAsyncType = (_ input: SimpleWorkflowModel.RegisterActivityTypeInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RegisterDomainSyncType = (_ input: SimpleWorkflowModel.RegisterDomainInput) throws -> ()
-    typealias RegisterDomainAsyncType = (_ input: SimpleWorkflowModel.RegisterDomainInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RegisterDomainAsyncType = (_ input: SimpleWorkflowModel.RegisterDomainInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RegisterWorkflowTypeSyncType = (_ input: SimpleWorkflowModel.RegisterWorkflowTypeInput) throws -> ()
-    typealias RegisterWorkflowTypeAsyncType = (_ input: SimpleWorkflowModel.RegisterWorkflowTypeInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RegisterWorkflowTypeAsyncType = (_ input: SimpleWorkflowModel.RegisterWorkflowTypeInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RequestCancelWorkflowExecutionSyncType = (_ input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput) throws -> ()
-    typealias RequestCancelWorkflowExecutionAsyncType = (_ input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RequestCancelWorkflowExecutionAsyncType = (_ input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RespondActivityTaskCanceledSyncType = (_ input: SimpleWorkflowModel.RespondActivityTaskCanceledInput) throws -> ()
-    typealias RespondActivityTaskCanceledAsyncType = (_ input: SimpleWorkflowModel.RespondActivityTaskCanceledInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RespondActivityTaskCanceledAsyncType = (_ input: SimpleWorkflowModel.RespondActivityTaskCanceledInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RespondActivityTaskCompletedSyncType = (_ input: SimpleWorkflowModel.RespondActivityTaskCompletedInput) throws -> ()
-    typealias RespondActivityTaskCompletedAsyncType = (_ input: SimpleWorkflowModel.RespondActivityTaskCompletedInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RespondActivityTaskCompletedAsyncType = (_ input: SimpleWorkflowModel.RespondActivityTaskCompletedInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RespondActivityTaskFailedSyncType = (_ input: SimpleWorkflowModel.RespondActivityTaskFailedInput) throws -> ()
-    typealias RespondActivityTaskFailedAsyncType = (_ input: SimpleWorkflowModel.RespondActivityTaskFailedInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RespondActivityTaskFailedAsyncType = (_ input: SimpleWorkflowModel.RespondActivityTaskFailedInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias RespondDecisionTaskCompletedSyncType = (_ input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput) throws -> ()
-    typealias RespondDecisionTaskCompletedAsyncType = (_ input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias RespondDecisionTaskCompletedAsyncType = (_ input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias SignalWorkflowExecutionSyncType = (_ input: SimpleWorkflowModel.SignalWorkflowExecutionInput) throws -> ()
-    typealias SignalWorkflowExecutionAsyncType = (_ input: SimpleWorkflowModel.SignalWorkflowExecutionInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias SignalWorkflowExecutionAsyncType = (_ input: SimpleWorkflowModel.SignalWorkflowExecutionInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
     typealias StartWorkflowExecutionSyncType = (_ input: SimpleWorkflowModel.StartWorkflowExecutionInput) throws -> SimpleWorkflowModel.Run
     typealias StartWorkflowExecutionAsyncType = (_ input: SimpleWorkflowModel.StartWorkflowExecutionInput, _ completion: @escaping (HTTPResult<SimpleWorkflowModel.Run>) -> ()) throws -> ()
     typealias TerminateWorkflowExecutionSyncType = (_ input: SimpleWorkflowModel.TerminateWorkflowExecutionInput) throws -> ()
-    typealias TerminateWorkflowExecutionAsyncType = (_ input: SimpleWorkflowModel.TerminateWorkflowExecutionInput, _ completion: @escaping (Error?) -> ()) throws -> ()
+    typealias TerminateWorkflowExecutionAsyncType = (_ input: SimpleWorkflowModel.TerminateWorkflowExecutionInput, _ completion: @escaping (Swift.Error?) -> ()) throws -> ()
 
     /**
      Invokes the CountClosedWorkflowExecutions operation returning immediately and passing the response to a callback.
@@ -191,7 +191,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, typeDeprecated, unknownResource.
      */
-    func deprecateActivityTypeAsync(input: SimpleWorkflowModel.DeprecateActivityTypeInput, completion: @escaping (Error?) -> ()) throws
+    func deprecateActivityTypeAsync(input: SimpleWorkflowModel.DeprecateActivityTypeInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeprecateActivityType operation waiting for the response before returning.
@@ -211,7 +211,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: domainDeprecated, operationNotPermitted, unknownResource.
      */
-    func deprecateDomainAsync(input: SimpleWorkflowModel.DeprecateDomainInput, completion: @escaping (Error?) -> ()) throws
+    func deprecateDomainAsync(input: SimpleWorkflowModel.DeprecateDomainInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeprecateDomain operation waiting for the response before returning.
@@ -231,7 +231,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, typeDeprecated, unknownResource.
      */
-    func deprecateWorkflowTypeAsync(input: SimpleWorkflowModel.DeprecateWorkflowTypeInput, completion: @escaping (Error?) -> ()) throws
+    func deprecateWorkflowTypeAsync(input: SimpleWorkflowModel.DeprecateWorkflowTypeInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the DeprecateWorkflowType operation waiting for the response before returning.
@@ -550,7 +550,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: limitExceeded, operationNotPermitted, typeAlreadyExists, unknownResource.
      */
-    func registerActivityTypeAsync(input: SimpleWorkflowModel.RegisterActivityTypeInput, completion: @escaping (Error?) -> ()) throws
+    func registerActivityTypeAsync(input: SimpleWorkflowModel.RegisterActivityTypeInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RegisterActivityType operation waiting for the response before returning.
@@ -570,7 +570,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: domainAlreadyExists, limitExceeded, operationNotPermitted.
      */
-    func registerDomainAsync(input: SimpleWorkflowModel.RegisterDomainInput, completion: @escaping (Error?) -> ()) throws
+    func registerDomainAsync(input: SimpleWorkflowModel.RegisterDomainInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RegisterDomain operation waiting for the response before returning.
@@ -590,7 +590,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: limitExceeded, operationNotPermitted, typeAlreadyExists, unknownResource.
      */
-    func registerWorkflowTypeAsync(input: SimpleWorkflowModel.RegisterWorkflowTypeInput, completion: @escaping (Error?) -> ()) throws
+    func registerWorkflowTypeAsync(input: SimpleWorkflowModel.RegisterWorkflowTypeInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RegisterWorkflowType operation waiting for the response before returning.
@@ -610,7 +610,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    func requestCancelWorkflowExecutionAsync(input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws
+    func requestCancelWorkflowExecutionAsync(input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RequestCancelWorkflowExecution operation waiting for the response before returning.
@@ -630,7 +630,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    func respondActivityTaskCanceledAsync(input: SimpleWorkflowModel.RespondActivityTaskCanceledInput, completion: @escaping (Error?) -> ()) throws
+    func respondActivityTaskCanceledAsync(input: SimpleWorkflowModel.RespondActivityTaskCanceledInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RespondActivityTaskCanceled operation waiting for the response before returning.
@@ -650,7 +650,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    func respondActivityTaskCompletedAsync(input: SimpleWorkflowModel.RespondActivityTaskCompletedInput, completion: @escaping (Error?) -> ()) throws
+    func respondActivityTaskCompletedAsync(input: SimpleWorkflowModel.RespondActivityTaskCompletedInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RespondActivityTaskCompleted operation waiting for the response before returning.
@@ -670,7 +670,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    func respondActivityTaskFailedAsync(input: SimpleWorkflowModel.RespondActivityTaskFailedInput, completion: @escaping (Error?) -> ()) throws
+    func respondActivityTaskFailedAsync(input: SimpleWorkflowModel.RespondActivityTaskFailedInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RespondActivityTaskFailed operation waiting for the response before returning.
@@ -690,7 +690,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    func respondDecisionTaskCompletedAsync(input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput, completion: @escaping (Error?) -> ()) throws
+    func respondDecisionTaskCompletedAsync(input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the RespondDecisionTaskCompleted operation waiting for the response before returning.
@@ -710,7 +710,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    func signalWorkflowExecutionAsync(input: SimpleWorkflowModel.SignalWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws
+    func signalWorkflowExecutionAsync(input: SimpleWorkflowModel.SignalWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the SignalWorkflowExecution operation waiting for the response before returning.
@@ -753,7 +753,7 @@ public protocol SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    func terminateWorkflowExecutionAsync(input: SimpleWorkflowModel.TerminateWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws
+    func terminateWorkflowExecutionAsync(input: SimpleWorkflowModel.TerminateWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws
 
     /**
      Invokes the TerminateWorkflowExecution operation waiting for the response before returning.

--- a/Sources/SimpleWorkflowClient/SimpleWorkflowOperationsClientOutput.swift
+++ b/Sources/SimpleWorkflowClient/SimpleWorkflowOperationsClientOutput.swift
@@ -1,0 +1,220 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// SimpleWorkflowOperationsClientOutput.swift
+// SimpleWorkflowClient
+//
+
+import Foundation
+import SmokeHTTPClient
+import SimpleWorkflowModel
+
+/**
+ Type to handle the output from the CountClosedWorkflowExecutions operation in a HTTP client.
+ */
+extension WorkflowExecutionCount: HTTPResponseOutputProtocol {
+    public typealias BodyType = WorkflowExecutionCount
+    public typealias HeadersType = WorkflowExecutionCount
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> WorkflowExecutionCount {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CountPendingActivityTasks operation in a HTTP client.
+ */
+extension PendingTaskCount: HTTPResponseOutputProtocol {
+    public typealias BodyType = PendingTaskCount
+    public typealias HeadersType = PendingTaskCount
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> PendingTaskCount {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeActivityType operation in a HTTP client.
+ */
+extension ActivityTypeDetail: HTTPResponseOutputProtocol {
+    public typealias BodyType = ActivityTypeDetail
+    public typealias HeadersType = ActivityTypeDetail
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ActivityTypeDetail {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeDomain operation in a HTTP client.
+ */
+extension DomainDetail: HTTPResponseOutputProtocol {
+    public typealias BodyType = DomainDetail
+    public typealias HeadersType = DomainDetail
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DomainDetail {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeWorkflowExecution operation in a HTTP client.
+ */
+extension WorkflowExecutionDetail: HTTPResponseOutputProtocol {
+    public typealias BodyType = WorkflowExecutionDetail
+    public typealias HeadersType = WorkflowExecutionDetail
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> WorkflowExecutionDetail {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeWorkflowType operation in a HTTP client.
+ */
+extension WorkflowTypeDetail: HTTPResponseOutputProtocol {
+    public typealias BodyType = WorkflowTypeDetail
+    public typealias HeadersType = WorkflowTypeDetail
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> WorkflowTypeDetail {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetWorkflowExecutionHistory operation in a HTTP client.
+ */
+extension History: HTTPResponseOutputProtocol {
+    public typealias BodyType = History
+    public typealias HeadersType = History
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> History {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListActivityTypes operation in a HTTP client.
+ */
+extension ActivityTypeInfos: HTTPResponseOutputProtocol {
+    public typealias BodyType = ActivityTypeInfos
+    public typealias HeadersType = ActivityTypeInfos
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ActivityTypeInfos {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListClosedWorkflowExecutions operation in a HTTP client.
+ */
+extension WorkflowExecutionInfos: HTTPResponseOutputProtocol {
+    public typealias BodyType = WorkflowExecutionInfos
+    public typealias HeadersType = WorkflowExecutionInfos
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> WorkflowExecutionInfos {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListDomains operation in a HTTP client.
+ */
+extension DomainInfos: HTTPResponseOutputProtocol {
+    public typealias BodyType = DomainInfos
+    public typealias HeadersType = DomainInfos
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DomainInfos {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListWorkflowTypes operation in a HTTP client.
+ */
+extension WorkflowTypeInfos: HTTPResponseOutputProtocol {
+    public typealias BodyType = WorkflowTypeInfos
+    public typealias HeadersType = WorkflowTypeInfos
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> WorkflowTypeInfos {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PollForActivityTask operation in a HTTP client.
+ */
+extension ActivityTask: HTTPResponseOutputProtocol {
+    public typealias BodyType = ActivityTask
+    public typealias HeadersType = ActivityTask
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ActivityTask {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the PollForDecisionTask operation in a HTTP client.
+ */
+extension DecisionTask: HTTPResponseOutputProtocol {
+    public typealias BodyType = DecisionTask
+    public typealias HeadersType = DecisionTask
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DecisionTask {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the RecordActivityTaskHeartbeat operation in a HTTP client.
+ */
+extension ActivityTaskStatus: HTTPResponseOutputProtocol {
+    public typealias BodyType = ActivityTaskStatus
+    public typealias HeadersType = ActivityTaskStatus
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ActivityTaskStatus {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the StartWorkflowExecution operation in a HTTP client.
+ */
+extension Run: HTTPResponseOutputProtocol {
+    public typealias BodyType = Run
+    public typealias HeadersType = Run
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> Run {
+        return try bodyDecodableProvider()
+    }
+}
+

--- a/Sources/SimpleWorkflowClient/ThrowingSimpleWorkflowClient.swift
+++ b/Sources/SimpleWorkflowClient/ThrowingSimpleWorkflowClient.swift
@@ -372,7 +372,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, typeDeprecated, unknownResource.
      */
-    public func deprecateActivityTypeAsync(input: SimpleWorkflowModel.DeprecateActivityTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func deprecateActivityTypeAsync(input: SimpleWorkflowModel.DeprecateActivityTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deprecateActivityTypeAsyncOverride = deprecateActivityTypeAsyncOverride {
             return try deprecateActivityTypeAsyncOverride(input, completion)
         }
@@ -404,7 +404,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: domainDeprecated, operationNotPermitted, unknownResource.
      */
-    public func deprecateDomainAsync(input: SimpleWorkflowModel.DeprecateDomainInput, completion: @escaping (Error?) -> ()) throws {
+    public func deprecateDomainAsync(input: SimpleWorkflowModel.DeprecateDomainInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deprecateDomainAsyncOverride = deprecateDomainAsyncOverride {
             return try deprecateDomainAsyncOverride(input, completion)
         }
@@ -436,7 +436,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, typeDeprecated, unknownResource.
      */
-    public func deprecateWorkflowTypeAsync(input: SimpleWorkflowModel.DeprecateWorkflowTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func deprecateWorkflowTypeAsync(input: SimpleWorkflowModel.DeprecateWorkflowTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let deprecateWorkflowTypeAsyncOverride = deprecateWorkflowTypeAsyncOverride {
             return try deprecateWorkflowTypeAsyncOverride(input, completion)
         }
@@ -923,7 +923,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: limitExceeded, operationNotPermitted, typeAlreadyExists, unknownResource.
      */
-    public func registerActivityTypeAsync(input: SimpleWorkflowModel.RegisterActivityTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func registerActivityTypeAsync(input: SimpleWorkflowModel.RegisterActivityTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let registerActivityTypeAsyncOverride = registerActivityTypeAsyncOverride {
             return try registerActivityTypeAsyncOverride(input, completion)
         }
@@ -955,7 +955,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: domainAlreadyExists, limitExceeded, operationNotPermitted.
      */
-    public func registerDomainAsync(input: SimpleWorkflowModel.RegisterDomainInput, completion: @escaping (Error?) -> ()) throws {
+    public func registerDomainAsync(input: SimpleWorkflowModel.RegisterDomainInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let registerDomainAsyncOverride = registerDomainAsyncOverride {
             return try registerDomainAsyncOverride(input, completion)
         }
@@ -987,7 +987,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: limitExceeded, operationNotPermitted, typeAlreadyExists, unknownResource.
      */
-    public func registerWorkflowTypeAsync(input: SimpleWorkflowModel.RegisterWorkflowTypeInput, completion: @escaping (Error?) -> ()) throws {
+    public func registerWorkflowTypeAsync(input: SimpleWorkflowModel.RegisterWorkflowTypeInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let registerWorkflowTypeAsyncOverride = registerWorkflowTypeAsyncOverride {
             return try registerWorkflowTypeAsyncOverride(input, completion)
         }
@@ -1019,7 +1019,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func requestCancelWorkflowExecutionAsync(input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws {
+    public func requestCancelWorkflowExecutionAsync(input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let requestCancelWorkflowExecutionAsyncOverride = requestCancelWorkflowExecutionAsyncOverride {
             return try requestCancelWorkflowExecutionAsyncOverride(input, completion)
         }
@@ -1051,7 +1051,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondActivityTaskCanceledAsync(input: SimpleWorkflowModel.RespondActivityTaskCanceledInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondActivityTaskCanceledAsync(input: SimpleWorkflowModel.RespondActivityTaskCanceledInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let respondActivityTaskCanceledAsyncOverride = respondActivityTaskCanceledAsyncOverride {
             return try respondActivityTaskCanceledAsyncOverride(input, completion)
         }
@@ -1083,7 +1083,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondActivityTaskCompletedAsync(input: SimpleWorkflowModel.RespondActivityTaskCompletedInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondActivityTaskCompletedAsync(input: SimpleWorkflowModel.RespondActivityTaskCompletedInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let respondActivityTaskCompletedAsyncOverride = respondActivityTaskCompletedAsyncOverride {
             return try respondActivityTaskCompletedAsyncOverride(input, completion)
         }
@@ -1115,7 +1115,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondActivityTaskFailedAsync(input: SimpleWorkflowModel.RespondActivityTaskFailedInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondActivityTaskFailedAsync(input: SimpleWorkflowModel.RespondActivityTaskFailedInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let respondActivityTaskFailedAsyncOverride = respondActivityTaskFailedAsyncOverride {
             return try respondActivityTaskFailedAsyncOverride(input, completion)
         }
@@ -1147,7 +1147,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func respondDecisionTaskCompletedAsync(input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput, completion: @escaping (Error?) -> ()) throws {
+    public func respondDecisionTaskCompletedAsync(input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let respondDecisionTaskCompletedAsyncOverride = respondDecisionTaskCompletedAsyncOverride {
             return try respondDecisionTaskCompletedAsyncOverride(input, completion)
         }
@@ -1179,7 +1179,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func signalWorkflowExecutionAsync(input: SimpleWorkflowModel.SignalWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws {
+    public func signalWorkflowExecutionAsync(input: SimpleWorkflowModel.SignalWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let signalWorkflowExecutionAsyncOverride = signalWorkflowExecutionAsyncOverride {
             return try signalWorkflowExecutionAsyncOverride(input, completion)
         }
@@ -1246,7 +1246,7 @@ public struct ThrowingSimpleWorkflowClient: SimpleWorkflowClientProtocol {
            is complete.
            The possible errors are: operationNotPermitted, unknownResource.
      */
-    public func terminateWorkflowExecutionAsync(input: SimpleWorkflowModel.TerminateWorkflowExecutionInput, completion: @escaping (Error?) -> ()) throws {
+    public func terminateWorkflowExecutionAsync(input: SimpleWorkflowModel.TerminateWorkflowExecutionInput, completion: @escaping (Swift.Error?) -> ()) throws {
         if let terminateWorkflowExecutionAsyncOverride = terminateWorkflowExecutionAsyncOverride {
             return try terminateWorkflowExecutionAsyncOverride(input, completion)
         }

--- a/Sources/SmokeAWSHttp/Data+debugString.swift
+++ b/Sources/SmokeAWSHttp/Data+debugString.swift
@@ -1,0 +1,36 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  Data+debugString.swift
+//  SmokeAWSHttp
+//
+
+import Foundation
+import SmokeHTTPClient
+
+extension Data {
+    var debugString: String {
+        return String(data: self, encoding: .utf8) ?? ""
+    }
+}
+
+extension Optional where Wrapped == Data {
+    var debugString: String {
+        switch self {
+        case .some(let wrapped):
+            return wrapped.debugString
+        case .none:
+            return ""
+        }
+    }
+}

--- a/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
@@ -46,11 +46,8 @@ public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
             throw HTTPError.unknownError("Error with status '\(responseHead.status)' with empty body")
         }
         
-        if Log.isLogging(.debug) {
-            let asString = String(data: bodyData, encoding: .utf8) ?? ""
-            
-            Log.debug("Attempting to decode error data into JSON: \(asString)")
-        }
+        // Convert bodyData to a debug string only if debug logging is enabled
+        Log.debug("Attempting to decode error data into JSON: \(bodyData.debugString)")
         
         // attempt to get an error of Error type by decoding the body data
         return try JSONDecoder.awsCompatibleDecoder.decode(ErrorType.self, from: bodyData)
@@ -61,12 +58,7 @@ public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
         httpPath: String) throws -> HTTPRequestComponents
         where InputType: HTTPRequestInputProtocol {
             
-            let pathPostfix: String
-            if let thePathPostfix = input.pathPostfix {
-                pathPostfix = thePathPostfix
-            } else {
-                pathPostfix = ""
-            }
+            let pathPostfix = input.pathPostfix ?? ""
             
             let pathTemplate = "\(httpPath)\(pathPostfix)"
             let path: String
@@ -139,16 +131,8 @@ public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
     public func decodeOutput<OutputType>(output: Data?,
                                   headers: [(String, String)]) throws -> OutputType
     where OutputType: HTTPResponseOutputProtocol {
-        if Log.isLogging(.debug) {
-            let asString: String
-            if let output = output {
-                asString = String(data: output, encoding: .utf8) ?? ""
-            } else {
-                asString = ""
-            }
-            
-            Log.debug("Attempting to decode result data into JSON: \(asString)")
-        }
+        // Convert output to a debug string only if debug logging is enabled
+        Log.debug("Attempting to decode result data: \(output.debugString)")
         
         func bodyDecodableProvider() throws -> OutputType.BodyType {
             // we are expecting a response body

--- a/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
@@ -42,11 +42,11 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
             throw HTTPError.unknownError("Error with status '\(responseHead.status)' with empty body")
         }
         
-        //if Log.isLogging(.debug) {
+        if Log.isLogging(.debug) {
             let asString = String(data: bodyData, encoding: .utf8) ?? ""
             
             Log.debug("Attempting to decode error data into JSON: \(asString)")
-        //}
+        }
         
         // attempt to get an error of Error type by decoding the body data
         return try JSONDecoder.awsCompatibleDecoder.decode(ErrorType.self, from: bodyData)

--- a/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
@@ -42,11 +42,8 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
             throw HTTPError.unknownError("Error with status '\(responseHead.status)' with empty body")
         }
         
-        if Log.isLogging(.debug) {
-            let asString = String(data: bodyData, encoding: .utf8) ?? ""
-            
-            Log.debug("Attempting to decode error data into JSON: \(asString)")
-        }
+        // Convert bodyData to a debug string only if debug logging is enabled
+        Log.debug("Attempting to decode error data into JSON: \(bodyData.debugString)")
         
         // attempt to get an error of Error type by decoding the body data
         return try JSONDecoder.awsCompatibleDecoder.decode(ErrorType.self, from: bodyData)
@@ -57,12 +54,7 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
         httpPath: String) throws -> HTTPRequestComponents
         where InputType: HTTPRequestInputProtocol {
             
-            let pathPostfix: String
-            if let thePathPostfix = input.pathPostfix {
-                pathPostfix = thePathPostfix
-            } else {
-                pathPostfix = ""
-            }
+            let pathPostfix = input.pathPostfix ?? ""
             
             let pathTemplate = "\(httpPath)\(pathPostfix)"
             let path: String
@@ -132,16 +124,8 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
     public func decodeOutput<OutputType>(output: Data?,
                                   headers: [(String, String)]) throws -> OutputType
     where OutputType: HTTPResponseOutputProtocol {
-        if Log.isLogging(.debug) {
-            let asString: String
-            if let output = output {
-                asString = String(data: output, encoding: .utf8) ?? ""
-            } else {
-                asString = ""
-            }
-            
-            Log.debug("Attempting to decode result data into JSON: \(asString)")
-        }
+        // Convert output to a debug string only if debug logging is enabled
+        Log.debug("Attempting to decode result data into JSON: \(output.debugString)")
         
         func bodyDecodableProvider() throws -> OutputType.BodyType {
             // we are expecting a response body

--- a/Sources/SmokeAWSHttp/V4Signer.swift
+++ b/Sources/SmokeAWSHttp/V4Signer.swift
@@ -228,12 +228,14 @@ struct V4Signer {
             urlPath = url.path
         }
         
+        // make sure the query string is in canonical form required by signing
         let query: String
         if let rawQuery = url.query {
             let queryComponents = rawQuery.split(separator: "&")
             
             let mappedComponents: [String] = queryComponents.map { component in
                 if component.index(of: "=") == nil {
+                    // query keys without values require '=' at the end
                     return "\(component)="
                 } else {
                     return String(component)

--- a/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
@@ -116,11 +116,8 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
         
         let decoder = XMLDecoder.awsCompatibleDecoder
         
-        if Log.isLogging(.debug) {
-            let asString = String(data: bodyData, encoding: .utf8) ?? ""
-            
-            Log.debug("Attempting to decode error data into XML: \(asString)")
-        }
+        // Convert bodyData to a debug string only if debug logging is enabled
+        Log.debug("Attempting to decode error data into XML: \(bodyData.debugString)")
         
         // attempt to decode the output body from an XML payload
         let result: Error
@@ -141,12 +138,7 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
         httpPath: String) throws -> HTTPRequestComponents
         where InputType: HTTPRequestInputProtocol {
             
-            let pathPostfix: String
-            if let thePathPostfix = input.pathPostfix {
-                pathPostfix = thePathPostfix
-            } else {
-                pathPostfix = ""
-            }
+            let pathPostfix = input.pathPostfix ?? ""
             
             let pathTemplate = "\(httpPath)\(pathPostfix)"
             let path: String
@@ -227,16 +219,8 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
             decoder.mapDecodingStrategy = outputMapDecodingStrategy
         }
         
-        if Log.isLogging(.debug) {
-            let asString: String
-            if let output = output {
-                asString = String(data: output, encoding: .utf8) ?? ""
-            } else {
-                asString = ""
-            }
-            
-            Log.debug("Attempting to decode result data into XML: \(asString)")
-        }
+        // Convert output to a debug string only if debug logging is enabled
+        Log.debug("Attempting to decode result data into XML: \(output.debugString)")
         
         func bodyDecodableProvider() throws -> OutputType.BodyType {
             // we are expecting a response body

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
@@ -64,6 +64,22 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
     }
 
     /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times.
+     */
+    public func close() {
+        httpClient.close()
+    }
+
+    /**
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
+     */
+    public func wait() {
+        httpClient.wait()
+    }
+
+    /**
      Invokes the CreateActivity operation returning immediately and passing the response to a callback.
 
      - Parameters:
@@ -80,7 +96,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.createActivity.rawValue,
                     target: target)
-        
+
         let requestInput = CreateActivityOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -107,7 +123,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.createActivity.rawValue,
                     target: target)
-        
+
         let requestInput = CreateActivityOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -134,7 +150,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.createStateMachine.rawValue,
                     target: target)
-        
+
         let requestInput = CreateStateMachineOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -161,7 +177,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.createStateMachine.rawValue,
                     target: target)
-        
+
         let requestInput = CreateStateMachineOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -188,7 +204,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.deleteActivity.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteActivityOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -215,7 +231,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.deleteActivity.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteActivityOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -242,7 +258,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.deleteStateMachine.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteStateMachineOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -269,7 +285,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.deleteStateMachine.rawValue,
                     target: target)
-        
+
         let requestInput = DeleteStateMachineOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -296,7 +312,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.describeActivity.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeActivityOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -323,7 +339,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.describeActivity.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeActivityOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -350,7 +366,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.describeExecution.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeExecutionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -377,7 +393,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.describeExecution.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeExecutionOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -404,7 +420,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.describeStateMachine.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeStateMachineOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -431,7 +447,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.describeStateMachine.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeStateMachineOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -458,7 +474,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.describeStateMachineForExecution.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeStateMachineForExecutionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -485,7 +501,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.describeStateMachineForExecution.rawValue,
                     target: target)
-        
+
         let requestInput = DescribeStateMachineForExecutionOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -512,7 +528,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.getActivityTask.rawValue,
                     target: target)
-        
+
         let requestInput = GetActivityTaskOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -539,7 +555,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.getActivityTask.rawValue,
                     target: target)
-        
+
         let requestInput = GetActivityTaskOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -566,7 +582,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.getExecutionHistory.rawValue,
                     target: target)
-        
+
         let requestInput = GetExecutionHistoryOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -593,7 +609,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.getExecutionHistory.rawValue,
                     target: target)
-        
+
         let requestInput = GetExecutionHistoryOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -620,7 +636,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.listActivities.rawValue,
                     target: target)
-        
+
         let requestInput = ListActivitiesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -647,7 +663,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.listActivities.rawValue,
                     target: target)
-        
+
         let requestInput = ListActivitiesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -674,7 +690,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.listExecutions.rawValue,
                     target: target)
-        
+
         let requestInput = ListExecutionsOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -701,7 +717,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.listExecutions.rawValue,
                     target: target)
-        
+
         let requestInput = ListExecutionsOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -728,7 +744,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.listStateMachines.rawValue,
                     target: target)
-        
+
         let requestInput = ListStateMachinesOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -755,7 +771,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.listStateMachines.rawValue,
                     target: target)
-        
+
         let requestInput = ListStateMachinesOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -782,7 +798,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.sendTaskFailure.rawValue,
                     target: target)
-        
+
         let requestInput = SendTaskFailureOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -809,7 +825,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.sendTaskFailure.rawValue,
                     target: target)
-        
+
         let requestInput = SendTaskFailureOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -836,7 +852,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.sendTaskHeartbeat.rawValue,
                     target: target)
-        
+
         let requestInput = SendTaskHeartbeatOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -863,7 +879,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.sendTaskHeartbeat.rawValue,
                     target: target)
-        
+
         let requestInput = SendTaskHeartbeatOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -890,7 +906,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.sendTaskSuccess.rawValue,
                     target: target)
-        
+
         let requestInput = SendTaskSuccessOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -917,7 +933,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.sendTaskSuccess.rawValue,
                     target: target)
-        
+
         let requestInput = SendTaskSuccessOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -944,7 +960,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.startExecution.rawValue,
                     target: target)
-        
+
         let requestInput = StartExecutionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -971,7 +987,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.startExecution.rawValue,
                     target: target)
-        
+
         let requestInput = StartExecutionOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -998,7 +1014,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.stopExecution.rawValue,
                     target: target)
-        
+
         let requestInput = StopExecutionOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1025,7 +1041,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.stopExecution.rawValue,
                     target: target)
-        
+
         let requestInput = StopExecutionOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(
@@ -1052,7 +1068,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.updateStateMachine.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateStateMachineOperationHTTPRequestInput(encodable: input)
 
         _ = try httpClient.executeAsyncWithOutput(
@@ -1079,7 +1095,7 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                     service: service,
                     operation: StepFunctionsModelOperations.updateStateMachine.rawValue,
                     target: target)
-        
+
         let requestInput = UpdateStateMachineOperationHTTPRequestInput(encodable: input)
 
         return try httpClient.executeSyncWithOutput(

--- a/Sources/StepFunctionsClient/StepFunctionsOperationsClientOutput.swift
+++ b/Sources/StepFunctionsClient/StepFunctionsOperationsClientOutput.swift
@@ -1,0 +1,272 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// -- Generated Code; do not edit --
+//
+// StepFunctionsOperationsClientOutput.swift
+// StepFunctionsClient
+//
+
+import Foundation
+import SmokeHTTPClient
+import StepFunctionsModel
+
+/**
+ Type to handle the output from the CreateActivity operation in a HTTP client.
+ */
+extension CreateActivityOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateActivityOutput
+    public typealias HeadersType = CreateActivityOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateActivityOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the CreateStateMachine operation in a HTTP client.
+ */
+extension CreateStateMachineOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = CreateStateMachineOutput
+    public typealias HeadersType = CreateStateMachineOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> CreateStateMachineOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteActivity operation in a HTTP client.
+ */
+extension DeleteActivityOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteActivityOutput
+    public typealias HeadersType = DeleteActivityOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteActivityOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DeleteStateMachine operation in a HTTP client.
+ */
+extension DeleteStateMachineOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DeleteStateMachineOutput
+    public typealias HeadersType = DeleteStateMachineOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DeleteStateMachineOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeActivity operation in a HTTP client.
+ */
+extension DescribeActivityOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeActivityOutput
+    public typealias HeadersType = DescribeActivityOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeActivityOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeExecution operation in a HTTP client.
+ */
+extension DescribeExecutionOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeExecutionOutput
+    public typealias HeadersType = DescribeExecutionOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeExecutionOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeStateMachine operation in a HTTP client.
+ */
+extension DescribeStateMachineOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeStateMachineOutput
+    public typealias HeadersType = DescribeStateMachineOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeStateMachineOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the DescribeStateMachineForExecution operation in a HTTP client.
+ */
+extension DescribeStateMachineForExecutionOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = DescribeStateMachineForExecutionOutput
+    public typealias HeadersType = DescribeStateMachineForExecutionOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> DescribeStateMachineForExecutionOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetActivityTask operation in a HTTP client.
+ */
+extension GetActivityTaskOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetActivityTaskOutput
+    public typealias HeadersType = GetActivityTaskOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetActivityTaskOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the GetExecutionHistory operation in a HTTP client.
+ */
+extension GetExecutionHistoryOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = GetExecutionHistoryOutput
+    public typealias HeadersType = GetExecutionHistoryOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> GetExecutionHistoryOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListActivities operation in a HTTP client.
+ */
+extension ListActivitiesOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListActivitiesOutput
+    public typealias HeadersType = ListActivitiesOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListActivitiesOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListExecutions operation in a HTTP client.
+ */
+extension ListExecutionsOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListExecutionsOutput
+    public typealias HeadersType = ListExecutionsOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListExecutionsOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the ListStateMachines operation in a HTTP client.
+ */
+extension ListStateMachinesOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = ListStateMachinesOutput
+    public typealias HeadersType = ListStateMachinesOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> ListStateMachinesOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the SendTaskFailure operation in a HTTP client.
+ */
+extension SendTaskFailureOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = SendTaskFailureOutput
+    public typealias HeadersType = SendTaskFailureOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> SendTaskFailureOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the SendTaskHeartbeat operation in a HTTP client.
+ */
+extension SendTaskHeartbeatOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = SendTaskHeartbeatOutput
+    public typealias HeadersType = SendTaskHeartbeatOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> SendTaskHeartbeatOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the SendTaskSuccess operation in a HTTP client.
+ */
+extension SendTaskSuccessOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = SendTaskSuccessOutput
+    public typealias HeadersType = SendTaskSuccessOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> SendTaskSuccessOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the StartExecution operation in a HTTP client.
+ */
+extension StartExecutionOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = StartExecutionOutput
+    public typealias HeadersType = StartExecutionOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> StartExecutionOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the StopExecution operation in a HTTP client.
+ */
+extension StopExecutionOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = StopExecutionOutput
+    public typealias HeadersType = StopExecutionOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> StopExecutionOutput {
+        return try bodyDecodableProvider()
+    }
+}
+
+/**
+ Type to handle the output from the UpdateStateMachine operation in a HTTP client.
+ */
+extension UpdateStateMachineOutput: HTTPResponseOutputProtocol {
+    public typealias BodyType = UpdateStateMachineOutput
+    public typealias HeadersType = UpdateStateMachineOutput
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType,
+                               headersDecodableProvider: () throws -> HeadersType) throws -> UpdateStateMachineOutput {
+        return try bodyDecodableProvider()
+    }
+}
+


### PR DESCRIPTION
*Issue #, if available:* #3 

*Description of changes:* Add a code generated S3 client and model. This required support for codable path, query and headers. Added support for these in the `*AWSHttpClientDelegate` implementations. Added explicit calls to close clients to reflect a recent change in smoke-http.

There are a lot of changed files here but *most* are code generated. Therefore all the `*Client` and `*Model` packages have similar changes. Hand made changes are in the `SmokeAWSHttp` package.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
