### PR TITLE
Remove '&', '(' and ')' from the uriAWSQueryValueAllowed character set.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 .DS_Store
 .build/
+.swiftpm/
 *.xcodeproj
 *~

--- a/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
@@ -26,7 +26,7 @@ import HTTPHeadersCoding
 import HTTPPathCoding
 
 extension CharacterSet {
-    public static let uriAWSQueryValueAllowed: CharacterSet = ["&", "(", ")", "-", ".", "0", "1", "2", "3", "4",
+    public static let uriAWSQueryValueAllowed: CharacterSet = ["~", "-", ".", "0", "1", "2", "3", "4",
                                                                "5", "6", "7", "8", "9", "A", "B", "C", "D", "E",
                                                                "F", "G", "H", "I", "J", "K", "L", "M", "N", "O",
                                                                "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* These characters break SNS publish requests. Verified SNS publish request with payload ",'.|():{_=-}~!*&()-._&$,&@%-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.