### PR TITLE
Remove single quote from set of allowed query characters

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "Cryptor",
-        "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
-        "state": {
-          "branch": null,
-          "revision": "6f79b4ea0a7ef8acb08ba3f3e23da32e83acaca3",
-          "version": "1.0.28"
-        }
-      },
-      {
         "package": "LoggerAPI",
         "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
         "state": {

--- a/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
@@ -26,13 +26,13 @@ import HTTPHeadersCoding
 import HTTPPathCoding
 
 extension CharacterSet {
-    public static let uriAWSQueryValueAllowed: CharacterSet = ["&", "\'", "(", ")", "-", ".", "0", "1", "2", "3",
-                                                               "4", "5", "6", "7", "8", "9", "A", "B", "C",
-                                                               "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
-                                                               "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W",
-                                                               "X", "Y", "Z", "_", "a", "b", "c", "d", "e", "f",
-                                                               "g", "h", "i", "j", "k", "l", "m", "n", "o", "p",
-                                                               "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
+    public static let uriAWSQueryValueAllowed: CharacterSet = ["&", "(", ")", "-", ".", "0", "1", "2", "3", "4",
+                                                               "5", "6", "7", "8", "9", "A", "B", "C", "D", "E",
+                                                               "F", "G", "H", "I", "J", "K", "L", "M", "N", "O",
+                                                               "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y",
+                                                               "Z", "_", "a", "b", "c", "d", "e", "f", "g", "h",
+                                                               "i", "j", "k", "l", "m", "n", "o", "p", "q", "r",
+                                                               "s", "t", "u", "v", "w", "x", "y", "z"]
 }
 
 struct ErrorWrapper<ErrorType: Error & Decodable>: Error & Decodable {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This change removes the single quote character `\'` from the `CharacterSet` of allowed characters in the query portion of AWS request URIs.

I have tested this change for several different AWS services locally.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
