### PR TITLE
Add the ability to pass an eventLoopProvider into each client

### DIFF
--- a/Sources/CloudWatchClient/AWSCloudWatchClient.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClient.swift
@@ -74,14 +74,16 @@ public struct AWSCloudWatchClient: CloudWatchClientProtocol {
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2010-08-01",
                 connectionTimeoutSeconds: Int = 10,
-                retryConfiguration: HTTPClientRetryConfiguration = .default) {
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>()
 
         self.httpClient = HTTPClient(endpointHostName: endpointHostName,
                                      endpointPort: endpointPort,
                                      contentType: contentType,
                                      clientDelegate: clientDelegate,
-                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                     eventLoopProvider: eventLoopProvider)
         self.awsRegion = awsRegion
         self.service = service
         self.target = nil

--- a/Sources/DynamoDBClient/AWSDynamoDBClient.swift
+++ b/Sources/DynamoDBClient/AWSDynamoDBClient.swift
@@ -73,14 +73,16 @@ public struct AWSDynamoDBClient: DynamoDBClientProtocol {
                 contentType: String = "application/x-amz-json-1.0",
                 target: String? = "DynamoDB_20120810",
                 connectionTimeoutSeconds: Int = 10,
-                retryConfiguration: HTTPClientRetryConfiguration = .default) {
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>()
 
         self.httpClient = HTTPClient(endpointHostName: endpointHostName,
                                      endpointPort: endpointPort,
                                      contentType: contentType,
                                      clientDelegate: clientDelegate,
-                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                     eventLoopProvider: eventLoopProvider)
         self.awsRegion = awsRegion
         self.service = service
         self.target = target

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
@@ -69,7 +69,8 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2016-11-15",
                 connectionTimeoutSeconds: Int = 10,
-                retryConfiguration: HTTPClientRetryConfiguration = .default) {
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(
             outputListDecodingStrategy: .collapseListUsingItemTag("item"), 
             inputQueryKeyEncodeTransformStrategy: .capitalizeFirstCharacter)
@@ -78,7 +79,8 @@ public struct AWSElasticComputeCloudClient: ElasticComputeCloudClientProtocol {
                                      endpointPort: endpointPort,
                                      contentType: contentType,
                                      clientDelegate: clientDelegate,
-                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                     eventLoopProvider: eventLoopProvider)
         self.awsRegion = awsRegion
         self.service = service
         self.target = nil

--- a/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
+++ b/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
@@ -73,14 +73,16 @@ public struct AWSElasticContainerClient: ElasticContainerClientProtocol {
                 contentType: String = "application/x-amz-json-1.1",
                 target: String? = "AmazonEC2ContainerServiceV20141113",
                 connectionTimeoutSeconds: Int = 10,
-                retryConfiguration: HTTPClientRetryConfiguration = .default) {
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>()
 
         self.httpClient = HTTPClient(endpointHostName: endpointHostName,
                                      endpointPort: endpointPort,
                                      contentType: contentType,
                                      clientDelegate: clientDelegate,
-                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                     eventLoopProvider: eventLoopProvider)
         self.awsRegion = awsRegion
         self.service = service
         self.target = target

--- a/Sources/S3Client/AWSS3Client.swift
+++ b/Sources/S3Client/AWSS3Client.swift
@@ -69,7 +69,8 @@ public struct AWSS3Client: S3ClientProtocol {
                 contentType: String = "application/x-amz-rest-xml",
                 target: String? = nil,
                 connectionTimeoutSeconds: Int = 10,
-                retryConfiguration: HTTPClientRetryConfiguration = .default) {
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let clientDelegate = XMLAWSHttpClientDelegate<S3Error>()
 
         let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>()
@@ -78,12 +79,14 @@ public struct AWSS3Client: S3ClientProtocol {
                                      endpointPort: endpointPort,
                                      contentType: contentType,
                                      clientDelegate: clientDelegate,
-                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                     eventLoopProvider: eventLoopProvider)
         self.dataHttpClient = HTTPClient(endpointHostName: endpointHostName,
                                           endpointPort: endpointPort,
                                           contentType: contentType,
                                           clientDelegate: clientDelegateForDataHttpClient,
-                                          connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                          connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                          eventLoopProvider: eventLoopProvider)
         self.awsRegion = awsRegion ?? .us_east_1
         self.service = service
         self.target = target

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
@@ -69,14 +69,16 @@ public struct AWSSecurityTokenClient: SecurityTokenClientProtocol {
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2011-06-15",
                 connectionTimeoutSeconds: Int = 10,
-                retryConfiguration: HTTPClientRetryConfiguration = .default) {
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>()
 
         self.httpClient = HTTPClient(endpointHostName: endpointHostName,
                                      endpointPort: endpointPort,
                                      contentType: contentType,
                                      clientDelegate: clientDelegate,
-                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                     eventLoopProvider: eventLoopProvider)
         self.awsRegion = awsRegion ?? .us_east_1
         self.service = service
         self.target = nil

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
@@ -74,14 +74,16 @@ public struct AWSSimpleNotificationClient: SimpleNotificationClientProtocol {
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2010-03-31",
                 connectionTimeoutSeconds: Int = 10,
-                retryConfiguration: HTTPClientRetryConfiguration = .default) {
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>()
 
         self.httpClient = HTTPClient(endpointHostName: endpointHostName,
                                      endpointPort: endpointPort,
                                      contentType: contentType,
                                      clientDelegate: clientDelegate,
-                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                     eventLoopProvider: eventLoopProvider)
         self.awsRegion = awsRegion
         self.service = service
         self.target = nil

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
@@ -75,7 +75,8 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2012-11-05",
                 connectionTimeoutSeconds: Int = 10,
-                retryConfiguration: HTTPClientRetryConfiguration = .default) {
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>()
 
         let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(
@@ -86,12 +87,14 @@ public struct AWSSimpleQueueClient: SimpleQueueClientProtocol {
                                      endpointPort: endpointPort,
                                      contentType: contentType,
                                      clientDelegate: clientDelegate,
-                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                     eventLoopProvider: eventLoopProvider)
         self.listHttpClient = HTTPClient(endpointHostName: endpointHostName,
                                           endpointPort: endpointPort,
                                           contentType: contentType,
                                           clientDelegate: clientDelegateForListHttpClient,
-                                          connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                          connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                          eventLoopProvider: eventLoopProvider)
         self.awsRegion = awsRegion
         self.service = service
         self.target = nil

--- a/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
+++ b/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
@@ -73,14 +73,16 @@ public struct AWSSimpleWorkflowClient: SimpleWorkflowClientProtocol {
                 contentType: String = "application/x-amz-json-1.0",
                 target: String? = "SimpleWorkflowService",
                 connectionTimeoutSeconds: Int = 10,
-                retryConfiguration: HTTPClientRetryConfiguration = .default) {
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>()
 
         self.httpClient = HTTPClient(endpointHostName: endpointHostName,
                                      endpointPort: endpointPort,
                                      contentType: contentType,
                                      clientDelegate: clientDelegate,
-                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                     eventLoopProvider: eventLoopProvider)
         self.awsRegion = awsRegion
         self.service = service
         self.target = target

--- a/Sources/SmokeAWSCore/JSONDecoder+awsCompatibleDecoder.swift
+++ b/Sources/SmokeAWSCore/JSONDecoder+awsCompatibleDecoder.swift
@@ -26,11 +26,9 @@ private func createDecoder() -> JSONDecoder {
     return jsonDecoder
 }
 
-private let jsonDecoder = createDecoder()
-
 public extension JSONDecoder {
     /// Return a AWS compatible JSON Decoder
-    public static var awsCompatibleDecoder: JSONDecoder {
-        return jsonDecoder
+    public static func awsCompatibleDecoder() -> JSONDecoder {
+        return createDecoder()
     }
 }

--- a/Sources/SmokeAWSCore/JSONDecoder+awsCompatibleEncoder.swift
+++ b/Sources/SmokeAWSCore/JSONDecoder+awsCompatibleEncoder.swift
@@ -28,11 +28,9 @@ private func createEncoder() -> JSONEncoder {
     return jsonEncoder
 }
 
-private let jsonEncoder = createEncoder()
-
 public extension JSONEncoder {
     /// Return a AWS compatible JSON Encoder
-    public static var awsCompatibleEncoder: JSONEncoder {
-        return jsonEncoder
+    public static func awsCompatibleEncoder() -> JSONEncoder {
+        return createEncoder()
     }
 }

--- a/Sources/SmokeAWSCore/XMLDecoder+awsCompatibleDecoder.swift
+++ b/Sources/SmokeAWSCore/XMLDecoder+awsCompatibleDecoder.swift
@@ -27,11 +27,9 @@ private func createDecoder() -> XMLDecoder {
     return xmlDecoder
 }
 
-private let xmlDecoder = createDecoder()
-
 public extension XMLDecoder {
     /// Return a AWS compatible XML Decoder
-    public static var awsCompatibleDecoder: XMLDecoder {
-        return xmlDecoder
+    public static func awsCompatibleDecoder() -> XMLDecoder {
+        return createDecoder()
     }
 }

--- a/Sources/SmokeAWSCore/XMLEncoder+awsCompatibleEncoder.swift
+++ b/Sources/SmokeAWSCore/XMLEncoder+awsCompatibleEncoder.swift
@@ -29,11 +29,9 @@ private func createEncoder() -> XMLEncoder {
     return xmlEncoder
 }
 
-private let xmlEncoder = createEncoder()
-
 public extension XMLEncoder {
     /// Return a AWS compatible XML Encoder
-    public static var awsCompatibleEncoder: XMLEncoder {
-        return xmlEncoder
+    public static func awsCompatibleEncoder() -> XMLEncoder {
+        return createEncoder()
     }
 }

--- a/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
@@ -125,7 +125,7 @@ public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
     public func encodeInputAndQueryString<InputType: Encodable>(input: InputType, httpPath: String) throws
         -> (pathWithQuery: String, body: Data) {
             // there is no query; encode the body as a JSON payload
-            return (pathWithQuery: httpPath, body: try JSONEncoder.awsCompatibleEncoder.encode(input))
+            return (pathWithQuery: httpPath, body: try JSONEncoder.awsCompatibleEncoder().encode(input))
     }
     
     public func decodeOutput<OutputType>(output: Data?,

--- a/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
@@ -46,7 +46,7 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
         Log.debug("Attempting to decode error data into JSON: \(bodyData.debugString)")
         
         // attempt to get an error of Error type by decoding the body data
-        return try JSONDecoder.awsCompatibleDecoder.decode(ErrorType.self, from: bodyData)
+        return try JSONDecoder.awsCompatibleDecoder().decode(ErrorType.self, from: bodyData)
     }
     
     public func encodeInputAndQueryString<InputType>(
@@ -83,7 +83,7 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
             
             let body: Data
             if let bodyEncodable = input.bodyEncodable {
-                body = try JSONEncoder.awsCompatibleEncoder.encode(bodyEncodable)
+                body = try JSONEncoder.awsCompatibleEncoder().encode(bodyEncodable)
             } else {
                 body = Data()
             }
@@ -118,7 +118,7 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
     public func encodeInputAndQueryString<InputType: Encodable>(input: InputType, httpPath: String) throws
         -> (pathWithQuery: String, body: Data) {
             // there is no query; encode the body as a JSON payload
-            return (pathWithQuery: httpPath, body: try JSONEncoder.awsCompatibleEncoder.encode(input))
+            return (pathWithQuery: httpPath, body: try JSONEncoder.awsCompatibleEncoder().encode(input))
     }
     
     public func decodeOutput<OutputType>(output: Data?,
@@ -133,7 +133,7 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
                 throw HTTPError.badResponse("Unexpected empty response.")
             }
             
-            return try JSONDecoder.awsCompatibleDecoder.decode(OutputType.BodyType.self,
+            return try JSONDecoder.awsCompatibleDecoder().decode(OutputType.BodyType.self,
                                                                from: responseBody)
         }
         

--- a/Sources/SmokeAWSHttp/V4Signer.swift
+++ b/Sources/SmokeAWSHttp/V4Signer.swift
@@ -68,7 +68,7 @@ struct V4Signer {
         }
         
         
-        queries = queries.sorted { $0.name.localizedCompare($1.name) == ComparisonResult.orderedAscending }
+        queries = queries.sorted { a, b in a.name < b.name }
         
         let url = URL(string: url.absoluteString.components(separatedBy: "?")[0]+"?"+queries.asStringForURL)!
         
@@ -157,7 +157,7 @@ struct V4Signer {
 
     private func canonicalHeaders(_ headers: [String: String]) -> String {
         var list = [String]()
-        let keys = Array(headers.keys).sorted {$0.localizedCompare($1) == ComparisonResult.orderedAscending }
+        let keys = Array(headers.keys).sorted(by: <)
         
         for key in keys {
             if key.caseInsensitiveCompare("authorization") != ComparisonResult.orderedSame {

--- a/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
@@ -46,17 +46,17 @@ struct ErrorWrapper<ErrorType: Error & Decodable>: Error & Decodable {
     
     internal static func errorFromBodyData<ErrorType: Error & Decodable>(errorType: ErrorType.Type,
                                                                          bodyData: Data) throws -> Error {
-        let decoder = XMLDecoder.awsCompatibleDecoder
-        
         // attempt to decode the output body from an XML payload
         let result: Error
         
         // the error is not wrapped
         do {
-            result = try decoder.decode(ErrorType.self, from: bodyData)
+            result = try XMLDecoder.awsCompatibleDecoder().decode(ErrorType.self,
+                                                                  from: bodyData)
         } catch is DecodingError {
             // if the error is wrapped
-            let errorWrapper = try decoder.decode(ErrorWrapper<ErrorType>.self, from: bodyData)
+            let errorWrapper = try XMLDecoder.awsCompatibleDecoder().decode(ErrorWrapper<ErrorType>.self,
+                                                         from: bodyData)
             
             if errorWrapper.errors.count == 1 {
                 result = errorWrapper.errors[0]
@@ -186,7 +186,7 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
             
             let body: Data
             if let bodyEncodable = input.bodyEncodable {
-                let encoder = XMLEncoder.awsCompatibleEncoder
+                let encoder = XMLEncoder.awsCompatibleEncoder()
                 encoder.listEncodingStrategy = .expandListWithItemTag("item")
                 
                 guard let inputBodyRootKey = inputBodyRootKey else {
@@ -227,7 +227,7 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
     public func decodeOutput<OutputType>(output: Data?,
                                   headers: [(String, String)]) throws -> OutputType
     where OutputType: HTTPResponseOutputProtocol {
-        let decoder = XMLDecoder.awsCompatibleDecoder
+        let decoder = XMLDecoder.awsCompatibleDecoder()
         
         if let outputListDecodingStrategy = outputListDecodingStrategy {
             decoder.listDecodingStrategy = outputListDecodingStrategy

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
@@ -73,14 +73,16 @@ public struct AWSStepFunctionsClient: StepFunctionsClientProtocol {
                 contentType: String = "application/x-amz-json-1.0",
                 target: String? = "AWSStepFunctions",
                 connectionTimeoutSeconds: Int = 10,
-                retryConfiguration: HTTPClientRetryConfiguration = .default) {
+                retryConfiguration: HTTPClientRetryConfiguration = .default,
+                eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) {
         let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>()
 
         self.httpClient = HTTPClient(endpointHostName: endpointHostName,
                                      endpointPort: endpointPort,
                                      contentType: contentType,
                                      clientDelegate: clientDelegate,
-                                     connectionTimeoutSeconds: connectionTimeoutSeconds)
+                                     connectionTimeoutSeconds: connectionTimeoutSeconds,
+                                     eventLoopProvider: eventLoopProvider)
         self.awsRegion = awsRegion
         self.service = service
         self.target = target


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add the ability to pass an eventLoopProvider into each client, allowing clients to share the same event loop threads.
* Avoid `localizedCompare` as this can have issues with thread pools (using thread local storage)
* Avoid using singleton decoder and encoder as these might store memory.

*Testing performed:* Tested in beta environment (Linux). Confirmed functionally correct. Continuing to investigate long term memory performance.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
