### PR TITLE
Add a MockInvocationReporting type, for testing. 

### DIFF
--- a/Sources/SmokeAWSCore/MockInvocationReporting.swift
+++ b/Sources/SmokeAWSCore/MockInvocationReporting.swift
@@ -1,0 +1,38 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  MockInvocationReporting.swift
+//  SmokeAWSCore
+//
+
+import Foundation
+import SmokeHTTPClient
+import Logging
+
+/**
+  A type conforming to the `SmokeAWSInvocationReporting` protocol, predominantly for testing.
+ */
+public struct MockInvocationReporting: SmokeAWSInvocationReporting {
+    public let logger: Logger
+    public var internalRequestId: String
+    public var traceContext: MockInvocationTraceContext
+    
+    public init(
+            logger: Logger = Logger(label: "com.amazon.SmokeAWSCore.MockInvocationReporting"),
+            internalRequestId: String = "internalRequestId",
+            traceContext: MockInvocationTraceContext = .init()) {
+        self.logger = logger
+        self.internalRequestId = internalRequestId
+        self.traceContext = traceContext
+    }
+}

--- a/Tests/ElasticComputeCloudClientTests/ElasticComputeCloudClientTests.swift
+++ b/Tests/ElasticComputeCloudClientTests/ElasticComputeCloudClientTests.swift
@@ -11,25 +11,6 @@ import NIOHTTP1
 import SmokeHTTPClient
 import Logging
 
-struct TestInvocationTraceContext: InvocationTraceContext {
-    typealias OutwardsRequestContext = String
-    
-    func handleOutwardsRequestStart(method: HTTPMethod, uri: String, version: HTTPVersion, logger: Logger, internalRequestId: String,
-                                    headers: inout [(String, String)], bodyData: Data) -> String {
-        return "request"
-    }
-    
-    func handleOutwardsRequestSuccess(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?) {
-        // do nothing
-    }
-    
-    func handleOutwardsRequestFailure(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?, error: Error) {
-        // do nothing
-    }
-}
-
 class ElasticComputeCloudClientTests: XCTestCase {
     
     func testAccessDeniedErrorDecode() throws {
@@ -51,7 +32,8 @@ class ElasticComputeCloudClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)
@@ -84,7 +66,8 @@ class ElasticComputeCloudClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = DataAWSHttpClientDelegate<ElasticComputeCloudError>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)

--- a/Tests/RDSClientTests/RDSClientTests.swift
+++ b/Tests/RDSClientTests/RDSClientTests.swift
@@ -11,25 +11,6 @@ import NIOHTTP1
 import SmokeHTTPClient
 import Logging
 
-struct TestInvocationTraceContext: InvocationTraceContext {
-    typealias OutwardsRequestContext = String
-    
-    func handleOutwardsRequestStart(method: HTTPMethod, uri: String, version: HTTPVersion, logger: Logger, internalRequestId: String,
-                                    headers: inout [(String, String)], bodyData: Data) -> String {
-        return "request"
-    }
-    
-    func handleOutwardsRequestSuccess(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?) {
-        // do nothing
-    }
-    
-    func handleOutwardsRequestFailure(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?, error: Error) {
-        // do nothing
-    }
-}
-
 class RDSClientTests: XCTestCase {
     func testAccessDeniedErrorDecode() throws {
         let message = "User: ... is not authorized to perform: rds:DescribeAccountAttributes"
@@ -48,7 +29,8 @@ class RDSClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = XMLAWSHttpClientDelegate<RDSError>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)
@@ -79,7 +61,8 @@ class RDSClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = DataAWSHttpClientDelegate<RDSError>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)

--- a/Tests/S3ClientTests/S3ClientTests.swift
+++ b/Tests/S3ClientTests/S3ClientTests.swift
@@ -11,25 +11,6 @@ import NIOHTTP1
 import SmokeHTTPClient
 import Logging
 
-struct TestInvocationTraceContext: InvocationTraceContext {
-    typealias OutwardsRequestContext = String
-    
-    func handleOutwardsRequestStart(method: HTTPMethod, uri: String, version: HTTPVersion, logger: Logger, internalRequestId: String,
-                                    headers: inout [(String, String)], bodyData: Data) -> String {
-        return "request"
-    }
-    
-    func handleOutwardsRequestSuccess(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?) {
-        // do nothing
-    }
-    
-    func handleOutwardsRequestFailure(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?, error: Swift.Error) {
-        // do nothing
-    }
-}
-
 class S3ClientTests: XCTestCase {
     
     func testValidS3Uri() throws {
@@ -112,7 +93,8 @@ class S3ClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = XMLAWSHttpClientDelegate<S3Error>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)
@@ -141,7 +123,8 @@ class S3ClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = DataAWSHttpClientDelegate<S3Error>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)
@@ -171,7 +154,8 @@ class S3ClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = DataAWSHttpClientDelegate<S3Error>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)

