### PR TITLE
Xcode-11 compatible platforms: macOS10.12, iOS10

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,11 +13,14 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-    
+
 import PackageDescription
 
 let package = Package(
     name: "SmokeAWS",
+    platforms: [
+        .macOS(.v10_12), .iOS(.v10)
+        ],
     products: [
         .library(
             name: "CloudWatchClient",
@@ -206,5 +209,6 @@ let package = Package(
         .testTarget(
             name: "RDSClientTests",
             dependencies: ["RDSClient"]),
-    ]
+    ],
+    swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
XMLDecode/Encoder uses .iso8601 that is available starting iOS10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
