### PR TITLE
Add listEncodingStrategy for Cloudwatch client

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,21 +11,21 @@
         }
       },
       {
-        "package": "smoke-http",
+        "package": "Cryptor",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
+        "state": {
+          "branch": null,
+          "revision": "12d2bf3ec7207ec3cd004b9582f69ef5fae1da3b",
+          "version": "1.0.32"
+        }
+      },
+      {
+        "package": "SmokeHTTP",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
           "revision": "9a129aa70d660b1eca03b19f3910d9f7ac0d0444",
           "version": "2.1.0"
-        }
-      },
-      {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "d67ac68d09a95443303e9d6e37b34e7ba101d5f1",
-          "version": "1.0.1"
         }
       },
       {

--- a/Sources/CloudWatchClient/AWSCloudWatchClient.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClient.swift
@@ -93,7 +93,9 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>
                     = SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>() ) {
         let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
-        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: useTLS)
+        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: useTLS,
+            outputListDecodingStrategy: .collapseListUsingItemTag("member"), 
+            inputQueryListEncodingStrategy: .expandListWithIndexAndItemTag(itemTag: "member"))
 
         self.httpClient = HTTPOperationsClient(
             endpointHostName: endpointHostName,

--- a/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
@@ -67,7 +67,9 @@ public struct AWSCloudWatchClientGenerator {
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>
                     = SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>() ) {
         let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
-        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: useTLS)
+        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: useTLS,
+            outputListDecodingStrategy: .collapseListUsingItemTag("member"), 
+            inputQueryListEncodingStrategy: .expandListWithIndexAndItemTag(itemTag: "member"))
 
         self.httpClient = HTTPOperationsClient(
             endpointHostName: endpointHostName,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds the necessary list encoding & decoding strategies for the Cloudwatch client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