--- a/Tests/SecurityTokenClientTests/SecurityTokenClientTests.swift
+++ b/Tests/SecurityTokenClientTests/SecurityTokenClientTests.swift
@@ -11,25 +11,6 @@ import NIOHTTP1
 import SmokeHTTPClient
 import Logging
 
-struct TestInvocationTraceContext: InvocationTraceContext {
-    typealias OutwardsRequestContext = String
-    
-    func handleOutwardsRequestStart(method: HTTPMethod, uri: String, version: HTTPVersion, logger: Logger, internalRequestId: String,
-                                    headers: inout [(String, String)], bodyData: Data) -> String {
-        return "request"
-    }
-    
-    func handleOutwardsRequestSuccess(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?) {
-        // do nothing
-    }
-    
-    func handleOutwardsRequestFailure(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?, error: Error) {
-        // do nothing
-    }
-}
-
 class SecurityTokenClientTests: XCTestCase {
     
     func testAccessDeniedErrorDecode() throws {
@@ -49,7 +30,8 @@ class SecurityTokenClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)

--- a/Tests/SimpleNotificationClientTests/SimpleNotificationClientTests.swift
+++ b/Tests/SimpleNotificationClientTests/SimpleNotificationClientTests.swift
@@ -11,25 +11,6 @@ import NIOHTTP1
 import SmokeHTTPClient
 import Logging
 
-struct TestInvocationTraceContext: InvocationTraceContext {
-    typealias OutwardsRequestContext = String
-    
-    func handleOutwardsRequestStart(method: HTTPMethod, uri: String, version: HTTPVersion, logger: Logger, internalRequestId: String,
-                                    headers: inout [(String, String)], bodyData: Data) -> String {
-        return "request"
-    }
-    
-    func handleOutwardsRequestSuccess(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?) {
-        // do nothing
-    }
-    
-    func handleOutwardsRequestFailure(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?, error: Error) {
-        // do nothing
-    }
-}
-
 class SimpleNotificationClientTests: XCTestCase {
     
     func testAccessDeniedErrorDecode() throws {
@@ -49,7 +30,8 @@ class SimpleNotificationClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)
@@ -80,7 +62,8 @@ class SimpleNotificationClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = DataAWSHttpClientDelegate<SimpleNotificationError>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)
@@ -109,7 +92,8 @@ class SimpleNotificationClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = DataAWSHttpClientDelegate<SimpleNotificationError>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)

--- a/Tests/SimpleQueueClientTests/SimpleQueueClientTests.swift
+++ b/Tests/SimpleQueueClientTests/SimpleQueueClientTests.swift
@@ -11,25 +11,6 @@ import NIOHTTP1
 import SmokeHTTPClient
 import Logging
 
-struct TestInvocationTraceContext: InvocationTraceContext {
-    typealias OutwardsRequestContext = String
-    
-    func handleOutwardsRequestStart(method: HTTPMethod, uri: String, version: HTTPVersion, logger: Logger, internalRequestId: String,
-                                    headers: inout [(String, String)], bodyData: Data) -> String {
-        return "request"
-    }
-    
-    func handleOutwardsRequestSuccess(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?) {
-        // do nothing
-    }
-    
-    func handleOutwardsRequestFailure(outwardsRequestContext: String?, logger: Logger, internalRequestId: String,
-                                      responseHead: HTTPResponseHead?, bodyData: Data?, error: Error) {
-        // do nothing
-    }
-}
-
 class SimpleQueueClientTests: XCTestCase {
     
     func testAccessDeniedErrorDecode() throws {
@@ -51,7 +32,8 @@ class SimpleQueueClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)
@@ -84,7 +66,8 @@ class SimpleQueueClientTests: XCTestCase {
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
         let clientDelegate = DataAWSHttpClientDelegate<SimpleQueueError>()
-        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId", traceContext: TestInvocationTraceContext())
+        let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
+                                                                        traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(responseHead: responseHead,
                                                         responseComponents: components,
                                                         invocationReporting: invocationReporting)


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
1. Add a MockInvocationReporting type, for testing. 
2. Use the MockInvocationTraceContext provided by SmokeHTTP.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
