### PR TITLE
Support non-TLS calls

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "smoke-http",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
-          "branch": "expose_default_tls_configuration",
-          "revision": "c02c95ca43f90c7c4766a3fac4652f8ce41d6968",
-          "version": null
+          "branch": null,
+          "revision": "c2ce7ef13ad62ad5b8ea76db5c3cfc9b32816cb0",
+          "version": "2.0.0-rc.1"
         }
       },
       {
@@ -26,6 +26,15 @@
           "branch": null,
           "revision": "d67ac68d09a95443303e9d6e37b34e7ba101d5f1",
           "version": "1.0.1"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log",
+        "state": {
+          "branch": null,
+          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
+          "version": "1.2.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "smoke-http",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
-          "branch": null,
-          "revision": "a3fd185135fe2fc40ef609983071d44dafce36f1",
-          "version": "2.0.0-beta.1"
+          "branch": "expose_default_tls_configuration",
+          "revision": "c02c95ca43f90c7c4766a3fac4652f8ce41d6968",
+          "version": null
         }
       },
       {
@@ -26,15 +26,6 @@
           "branch": null,
           "revision": "d67ac68d09a95443303e9d6e37b34e7ba101d5f1",
           "version": "1.0.1"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log",
-        "state": {
-          "branch": null,
-          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
-          "version": "1.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", .branch("expose_default_tls_configuration")),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-rc.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/amzn/smoke-http.git", .branch("expose_default_tls_configuration")),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -107,7 +107,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", .branch("expose_default_tls_configuration")),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-rc.1"),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
     ],
     targets: [

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -107,7 +107,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/amzn/smoke-http.git", .branch("expose_default_tls_configuration")),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
     ],
     targets: [

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -107,7 +107,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", .branch("expose_default_tls_configuration")),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-rc.1"),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
     ],
     targets: [

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -107,7 +107,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/amzn/smoke-http.git", .branch("expose_default_tls_configuration")),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/CloudWatchClient/AWSCloudWatchClient.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClient.swift
@@ -82,6 +82,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "monitoring",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2010-08-01",
@@ -90,7 +91,8 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>
                     = SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/CloudWatchClient/AWSCloudWatchClient.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClient.swift
@@ -71,14 +71,14 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: CloudWatchOperationsReporting
     let invocationsReporting: CloudWatchInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -90,7 +90,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>
                     = SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -110,7 +110,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
         self.invocationsReporting = CloudWatchInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/CloudWatchClient/AWSCloudWatchClient.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClient.swift
@@ -71,14 +71,14 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: CloudWatchOperationsReporting
     let invocationsReporting: CloudWatchInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -90,7 +90,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>
                     = SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -110,7 +110,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
         self.invocationsReporting = CloudWatchInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
@@ -57,6 +57,7 @@ public struct AWSCloudWatchClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "monitoring",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2010-08-01",
@@ -65,7 +66,8 @@ public struct AWSCloudWatchClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>
                     = SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSCloudWatchClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: CloudWatchOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "monitoring",
@@ -65,7 +65,7 @@ public struct AWSCloudWatchClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>
                     = SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSCloudWatchClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: CloudWatchOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "monitoring",
@@ -65,7 +65,7 @@ public struct AWSCloudWatchClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>
                     = SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/DynamoDBClient/AWSDynamoDBClient.swift
+++ b/Sources/DynamoDBClient/AWSDynamoDBClient.swift
@@ -70,14 +70,14 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: DynamoDBOperationsReporting
     let invocationsReporting: DynamoDBInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -89,7 +89,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
                     = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>()
+        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -108,7 +108,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
         self.invocationsReporting = DynamoDBInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/DynamoDBClient/AWSDynamoDBClient.swift
+++ b/Sources/DynamoDBClient/AWSDynamoDBClient.swift
@@ -70,14 +70,14 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: DynamoDBOperationsReporting
     let invocationsReporting: DynamoDBInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -89,7 +89,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
                     = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -108,7 +108,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
         self.invocationsReporting = DynamoDBInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/DynamoDBClient/AWSDynamoDBClient.swift
+++ b/Sources/DynamoDBClient/AWSDynamoDBClient.swift
@@ -81,6 +81,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "dynamodb",
                 contentType: String = "application/x-amz-json-1.0",
                 target: String? = "DynamoDB_20120810",
@@ -89,7 +90,8 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
                     = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/DynamoDBClient/AWSDynamoDBClientGenerator.swift
+++ b/Sources/DynamoDBClient/AWSDynamoDBClientGenerator.swift
@@ -49,11 +49,11 @@ public struct AWSDynamoDBClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: DynamoDBOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "dynamodb",
@@ -64,7 +64,7 @@ public struct AWSDynamoDBClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
                     = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/DynamoDBClient/AWSDynamoDBClientGenerator.swift
+++ b/Sources/DynamoDBClient/AWSDynamoDBClientGenerator.swift
@@ -49,11 +49,11 @@ public struct AWSDynamoDBClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: DynamoDBOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "dynamodb",
@@ -64,7 +64,7 @@ public struct AWSDynamoDBClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
                     = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>()
+        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/DynamoDBClient/AWSDynamoDBClientGenerator.swift
+++ b/Sources/DynamoDBClient/AWSDynamoDBClientGenerator.swift
@@ -56,6 +56,7 @@ public struct AWSDynamoDBClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "dynamodb",
                 contentType: String = "application/x-amz-json-1.0",
                 target: String? = "DynamoDB_20120810",
@@ -64,7 +65,8 @@ public struct AWSDynamoDBClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>
                     = SmokeAWSClientReportingConfiguration<DynamoDBModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = JSONAWSHttpClientDelegate<DynamoDBError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
@@ -66,14 +66,14 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: ElasticComputeCloudOperationsReporting
     let invocationsReporting: ElasticComputeCloudInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -85,7 +85,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(requiresTLS: credentialsProvider != nil,
+        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(forEndpointPort: endpointPort,
             outputListDecodingStrategy: .collapseListUsingItemTag("item"), 
             inputQueryKeyEncodeTransformStrategy: .capitalizeFirstCharacter)
 
@@ -107,7 +107,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
         self.invocationsReporting = ElasticComputeCloudInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
@@ -77,6 +77,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "ec2",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2016-11-15",
@@ -85,7 +86,8 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(forEndpointPort: endpointPort,
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(requiresTLS: useTLS,
             outputListDecodingStrategy: .collapseListUsingItemTag("item"), 
             inputQueryKeyEncodeTransformStrategy: .capitalizeFirstCharacter)
 

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
@@ -66,14 +66,14 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: ElasticComputeCloudOperationsReporting
     let invocationsReporting: ElasticComputeCloudInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -85,7 +85,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(
+        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(requiresTLS: credentialsProvider != nil,
             outputListDecodingStrategy: .collapseListUsingItemTag("item"), 
             inputQueryKeyEncodeTransformStrategy: .capitalizeFirstCharacter)
 
@@ -107,7 +107,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
         self.invocationsReporting = ElasticComputeCloudInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClientGenerator.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClientGenerator.swift
@@ -57,6 +57,7 @@ public struct AWSElasticComputeCloudClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "ec2",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2016-11-15",
@@ -65,7 +66,8 @@ public struct AWSElasticComputeCloudClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(forEndpointPort: endpointPort,
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(requiresTLS: useTLS,
             outputListDecodingStrategy: .collapseListUsingItemTag("item"), 
             inputQueryKeyEncodeTransformStrategy: .capitalizeFirstCharacter)
 

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClientGenerator.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSElasticComputeCloudClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: ElasticComputeCloudOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "ec2",
@@ -65,7 +65,7 @@ public struct AWSElasticComputeCloudClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(
+        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(requiresTLS: credentialsProvider != nil,
             outputListDecodingStrategy: .collapseListUsingItemTag("item"), 
             inputQueryKeyEncodeTransformStrategy: .capitalizeFirstCharacter)
 

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClientGenerator.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSElasticComputeCloudClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: ElasticComputeCloudOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "ec2",
@@ -65,7 +65,7 @@ public struct AWSElasticComputeCloudClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(requiresTLS: credentialsProvider != nil,
+        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(forEndpointPort: endpointPort,
             outputListDecodingStrategy: .collapseListUsingItemTag("item"), 
             inputQueryKeyEncodeTransformStrategy: .capitalizeFirstCharacter)
 

--- a/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
+++ b/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
@@ -70,14 +70,14 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: ElasticContainerOperationsReporting
     let invocationsReporting: ElasticContainerInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -89,7 +89,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -108,7 +108,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
         self.invocationsReporting = ElasticContainerInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
+++ b/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
@@ -81,6 +81,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "ecs",
                 contentType: String = "application/x-amz-json-1.1",
                 target: String? = "AmazonEC2ContainerServiceV20141113",
@@ -89,7 +90,8 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
+++ b/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
@@ -70,14 +70,14 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: ElasticContainerOperationsReporting
     let invocationsReporting: ElasticContainerInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -89,7 +89,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>()
+        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -108,7 +108,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
         self.invocationsReporting = ElasticContainerInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/ElasticContainerClient/AWSElasticContainerClientGenerator.swift
+++ b/Sources/ElasticContainerClient/AWSElasticContainerClientGenerator.swift
@@ -56,6 +56,7 @@ public struct AWSElasticContainerClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "ecs",
                 contentType: String = "application/x-amz-json-1.1",
                 target: String? = "AmazonEC2ContainerServiceV20141113",
@@ -64,7 +65,8 @@ public struct AWSElasticContainerClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/ElasticContainerClient/AWSElasticContainerClientGenerator.swift
+++ b/Sources/ElasticContainerClient/AWSElasticContainerClientGenerator.swift
@@ -49,11 +49,11 @@ public struct AWSElasticContainerClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: ElasticContainerOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "ecs",
@@ -64,7 +64,7 @@ public struct AWSElasticContainerClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/ElasticContainerClient/AWSElasticContainerClientGenerator.swift
+++ b/Sources/ElasticContainerClient/AWSElasticContainerClientGenerator.swift
@@ -49,11 +49,11 @@ public struct AWSElasticContainerClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: ElasticContainerOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "ecs",
@@ -64,7 +64,7 @@ public struct AWSElasticContainerClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>
                     = SmokeAWSClientReportingConfiguration<ElasticContainerModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>()
+        let clientDelegate = JSONAWSHttpClientDelegate<ElasticContainerError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/RDSClient/AWSRDSClient.swift
+++ b/Sources/RDSClient/AWSRDSClient.swift
@@ -66,14 +66,14 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: RDSOperationsReporting
     let invocationsReporting: RDSInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -85,7 +85,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -105,7 +105,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
         self.invocationsReporting = RDSInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/RDSClient/AWSRDSClient.swift
+++ b/Sources/RDSClient/AWSRDSClient.swift
@@ -66,14 +66,14 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: RDSOperationsReporting
     let invocationsReporting: RDSInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -85,7 +85,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -105,7 +105,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
         self.invocationsReporting = RDSInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/RDSClient/AWSRDSClient.swift
+++ b/Sources/RDSClient/AWSRDSClient.swift
@@ -77,6 +77,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "rds",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2014-10-31",
@@ -85,7 +86,8 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/RDSClient/AWSRDSClientGenerator.swift
+++ b/Sources/RDSClient/AWSRDSClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSRDSClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: RDSOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "rds",
@@ -65,7 +65,7 @@ public struct AWSRDSClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/RDSClient/AWSRDSClientGenerator.swift
+++ b/Sources/RDSClient/AWSRDSClientGenerator.swift
@@ -57,6 +57,7 @@ public struct AWSRDSClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "rds",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2014-10-31",
@@ -65,7 +66,8 @@ public struct AWSRDSClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/RDSClient/AWSRDSClientGenerator.swift
+++ b/Sources/RDSClient/AWSRDSClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSRDSClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: RDSOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "rds",
@@ -65,7 +65,7 @@ public struct AWSRDSClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/RDSDataClient/AWSRDSDataClient.swift
+++ b/Sources/RDSDataClient/AWSRDSDataClient.swift
@@ -76,6 +76,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "rds-data",
                 contentType: String = "application/x-amz-rest-json-1.1",
                 target: String? = nil,
@@ -84,7 +85,8 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSDataModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSDataModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/RDSDataClient/AWSRDSDataClient.swift
+++ b/Sources/RDSDataClient/AWSRDSDataClient.swift
@@ -65,14 +65,14 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: RDSDataOperationsReporting
     let invocationsReporting: RDSDataInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -84,7 +84,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSDataModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSDataModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>()
+        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -103,7 +103,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
         self.invocationsReporting = RDSDataInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/RDSDataClient/AWSRDSDataClient.swift
+++ b/Sources/RDSDataClient/AWSRDSDataClient.swift
@@ -65,14 +65,14 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: RDSDataOperationsReporting
     let invocationsReporting: RDSDataInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -84,7 +84,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSDataModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSDataModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -103,7 +103,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
         self.invocationsReporting = RDSDataInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/RDSDataClient/AWSRDSDataClientGenerator.swift
+++ b/Sources/RDSDataClient/AWSRDSDataClientGenerator.swift
@@ -49,11 +49,11 @@ public struct AWSRDSDataClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: RDSDataOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "rds-data",
@@ -64,7 +64,7 @@ public struct AWSRDSDataClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSDataModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSDataModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>()
+        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/RDSDataClient/AWSRDSDataClientGenerator.swift
+++ b/Sources/RDSDataClient/AWSRDSDataClientGenerator.swift
@@ -49,11 +49,11 @@ public struct AWSRDSDataClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: RDSDataOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "rds-data",
@@ -64,7 +64,7 @@ public struct AWSRDSDataClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSDataModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSDataModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/RDSDataClient/AWSRDSDataClientGenerator.swift
+++ b/Sources/RDSDataClient/AWSRDSDataClientGenerator.swift
@@ -56,6 +56,7 @@ public struct AWSRDSDataClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "rds-data",
                 contentType: String = "application/x-amz-rest-json-1.1",
                 target: String? = nil,
@@ -64,7 +65,8 @@ public struct AWSRDSDataClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<RDSDataModelOperations>
                     = SmokeAWSClientReportingConfiguration<RDSDataModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = JSONAWSHttpClientDelegate<RDSDataError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/S3Client/AWSS3Client.swift
+++ b/Sources/S3Client/AWSS3Client.swift
@@ -66,14 +66,14 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: S3OperationsReporting
     let invocationsReporting: S3InvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
                 reporting: InvocationReportingType,
                 endpointHostName: String = "s3.amazonaws.com",
                 endpointPort: Int = 443,
@@ -85,9 +85,9 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<S3ModelOperations>
                     = SmokeAWSClientReportingConfiguration<S3ModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>()
+        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(requiresTLS: credentialsProvider != nil)
 
-        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>()
+        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -112,7 +112,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
         self.invocationsReporting = S3InvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient, dataHttpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/S3Client/AWSS3Client.swift
+++ b/Sources/S3Client/AWSS3Client.swift
@@ -77,6 +77,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
                 reporting: InvocationReportingType,
                 endpointHostName: String = "s3.amazonaws.com",
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "s3",
                 contentType: String = "application/x-amz-rest-xml",
                 target: String? = nil,
@@ -85,9 +86,10 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<S3ModelOperations>
                     = SmokeAWSClientReportingConfiguration<S3ModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(requiresTLS: useTLS)
 
-        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>(forEndpointPort: endpointPort)
+        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/S3Client/AWSS3Client.swift
+++ b/Sources/S3Client/AWSS3Client.swift
@@ -66,14 +66,14 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: S3OperationsReporting
     let invocationsReporting: S3InvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
                 reporting: InvocationReportingType,
                 endpointHostName: String = "s3.amazonaws.com",
                 endpointPort: Int = 443,
@@ -85,9 +85,9 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<S3ModelOperations>
                     = SmokeAWSClientReportingConfiguration<S3ModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(forEndpointPort: endpointPort)
 
-        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>(requiresTLS: credentialsProvider != nil)
+        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -112,7 +112,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
         self.invocationsReporting = S3InvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient, dataHttpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/S3Client/AWSS3ClientGenerator.swift
+++ b/Sources/S3Client/AWSS3ClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSS3ClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: S3OperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
                 endpointHostName: String = "s3.amazonaws.com",
                 endpointPort: Int = 443,
                 service: String = "s3",
@@ -65,9 +65,9 @@ public struct AWSS3ClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<S3ModelOperations>
                     = SmokeAWSClientReportingConfiguration<S3ModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>()
+        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(requiresTLS: credentialsProvider != nil)
 
-        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>()
+        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/S3Client/AWSS3ClientGenerator.swift
+++ b/Sources/S3Client/AWSS3ClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSS3ClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: S3OperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
                 endpointHostName: String = "s3.amazonaws.com",
                 endpointPort: Int = 443,
                 service: String = "s3",
@@ -65,9 +65,9 @@ public struct AWSS3ClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<S3ModelOperations>
                     = SmokeAWSClientReportingConfiguration<S3ModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(forEndpointPort: endpointPort)
 
-        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>(requiresTLS: credentialsProvider != nil)
+        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/S3Client/AWSS3ClientGenerator.swift
+++ b/Sources/S3Client/AWSS3ClientGenerator.swift
@@ -57,6 +57,7 @@ public struct AWSS3ClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
                 endpointHostName: String = "s3.amazonaws.com",
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "s3",
                 contentType: String = "application/x-amz-rest-xml",
                 target: String? = nil,
@@ -65,9 +66,10 @@ public struct AWSS3ClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<S3ModelOperations>
                     = SmokeAWSClientReportingConfiguration<S3ModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(requiresTLS: useTLS)
 
-        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>(forEndpointPort: endpointPort)
+        let clientDelegateForDataHttpClient = DataAWSHttpClientDelegate<S3Error>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
@@ -66,14 +66,14 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: SecurityTokenOperationsReporting
     let invocationsReporting: SecurityTokenInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
                 reporting: InvocationReportingType,
                 endpointHostName: String = "sts.amazonaws.com",
                 endpointPort: Int = 443,
@@ -85,7 +85,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>
                     = SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -105,7 +105,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
         self.invocationsReporting = SecurityTokenInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
@@ -77,6 +77,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
                 reporting: InvocationReportingType,
                 endpointHostName: String = "sts.amazonaws.com",
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "sts",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2011-06-15",
@@ -85,7 +86,8 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>
                     = SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
@@ -66,14 +66,14 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: SecurityTokenOperationsReporting
     let invocationsReporting: SecurityTokenInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
                 reporting: InvocationReportingType,
                 endpointHostName: String = "sts.amazonaws.com",
                 endpointPort: Int = 443,
@@ -85,7 +85,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>
                     = SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -105,7 +105,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
         self.invocationsReporting = SecurityTokenInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClientGenerator.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClientGenerator.swift
@@ -57,6 +57,7 @@ public struct AWSSecurityTokenClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
                 endpointHostName: String = "sts.amazonaws.com",
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "sts",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2011-06-15",
@@ -65,7 +66,8 @@ public struct AWSSecurityTokenClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>
                     = SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClientGenerator.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSSecurityTokenClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: SecurityTokenOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
                 endpointHostName: String = "sts.amazonaws.com",
                 endpointPort: Int = 443,
                 service: String = "sts",
@@ -65,7 +65,7 @@ public struct AWSSecurityTokenClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>
                     = SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClientGenerator.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSSecurityTokenClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: SecurityTokenOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion? = nil,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion? = nil,
                 endpointHostName: String = "sts.amazonaws.com",
                 endpointPort: Int = 443,
                 service: String = "sts",
@@ -65,7 +65,7 @@ public struct AWSSecurityTokenClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>
                     = SmokeAWSClientReportingConfiguration<SecurityTokenModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
@@ -71,14 +71,14 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: SimpleNotificationOperationsReporting
     let invocationsReporting: SimpleNotificationInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -90,7 +90,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -110,7 +110,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
         self.invocationsReporting = SimpleNotificationInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
@@ -82,6 +82,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "sns",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2010-03-31",
@@ -90,7 +91,8 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
@@ -71,14 +71,14 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: SimpleNotificationOperationsReporting
     let invocationsReporting: SimpleNotificationInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -90,7 +90,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -110,7 +110,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
         self.invocationsReporting = SimpleNotificationInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClientGenerator.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSSimpleNotificationClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: SimpleNotificationOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "sns",
@@ -65,7 +65,7 @@ public struct AWSSimpleNotificationClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClientGenerator.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClientGenerator.swift
@@ -57,6 +57,7 @@ public struct AWSSimpleNotificationClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "sns",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2010-03-31",
@@ -65,7 +66,8 @@ public struct AWSSimpleNotificationClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClientGenerator.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClientGenerator.swift
@@ -50,11 +50,11 @@ public struct AWSSimpleNotificationClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: SimpleNotificationOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "sns",
@@ -65,7 +65,7 @@ public struct AWSSimpleNotificationClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
@@ -72,14 +72,14 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: SimpleQueueOperationsReporting
     let invocationsReporting: SimpleQueueInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -91,9 +91,9 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: credentialsProvider != nil)
 
-        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(
+        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: credentialsProvider != nil,
             outputMapDecodingStrategy: .collapseMapUsingTags(keyTag: "Key", valueTag: "Value"), 
             inputQueryMapDecodingStrategy: .separateQueryEntriesWith(keyTag: "Key", valueTag: "Value"))
 
@@ -121,7 +121,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
         self.invocationsReporting = SimpleQueueInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient, listHttpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
@@ -83,6 +83,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "sqs",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2012-11-05",
@@ -91,9 +92,10 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: useTLS)
 
-        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(forEndpointPort: endpointPort,
+        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: useTLS,
             outputMapDecodingStrategy: .collapseMapUsingTags(keyTag: "Key", valueTag: "Value"), 
             inputQueryMapDecodingStrategy: .separateQueryEntriesWith(keyTag: "Key", valueTag: "Value"))
 

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
@@ -72,14 +72,14 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: SimpleQueueOperationsReporting
     let invocationsReporting: SimpleQueueInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -91,9 +91,9 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(forEndpointPort: endpointPort)
 
-        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: credentialsProvider != nil,
+        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(forEndpointPort: endpointPort,
             outputMapDecodingStrategy: .collapseMapUsingTags(keyTag: "Key", valueTag: "Value"), 
             inputQueryMapDecodingStrategy: .separateQueryEntriesWith(keyTag: "Key", valueTag: "Value"))
 
@@ -121,7 +121,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
         self.invocationsReporting = SimpleQueueInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient, listHttpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClientGenerator.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClientGenerator.swift
@@ -51,11 +51,11 @@ public struct AWSSimpleQueueClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: SimpleQueueOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "sqs",
@@ -66,9 +66,9 @@ public struct AWSSimpleQueueClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: credentialsProvider != nil)
 
-        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(
+        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: credentialsProvider != nil,
             outputMapDecodingStrategy: .collapseMapUsingTags(keyTag: "Key", valueTag: "Value"), 
             inputQueryMapDecodingStrategy: .separateQueryEntriesWith(keyTag: "Key", valueTag: "Value"))
 

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClientGenerator.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClientGenerator.swift
@@ -58,6 +58,7 @@ public struct AWSSimpleQueueClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "sqs",
                 contentType: String = "application/octet-stream",
                 apiVersion: String = "2012-11-05",
@@ -66,9 +67,10 @@ public struct AWSSimpleQueueClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: useTLS)
 
-        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(forEndpointPort: endpointPort,
+        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: useTLS,
             outputMapDecodingStrategy: .collapseMapUsingTags(keyTag: "Key", valueTag: "Value"), 
             inputQueryMapDecodingStrategy: .separateQueryEntriesWith(keyTag: "Key", valueTag: "Value"))
 

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClientGenerator.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClientGenerator.swift
@@ -51,11 +51,11 @@ public struct AWSSimpleQueueClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: SimpleQueueOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "sqs",
@@ -66,9 +66,9 @@ public struct AWSSimpleQueueClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleQueueModelOperations>() ) {
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(forEndpointPort: endpointPort)
 
-        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: credentialsProvider != nil,
+        let clientDelegateForListHttpClient = XMLAWSHttpClientDelegate<SimpleQueueError>(forEndpointPort: endpointPort,
             outputMapDecodingStrategy: .collapseMapUsingTags(keyTag: "Key", valueTag: "Value"), 
             inputQueryMapDecodingStrategy: .separateQueryEntriesWith(keyTag: "Key", valueTag: "Value"))
 

--- a/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
+++ b/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
@@ -70,14 +70,14 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: SimpleWorkflowOperationsReporting
     let invocationsReporting: SimpleWorkflowInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -89,7 +89,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>()
+        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -108,7 +108,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
         self.invocationsReporting = SimpleWorkflowInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
+++ b/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
@@ -70,14 +70,14 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: SimpleWorkflowOperationsReporting
     let invocationsReporting: SimpleWorkflowInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -89,7 +89,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -108,7 +108,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
         self.invocationsReporting = SimpleWorkflowInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
+++ b/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
@@ -81,6 +81,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "swf",
                 contentType: String = "application/x-amz-json-1.0",
                 target: String? = "SimpleWorkflowService",
@@ -89,7 +90,8 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClientGenerator.swift
+++ b/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClientGenerator.swift
@@ -56,6 +56,7 @@ public struct AWSSimpleWorkflowClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "swf",
                 contentType: String = "application/x-amz-json-1.0",
                 target: String? = "SimpleWorkflowService",
@@ -64,7 +65,8 @@ public struct AWSSimpleWorkflowClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClientGenerator.swift
+++ b/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClientGenerator.swift
@@ -49,11 +49,11 @@ public struct AWSSimpleWorkflowClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: SimpleWorkflowOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "swf",
@@ -64,7 +64,7 @@ public struct AWSSimpleWorkflowClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClientGenerator.swift
+++ b/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClientGenerator.swift
@@ -49,11 +49,11 @@ public struct AWSSimpleWorkflowClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: SimpleWorkflowOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "swf",
@@ -64,7 +64,7 @@ public struct AWSSimpleWorkflowClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleWorkflowModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>()
+        let clientDelegate = JSONAWSHttpClientDelegate<SimpleWorkflowError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/SmokeAWSHttp/AWSClientInvocationDelegate.swift
+++ b/Sources/SmokeAWSHttp/AWSClientInvocationDelegate.swift
@@ -25,7 +25,7 @@ import SmokeHTTPClient
 public struct AWSClientInvocationDelegate : HTTPClientInvocationDelegate {
     public var specifyContentHeadersForZeroLengthBody: Bool
     
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     let awsRegion: AWSRegion
     let service: String
     let operation: String?
@@ -33,7 +33,7 @@ public struct AWSClientInvocationDelegate : HTTPClientInvocationDelegate {
     let isV4SignRequest: Bool
     let signAllHeaders: Bool
     
-    public init (credentialsProvider: CredentialsProvider,
+    public init (credentialsProvider: CredentialsProvider?,
                  awsRegion: AWSRegion,
                  service: String,
                  operation: String? = nil,
@@ -74,7 +74,12 @@ public struct AWSClientInvocationDelegate : HTTPClientInvocationDelegate {
     public func addClientSpecificHeaders<InvocationReportingType>(
             parameters: HTTPRequestParameters,
             invocationReporting: InvocationReportingType) -> [(String, String)] where InvocationReportingType : HTTPClientInvocationReporting {
-        let v4Signer = V4Signer(credentials: credentialsProvider.credentials, region: awsRegion,
+        // if there are no credentials, there are no headers to be added
+        guard let currentCredentialsProvider = credentialsProvider else {
+            return []
+        }
+        
+        let v4Signer = V4Signer(credentials: currentCredentialsProvider.credentials, region: awsRegion,
                                 service: service,
                                 signAllHeaders: signAllHeaders)
         var headers: [(String, String)]

--- a/Sources/SmokeAWSHttp/AWSClientInvocationDelegate.swift
+++ b/Sources/SmokeAWSHttp/AWSClientInvocationDelegate.swift
@@ -25,7 +25,7 @@ import SmokeHTTPClient
 public struct AWSClientInvocationDelegate : HTTPClientInvocationDelegate {
     public var specifyContentHeadersForZeroLengthBody: Bool
     
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     let awsRegion: AWSRegion
     let service: String
     let operation: String?
@@ -33,7 +33,7 @@ public struct AWSClientInvocationDelegate : HTTPClientInvocationDelegate {
     let isV4SignRequest: Bool
     let signAllHeaders: Bool
     
-    public init (credentialsProvider: CredentialsProvider?,
+    public init (credentialsProvider: CredentialsProvider,
                  awsRegion: AWSRegion,
                  service: String,
                  operation: String? = nil,
@@ -74,12 +74,7 @@ public struct AWSClientInvocationDelegate : HTTPClientInvocationDelegate {
     public func addClientSpecificHeaders<InvocationReportingType>(
             parameters: HTTPRequestParameters,
             invocationReporting: InvocationReportingType) -> [(String, String)] where InvocationReportingType : HTTPClientInvocationReporting {
-        // if there are no credentials, there are no headers to be added
-        guard let currentCredentialsProvider = credentialsProvider else {
-            return []
-        }
-        
-        let v4Signer = V4Signer(credentials: currentCredentialsProvider.credentials, region: awsRegion,
+        let v4Signer = V4Signer(credentials: credentialsProvider.credentials, region: awsRegion,
                                 service: service,
                                 signAllHeaders: signAllHeaders)
         var headers: [(String, String)]

--- a/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import NIOHTTP1
+import NIOSSL
 import SmokeHTTPClient
 import SmokeAWSCore
 import QueryCoding
@@ -36,9 +37,11 @@ enum DataAWSHttpClientDelegateError: Error {
  on the decoding a JSON error payload from the response body.
  */
 public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClientDelegate {
+    private let requiresTLS: Bool
     private let inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy?
     
-    public init(inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
+    public init(requiresTLS: Bool, inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
+        self.requiresTLS = requiresTLS
         self.inputQueryMapDecodingStrategy = inputQueryMapDecodingStrategy
     }
     
@@ -162,5 +165,13 @@ public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
         
         return try OutputType.compose(bodyDecodableProvider: bodyDecodableProvider,
                                       headersDecodableProvider: headersDecodableProvider)
+    }
+    
+    public func getTLSConfiguration() -> TLSConfiguration? {
+        if requiresTLS {
+            return getDefaultTLSConfiguration()
+        } else {
+            return nil
+        }
     }
 }

--- a/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
@@ -40,8 +40,8 @@ public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
     private let requiresTLS: Bool
     private let inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy?
     
-    public init(requiresTLS: Bool, inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
-        self.requiresTLS = requiresTLS
+    public init(forEndpointPort endpointPort: Int, inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
+        self.requiresTLS = (endpointPort % 1000 == 443)
         self.inputQueryMapDecodingStrategy = inputQueryMapDecodingStrategy
     }
     

--- a/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
@@ -40,8 +40,8 @@ public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
     private let requiresTLS: Bool
     private let inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy?
     
-    public init(forEndpointPort endpointPort: Int, inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
-        self.requiresTLS = (endpointPort % 1000 == 443)
+    public init(requiresTLS: Bool, inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
+        self.requiresTLS = requiresTLS
         self.inputQueryMapDecodingStrategy = inputQueryMapDecodingStrategy
     }
     

--- a/Sources/SmokeAWSHttp/HTTPClientDelegate+requiresTLS.swift
+++ b/Sources/SmokeAWSHttp/HTTPClientDelegate+requiresTLS.swift
@@ -1,0 +1,26 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClientDelegate+requiresTLS.swift
+//  SmokeAWSHttp
+//
+
+private let securePort = 443
+private let securePortModulo = 1000
+
+public struct AWSHTTPClientDelegate {
+    public static func requiresTLS(forEndpointPort endpointPort: Int) -> Bool {
+        // returns that TLS should be used for ports 443, 4443 etc
+        return (endpointPort % securePortModulo == securePort)
+    }
+}

--- a/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
@@ -35,8 +35,8 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
     private let requiresTLS: Bool
     private let inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy?
     
-    public init(forEndpointPort endpointPort: Int, inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
-        self.requiresTLS = (endpointPort % 1000 == 443)
+    public init(requiresTLS: Bool, inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
+        self.requiresTLS = requiresTLS
         self.inputQueryMapDecodingStrategy = inputQueryMapDecodingStrategy
     }
     

--- a/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import NIOHTTP1
+import NIOSSL
 import SmokeHTTPClient
 import SmokeAWSCore
 import QueryCoding
@@ -31,9 +32,11 @@ import Logging
  on the decoding a JSON error payload from the response body.
  */
 public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClientDelegate {
+    private let requiresTLS: Bool
     private let inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy?
     
-    public init(inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
+    public init(requiresTLS: Bool, inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
+        self.requiresTLS = requiresTLS
         self.inputQueryMapDecodingStrategy = inputQueryMapDecodingStrategy
     }
     
@@ -152,5 +155,13 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
         
         return try OutputType.compose(bodyDecodableProvider: bodyDecodableProvider,
                                       headersDecodableProvider: headersDecodableProvider)
+    }
+    
+    public func getTLSConfiguration() -> TLSConfiguration? {
+        if requiresTLS {
+            return getDefaultTLSConfiguration()
+        } else {
+            return nil
+        }
     }
 }

--- a/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
@@ -35,8 +35,8 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
     private let requiresTLS: Bool
     private let inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy?
     
-    public init(requiresTLS: Bool, inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
-        self.requiresTLS = requiresTLS
+    public init(forEndpointPort endpointPort: Int, inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy? = nil) {
+        self.requiresTLS = (endpointPort % 1000 == 443)
         self.inputQueryMapDecodingStrategy = inputQueryMapDecodingStrategy
     }
     

--- a/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
@@ -129,13 +129,13 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
     private let inputQueryKeyEncodingStrategy: QueryEncoder.KeyEncodingStrategy
     private let inputQueryKeyEncodeTransformStrategy: QueryEncoder.KeyEncodeTransformStrategy
     
-    public init(requiresTLS: Bool, inputBodyRootKey: String? = nil,
+    public init(forEndpointPort endpointPort: Int, inputBodyRootKey: String? = nil,
                 outputListDecodingStrategy: XMLDecoder.ListDecodingStrategy? = nil,
                 outputMapDecodingStrategy: XMLDecoder.MapDecodingStrategy? = nil,
                 inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy = .singleQueryEntry,
                 inputQueryKeyEncodingStrategy: QueryEncoder.KeyEncodingStrategy = .useAsShapeSeparator("."),
                 inputQueryKeyEncodeTransformStrategy: QueryEncoder.KeyEncodeTransformStrategy = .none) {
-        self.requiresTLS = requiresTLS
+        self.requiresTLS = (endpointPort % 1000 == 443)
         self.inputBodyRootKey = inputBodyRootKey
         self.outputListDecodingStrategy = outputListDecodingStrategy
         self.outputMapDecodingStrategy = outputMapDecodingStrategy

--- a/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
@@ -129,13 +129,13 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
     private let inputQueryKeyEncodingStrategy: QueryEncoder.KeyEncodingStrategy
     private let inputQueryKeyEncodeTransformStrategy: QueryEncoder.KeyEncodeTransformStrategy
     
-    public init(forEndpointPort endpointPort: Int, inputBodyRootKey: String? = nil,
+    public init(requiresTLS: Bool, inputBodyRootKey: String? = nil,
                 outputListDecodingStrategy: XMLDecoder.ListDecodingStrategy? = nil,
                 outputMapDecodingStrategy: XMLDecoder.MapDecodingStrategy? = nil,
                 inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy = .singleQueryEntry,
                 inputQueryKeyEncodingStrategy: QueryEncoder.KeyEncodingStrategy = .useAsShapeSeparator("."),
                 inputQueryKeyEncodeTransformStrategy: QueryEncoder.KeyEncodeTransformStrategy = .none) {
-        self.requiresTLS = (endpointPort % 1000 == 443)
+        self.requiresTLS = requiresTLS
         self.inputBodyRootKey = inputBodyRootKey
         self.outputListDecodingStrategy = outputListDecodingStrategy
         self.outputMapDecodingStrategy = outputMapDecodingStrategy

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
@@ -70,14 +70,14 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: StepFunctionsOperationsReporting
     let invocationsReporting: StepFunctionsInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -89,7 +89,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>
                     = SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>()
+        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -108,7 +108,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
         self.invocationsReporting = StepFunctionsInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
@@ -81,6 +81,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "states",
                 contentType: String = "application/x-amz-json-1.0",
                 target: String? = "AWSStepFunctions",
@@ -89,7 +90,8 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>
                     = SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
@@ -70,14 +70,14 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
 
     let operationsReporting: StepFunctionsOperationsReporting
     let invocationsReporting: StepFunctionsInvocationsReporting<InvocationReportingType>
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 endpointHostName: String,
                 endpointPort: Int = 443,
@@ -89,7 +89,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>
                     = SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,
@@ -108,7 +108,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
         self.invocationsReporting = StepFunctionsInvocationsReporting(reporting: reporting, operationsReporting: self.operationsReporting)
     }
     
-    internal init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    internal init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 reporting: InvocationReportingType,
                 httpClient: HTTPOperationsClient,
                 service: String,

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClientGenerator.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClientGenerator.swift
@@ -49,11 +49,11 @@ public struct AWSStepFunctionsClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider?
+    let credentialsProvider: CredentialsProvider
 
     let operationsReporting: StepFunctionsOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "states",
@@ -64,7 +64,7 @@ public struct AWSStepFunctionsClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>
                     = SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>(requiresTLS: credentialsProvider != nil)
+        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>(forEndpointPort: endpointPort)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClientGenerator.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClientGenerator.swift
@@ -49,11 +49,11 @@ public struct AWSStepFunctionsClientGenerator {
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
     let retryOnErrorProvider: (Swift.Error) -> Bool
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProvider?
 
     let operationsReporting: StepFunctionsOperationsReporting
     
-    public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
+    public init(credentialsProvider: CredentialsProvider?, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
                 service: String = "states",
@@ -64,7 +64,7 @@ public struct AWSStepFunctionsClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>
                     = SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>()
+        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>(requiresTLS: credentialsProvider != nil)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClientGenerator.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClientGenerator.swift
@@ -56,6 +56,7 @@ public struct AWSStepFunctionsClientGenerator {
     public init(credentialsProvider: CredentialsProvider, awsRegion: AWSRegion,
                 endpointHostName: String,
                 endpointPort: Int = 443,
+                requiresTLS: Bool? = nil,
                 service: String = "states",
                 contentType: String = "application/x-amz-json-1.0",
                 target: String? = "AWSStepFunctions",
@@ -64,7 +65,8 @@ public struct AWSStepFunctionsClientGenerator {
                 eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>
                     = SmokeAWSClientReportingConfiguration<StepFunctionsModelOperations>() ) {
-        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>(forEndpointPort: endpointPort)
+        let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
+        let clientDelegate = JSONAWSHttpClientDelegate<StepFunctionsError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(endpointHostName: endpointHostName,
                                                endpointPort: endpointPort,

--- a/Tests/ElasticComputeCloudClientTests/ElasticComputeCloudClientTests.swift
+++ b/Tests/ElasticComputeCloudClientTests/ElasticComputeCloudClientTests.swift
@@ -32,7 +32,7 @@ class ElasticComputeCloudClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<ElasticComputeCloudError>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,
@@ -66,7 +66,7 @@ class ElasticComputeCloudClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = DataAWSHttpClientDelegate<ElasticComputeCloudError>()
+        let clientDelegate = DataAWSHttpClientDelegate<ElasticComputeCloudError>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,

--- a/Tests/RDSClientTests/RDSClientTests.swift
+++ b/Tests/RDSClientTests/RDSClientTests.swift
@@ -29,7 +29,7 @@ class RDSClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<RDSError>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,
@@ -61,7 +61,7 @@ class RDSClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = DataAWSHttpClientDelegate<RDSError>()
+        let clientDelegate = DataAWSHttpClientDelegate<RDSError>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,

--- a/Tests/S3ClientTests/S3ClientTests.swift
+++ b/Tests/S3ClientTests/S3ClientTests.swift
@@ -93,7 +93,7 @@ class S3ClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>()
+        let clientDelegate = XMLAWSHttpClientDelegate<S3Error>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,
@@ -123,7 +123,7 @@ class S3ClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = DataAWSHttpClientDelegate<S3Error>()
+        let clientDelegate = DataAWSHttpClientDelegate<S3Error>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,
@@ -154,7 +154,7 @@ class S3ClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = DataAWSHttpClientDelegate<S3Error>()
+        let clientDelegate = DataAWSHttpClientDelegate<S3Error>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,

--- a/Tests/SecurityTokenClientTests/SecurityTokenClientTests.swift
+++ b/Tests/SecurityTokenClientTests/SecurityTokenClientTests.swift
@@ -30,7 +30,7 @@ class SecurityTokenClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<SecurityTokenError>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,

--- a/Tests/SimpleNotificationClientTests/SimpleNotificationClientTests.swift
+++ b/Tests/SimpleNotificationClientTests/SimpleNotificationClientTests.swift
@@ -30,7 +30,7 @@ class SimpleNotificationClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,
@@ -62,7 +62,7 @@ class SimpleNotificationClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = DataAWSHttpClientDelegate<SimpleNotificationError>()
+        let clientDelegate = DataAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,
@@ -92,7 +92,7 @@ class SimpleNotificationClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = DataAWSHttpClientDelegate<SimpleNotificationError>()
+        let clientDelegate = DataAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,

--- a/Tests/SimpleQueueClientTests/SimpleQueueClientTests.swift
+++ b/Tests/SimpleQueueClientTests/SimpleQueueClientTests.swift
@@ -32,7 +32,7 @@ class SimpleQueueClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>()
+        let clientDelegate = XMLAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,
@@ -66,7 +66,7 @@ class SimpleQueueClientTests: XCTestCase {
                                            headers: HTTPHeaders(), body: nil)
         let components = HTTPResponseComponents(headers: [],
                                                 body: errorResponse.data(using: .utf8)!)
-        let clientDelegate = DataAWSHttpClientDelegate<SimpleQueueError>()
+        let clientDelegate = DataAWSHttpClientDelegate<SimpleQueueError>(requiresTLS: true)
         let invocationReporting = StandardHTTPClientInvocationReporting(internalRequestId: "internalRequestId",
                                                                         traceContext: MockInvocationTraceContext())
         let error = try clientDelegate.getResponseError(response: response,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* By default will not use TLS unless the port is 443, 4443 (using the formula port % 1000 == 443). Provide an optional parameter that overrides this logic to explicitly specify if TLS should be used.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
