### PR TITLE
Swift 5.x and Ubuntu 18.04 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,26 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.1-bionic USE_SWIFT_LINT=no
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=no
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.0.1-bionic USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.0.1-xenial USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE_TAG=swift:4.2.1 USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial

--- a/CITests/run
+++ b/CITests/run
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
-swiftLintVersion=0.29.0
+swiftLintVersion=0.33.0
 
 USE_SWIFT_LINT=$1
+
+apt-get update
+apt-get -y install libssl-dev libz-dev
 
 workspaceRoot=($PWD)
 srcRoot=$workspaceRoot/sources

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "Cryptor",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
+        "state": {
+          "branch": null,
+          "revision": "6e83ae419817e7272f2f80a7a005a26df366dd8e",
+          "version": "1.0.31"
+        }
+      },
+      {
         "package": "LoggerAPI",
         "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,9 +68,9 @@
         "package": "XMLCoding",
         "repositoryURL": "https://github.com/LiveUI/XMLCoding.git",
         "state": {
-          "branch": "master",
+          "branch": null,
           "revision": "f0fbfe17e73f329e13a6133ff5437f7b174049fd",
-          "version": null
+          "version": "0.4.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,9 +68,9 @@
         "package": "XMLCoding",
         "repositoryURL": "https://github.com/LiveUI/XMLCoding.git",
         "state": {
-          "branch": null,
-          "revision": "8c760e960a5e53a5338c2871c4fcdf06b8c5ace4",
-          "version": "0.4.0"
+          "branch": "master",
+          "revision": "f0fbfe17e73f329e13a6133ff5437f7b174049fd",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.8.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/LiveUI/XMLCoding.git", .branch("master")),
+        .package(url: "https://github.com/LiveUI/XMLCoding.git", .upToNextMajor(from: "0.4.1")),
         .package(url: "https://github.com/amzn/smoke-http.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", .upToNextMajor(from: "1.0.0")),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -104,6 +104,7 @@ let package = Package(
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", .upToNextMajor(from: "0.4.0")),
         .package(url: "https://github.com/amzn/smoke-http.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [
         .target(
@@ -185,7 +186,7 @@ let package = Package(
             name: "SmokeAWSHttp",
             dependencies: ["LoggerAPI", "NIO", "NIOHTTP1", "NIOOpenSSL",
                            "SmokeAWSCore", "SmokeHTTPClient", "QueryCoding",
-                           "HTTPPathCoding", "HTTPHeadersCoding"]),
+                           "HTTPPathCoding", "HTTPHeadersCoding", "Cryptor"]),
         .testTarget(
             name: "S3ClientTests",
             dependencies: ["S3Client"]),

--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.8.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/LiveUI/XMLCoding.git", .upToNextMajor(from: "0.4.0")),
+        .package(url: "https://github.com/LiveUI/XMLCoding.git", .branch("master")),
         .package(url: "https://github.com/amzn/smoke-http.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", .upToNextMajor(from: "1.0.0")),
     ],

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 <a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-4.2-orange.svg?style=flat" alt="Swift 4.1 Compatible">
 </a>
+<a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.0-orange.svg?style=flat" alt="Swift 5.0 Compatible">
+</a>
+<a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.1-orange.svg?style=flat" alt="Swift 5.1 Compatible">
+</a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">
 </a>

--- a/Sources/SmokeAWSHttp/String+hmac.swift
+++ b/Sources/SmokeAWSHttp/String+hmac.swift
@@ -16,7 +16,7 @@
 //
 
 import Foundation
-import CNIOOpenSSL
+import Cryptor
 
 extension String {
     /**
@@ -26,16 +26,11 @@ extension String {
         - key: the key to use to generate the hmac.
      */
     func hmac(withKey key: [UInt8]) -> [UInt8] {
-        var context = HMAC_CTX()
-        HMAC_Init_ex(&context, key, Int32(key.count), EVP_sha256(), nil)
+        let data: [UInt8] = Array(self.utf8)
+        guard let hmac = HMAC(using: HMAC.Algorithm.sha256, key: key).update(byteArray: data)?.final() else {
+            return []
+        }
         
-        let bytes = Array(self.utf8)
-        HMAC_Update(&context, bytes, bytes.count)
-        var digest = [UInt8](repeating: 0, count: Int(EVP_MAX_MD_SIZE))
-        var length: UInt32 = 0
-        HMAC_Final(&context, &digest, &length)
-        HMAC_CTX_cleanup(&context)
-        
-        return Array(digest[0..<Int(length)])
+        return hmac
     }
 }

--- a/Sources/SmokeAWSHttp/sha256Extensions.swift
+++ b/Sources/SmokeAWSHttp/sha256Extensions.swift
@@ -16,32 +16,31 @@
 //
 
 import Foundation
-import CNIOOpenSSL
+import Cryptor
 
 extension String {
     /// The SHA256 of this String
     var sha256: [UInt8] {
-        let bytes = Array(self.utf8)
-        return bytes.sha256
+        let hash = Digest(using: .sha256)
+        _ = hash.update(string: self)
+        return hash.final()
     }
 }
 
 extension Array where Element == UInt8 {
     /// The SHA256 of this Array
     var sha256: [UInt8] {
-        var hash = [UInt8](repeating: 0, count: Int(SHA256_DIGEST_LENGTH))
-        SHA256(self, self.count, &hash)
-        return hash
+        let hash = Digest(using: .sha256)
+        _ = hash.update(byteArray: self)
+        return hash.final()
     }
 }
 
 extension Data {
     /// The SHA256 of this Data
     var sha256: [UInt8] {
-        return self.withUnsafeBytes {(bytes: UnsafePointer<UInt8>) in
-            var hash = [UInt8](repeating: 0, count: Int(SHA256_DIGEST_LENGTH))
-            SHA256(bytes, self.count, &hash)
-            return hash
-        }
+        let hash = Digest(using: .sha256)
+        _ = hash.update(data: self)
+        return hash.final()
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #14 #25 

*Description of changes:*

1. Use BlueCryptor to support systems that ship with OpenSSL 1.1.
2. Require 0.4.1 of XMLCoding dependency to support Swift 5.1.
3. Add Swift 5.0 and 5.1 CI Tests for both Ubuntu 16.04 and 18.04


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
