### PR TITLE
Use valid semantic version for SmokeHTTP.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "SmokeHTTP",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
-          "branch": "2.0.0.alpha.4",
+          "branch": null,
           "revision": "705a512220e9308c3268e85ea4db8535b54294eb",
-          "version": null
+          "version": "2.0.0-alpha.4"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/apple/swift-metrics", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", .upToNextMajor(from: "0.4.1")),
-        .package(url: "https://github.com/amzn/smoke-http.git", .branch("2.0.0.alpha.4")),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-alpha"),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use valid semantic version for SmokeHTTP.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
