### PR TITLE
Fix memory leak in hmac generation.

### DIFF
--- a/Sources/SmokeAWSHttp/String+hmac.swift
+++ b/Sources/SmokeAWSHttp/String+hmac.swift
@@ -34,6 +34,7 @@ extension String {
         var digest = [UInt8](repeating: 0, count: Int(EVP_MAX_MD_SIZE))
         var length: UInt32 = 0
         HMAC_Final(&context, &digest, &length)
+        HMAC_CTX_cleanup(&context)
         
         return Array(digest[0..<Int(length)])
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Identified a memory leak in hmac generation with the Xcode Memory Graph Debugger. The same fix has been applied to similar code in aws-sdk-swift-core[1].

*Testing performed:* Re-ran Xcode Memory Graph Debugger with fix, showing no memory issue.

[1] https://github.com/swift-aws/aws-sdk-swift-core/commit/6a4a7e07364934f31052f895490eb1dd5a277eea


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
