### PR TITLE
Add CI tests for Swift 5.0 and 5.1 (1.x branch).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,16 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=no
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.0.1-xenial USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE_TAG=swift:4.2.1 USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial

--- a/CITests/run
+++ b/CITests/run
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
-swiftLintVersion=0.29.0
+swiftLintVersion=0.33.0
 
 USE_SWIFT_LINT=$1
+
+apt-get update
+apt-get -y install libssl-dev libz-dev
 
 workspaceRoot=($PWD)
 srcRoot=$workspaceRoot/sources

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/LiveUI/XMLCoding.git",
         "state": {
           "branch": null,
-          "revision": "8c760e960a5e53a5338c2871c4fcdf06b8c5ace4",
-          "version": "0.4.0"
+          "revision": "f0fbfe17e73f329e13a6133ff5437f7b174049fd",
+          "version": "0.4.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.8.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/LiveUI/XMLCoding.git", .upToNextMajor(from: "0.4.0")),
+        .package(url: "https://github.com/LiveUI/XMLCoding.git", .upToNextMajor(from: "0.4.1")),
         .package(url: "https://github.com/amzn/smoke-http.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 <a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-4.2-orange.svg?style=flat" alt="Swift 4.1 Compatible">
 </a>
+<a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.0-orange.svg?style=flat" alt="Swift 5.0 Compatible">
+</a>
+<a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.1-orange.svg?style=flat" alt="Swift 5.1 Compatible">
+</a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">
 </a>


### PR DESCRIPTION
*Issue #, if available:* #25 

*Description of changes:*

1. Require 0.4.1 of XMLCoding dependency to support Swift 5.1.
2. Add Swift 5.0 and 5.1 CI Tests for Ubuntu 16.04

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
