### PR TITLE
String.asS3ObjectIdentifier() to parse http and http S3 urls

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "d46977166ceecdda654ec2859e074dfbd012d6a4",
-          "version": "0.6.0"
+          "revision": "01718910a341f2f53bdaa1cb3021ab98d598539d",
+          "version": "0.6.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "a20e129c22ad00a51c902dca54a5456f90664780",
-          "version": "1.12.0"
+          "revision": "98434c1f1d687ff5a24d2cabfbd19b5c7d2d7a2f",
+          "version": "1.13.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "db16c3a90b101bb53b26a58867a344ad428072e0",
-          "version": "1.3.2"
+          "revision": "0f3999f3e3c359cc74480c292644c3419e44a12f",
+          "version": "1.4.0"
         }
       },
       {

--- a/Sources/S3Client/S3Object.swift
+++ b/Sources/S3Client/S3Object.swift
@@ -72,8 +72,16 @@ public struct S3Object: S3ObjectProtocol {
             }
         }
         
+        // make sure the object path is submitted starting with a "/"
+        let fullEndpointPath: String
+        if let first = objectPath.first, first == "/" {
+            fullEndpointPath = objectPath
+        } else {
+            fullEndpointPath = "/" + objectPath
+        }
+        
         _ = try httpClient.executeAsyncWithOutput(
-            endpointPath: objectPath,
+            endpointPath: fullEndpointPath,
             httpMethod: .GET,
             input: NoHTTPRequestInput(),
             completion: innerCompletion,
@@ -84,9 +92,17 @@ public struct S3Object: S3ObjectProtocol {
      Gets an object from the S3 bucket, returning the decoded response.
      */
     public func getSync<OutputType: Codable>(objectPath: String) throws -> OutputType {
+        // make sure the object path is submitted starting with a "/"
+        let fullEndpointPath: String
+        if let first = objectPath.first, first == "/" {
+            fullEndpointPath = objectPath
+        } else {
+            fullEndpointPath = "/" + objectPath
+        }
+        
         let responseOutput: BodyHTTPRequestOutput<OutputType> =
             try httpClient.executeSyncWithOutput(
-                endpointPath: objectPath,
+                endpointPath: fullEndpointPath,
                 httpMethod: .GET,
                 input: NoHTTPRequestInput(),
                 handlerDelegate: handlerDelegate)

--- a/Tests/S3ClientTests/S3ClientTests.swift
+++ b/Tests/S3ClientTests/S3ClientTests.swift
@@ -14,13 +14,35 @@ class S3ClientTests: XCTestCase {
         let identifier = s3Uri.asS3ObjectIdentifier()
         
         let expected = S3ObjectIdentifer(bucketName: "bucketName",
-                                         keyPath: "/the/key/path")
+                                         keyPath: "the/key/path")
+        
+        XCTAssertEqual(expected, identifier)
+    }
+    
+    func testValidHttpsUri() throws {
+        let s3Uri = "https://host/bucketName/the/key/path"
+        
+        let identifier = s3Uri.asS3ObjectIdentifier()
+        
+        let expected = S3ObjectIdentifer(bucketName: "bucketName",
+                                         keyPath: "the/key/path")
+        
+        XCTAssertEqual(expected, identifier)
+    }
+    
+    func testValidHttpUri() throws {
+        let s3Uri = "http://host/bucketName/the/key/path"
+        
+        let identifier = s3Uri.asS3ObjectIdentifier()
+        
+        let expected = S3ObjectIdentifer(bucketName: "bucketName",
+                                         keyPath: "the/key/path")
         
         XCTAssertEqual(expected, identifier)
     }
     
     func testInvalidS3UriPrefix() throws {
-        let s3Uri = "https://bucketName/the/key/path"
+        let s3Uri = "ssh://bucketName/the/key/path"
         
         let identifier = s3Uri.asS3ObjectIdentifier()
         
@@ -28,7 +50,23 @@ class S3ClientTests: XCTestCase {
     }
     
     func testS3UriNoSeparator() throws {
+        let s3Uri = "s3://bucketName"
+        
+        let identifier = s3Uri.asS3ObjectIdentifier()
+        
+        XCTAssertNil(identifier)
+    }
+    
+    func testHttpsUriNoSeparatorForBucket() throws {
         let s3Uri = "https://bucketName"
+        
+        let identifier = s3Uri.asS3ObjectIdentifier()
+        
+        XCTAssertNil(identifier)
+    }
+    
+    func testHttpsUriNoSeparatorForKey() throws {
+        let s3Uri = "https://host/bucketName"
         
         let identifier = s3Uri.asS3ObjectIdentifier()
         
@@ -37,7 +75,11 @@ class S3ClientTests: XCTestCase {
 
     static var allTests = [
         ("testValidS3Uri", testValidS3Uri),
+        ("testValidHttpsUri", testValidHttpsUri),
+        ("testValidHttpUri", testValidHttpUri),
         ("testInvalidS3UriPrefix", testInvalidS3UriPrefix),
         ("testS3UriNoSeparator", testS3UriNoSeparator),
+        ("testHttpsUriNoSeparatorForBucket", testHttpsUriNoSeparatorForBucket),
+        ("testHttpsUriNoSeparatorForKey", testHttpsUriNoSeparatorForKey),
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Enhance String.asS3ObjectIdentifier() to be able to parse http and https S3 urls. Drop the leading "/" from the key returned from this function to be compatible with the AWSS3Client. Add logic to add back the leading "/" on they key in the S3Object client.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
