### PR TITLE
Code generate with Go SDK v1.30.28 models.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,21 +11,21 @@
         }
       },
       {
-        "package": "Cryptor",
-        "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
-        "state": {
-          "branch": null,
-          "revision": "12d2bf3ec7207ec3cd004b9582f69ef5fae1da3b",
-          "version": "1.0.32"
-        }
-      },
-      {
-        "package": "SmokeHTTP",
+        "package": "smoke-http",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
           "revision": "9a129aa70d660b1eca03b19f3910d9f7ac0d0444",
           "version": "2.1.0"
+        }
+      },
+      {
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
+        "state": {
+          "branch": null,
+          "revision": "d67ac68d09a95443303e9d6e37b34e7ba101d5f1",
+          "version": "1.0.1"
         }
       },
       {

--- a/Sources/ElasticComputeCloudModel/ElasticComputeCloudModelDefaultInstances.swift
+++ b/Sources/ElasticComputeCloudModel/ElasticComputeCloudModelDefaultInstances.swift
@@ -2381,7 +2381,8 @@ public extension CreateLaunchTemplateResult {
      */
     static let __default: ElasticComputeCloudModel.CreateLaunchTemplateResult = {
         let defaultInstance = ElasticComputeCloudModel.CreateLaunchTemplateResult(
-            launchTemplate: nil)
+            launchTemplate: nil,
+            warning: nil)
 
         return defaultInstance
     }()
@@ -2411,7 +2412,8 @@ public extension CreateLaunchTemplateVersionResult {
      */
     static let __default: ElasticComputeCloudModel.CreateLaunchTemplateVersionResult = {
         let defaultInstance = ElasticComputeCloudModel.CreateLaunchTemplateVersionResult(
-            launchTemplateVersion: nil)
+            launchTemplateVersion: nil,
+            warning: nil)
 
         return defaultInstance
     }()
@@ -2452,6 +2454,7 @@ public extension CreateLocalGatewayRouteTableVpcAssociationRequest {
         let defaultInstance = ElasticComputeCloudModel.CreateLocalGatewayRouteTableVpcAssociationRequest(
             dryRun: nil,
             localGatewayRouteTableId: "value",
+            tagSpecifications: nil,
             vpcId: "value")
 
         return defaultInstance
@@ -17367,6 +17370,31 @@ public extension VCpuInfo {
             defaultVCpus: nil,
             validCores: nil,
             validThreadsPerCore: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ValidationError {
+    /**
+     Default instance of the ValidationError structure.
+     */
+    static let __default: ElasticComputeCloudModel.ValidationError = {
+        let defaultInstance = ElasticComputeCloudModel.ValidationError(
+            code: nil,
+            message: nil)
+
+        return defaultInstance
+    }()
+}
+
+public extension ValidationWarning {
+    /**
+     Default instance of the ValidationWarning structure.
+     */
+    static let __default: ElasticComputeCloudModel.ValidationWarning = {
+        let defaultInstance = ElasticComputeCloudModel.ValidationWarning(
+            errors: nil)
 
         return defaultInstance
     }()

--- a/Sources/ElasticComputeCloudModel/ElasticComputeCloudModelStructures.swift
+++ b/Sources/ElasticComputeCloudModel/ElasticComputeCloudModelStructures.swift
@@ -4086,17 +4086,22 @@ public struct CreateLaunchTemplateRequest: Codable, Equatable {
 
 public struct CreateLaunchTemplateResult: Codable, Equatable {
     public var launchTemplate: LaunchTemplate?
+    public var warning: ValidationWarning?
 
-    public init(launchTemplate: LaunchTemplate? = nil) {
+    public init(launchTemplate: LaunchTemplate? = nil,
+                warning: ValidationWarning? = nil) {
         self.launchTemplate = launchTemplate
+        self.warning = warning
     }
 
     enum CodingKeys: String, CodingKey {
         case launchTemplate
+        case warning
     }
 
     public func validate() throws {
         try launchTemplate?.validate()
+        try warning?.validate()
     }
 }
 
@@ -4144,17 +4149,22 @@ public struct CreateLaunchTemplateVersionRequest: Codable, Equatable {
 
 public struct CreateLaunchTemplateVersionResult: Codable, Equatable {
     public var launchTemplateVersion: LaunchTemplateVersion?
+    public var warning: ValidationWarning?
 
-    public init(launchTemplateVersion: LaunchTemplateVersion? = nil) {
+    public init(launchTemplateVersion: LaunchTemplateVersion? = nil,
+                warning: ValidationWarning? = nil) {
         self.launchTemplateVersion = launchTemplateVersion
+        self.warning = warning
     }
 
     enum CodingKeys: String, CodingKey {
         case launchTemplateVersion
+        case warning
     }
 
     public func validate() throws {
         try launchTemplateVersion?.validate()
+        try warning?.validate()
     }
 }
 
@@ -4204,19 +4214,23 @@ public struct CreateLocalGatewayRouteResult: Codable, Equatable {
 public struct CreateLocalGatewayRouteTableVpcAssociationRequest: Codable, Equatable {
     public var dryRun: Boolean?
     public var localGatewayRouteTableId: LocalGatewayRoutetableId
+    public var tagSpecifications: TagSpecificationList?
     public var vpcId: VpcId
 
     public init(dryRun: Boolean? = nil,
                 localGatewayRouteTableId: LocalGatewayRoutetableId,
+                tagSpecifications: TagSpecificationList? = nil,
                 vpcId: VpcId) {
         self.dryRun = dryRun
         self.localGatewayRouteTableId = localGatewayRouteTableId
+        self.tagSpecifications = tagSpecifications
         self.vpcId = vpcId
     }
 
     enum CodingKeys: String, CodingKey {
         case dryRun = "DryRun"
         case localGatewayRouteTableId = "LocalGatewayRouteTableId"
+        case tagSpecifications = "TagSpecification"
         case vpcId = "VpcId"
     }
 
@@ -30894,6 +30908,40 @@ public struct VCpuInfo: Codable, Equatable {
         case defaultVCpus
         case validCores
         case validThreadsPerCore
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ValidationError: Codable, Equatable {
+    public var code: String?
+    public var message: String?
+
+    public init(code: String? = nil,
+                message: String? = nil) {
+        self.code = code
+        self.message = message
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case code
+        case message
+    }
+
+    public func validate() throws {
+    }
+}
+
+public struct ValidationWarning: Codable, Equatable {
+    public var errors: ErrorSet?
+
+    public init(errors: ErrorSet? = nil) {
+        self.errors = errors
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case errors = "errorSet"
     }
 
     public func validate() throws {

--- a/Sources/ElasticComputeCloudModel/ElasticComputeCloudModelTypes.swift
+++ b/Sources/ElasticComputeCloudModel/ElasticComputeCloudModelTypes.swift
@@ -1579,6 +1579,11 @@ public enum EndDateType: String, Codable, CustomStringConvertible {
 public typealias EndpointSet = [ClientVpnEndpoint]
 
 /**
+ Type definition for the ErrorSet field.
+ */
+public typealias ErrorSet = [ValidationError]
+
+/**
  Enumeration restricting the values of the EventCode field.
  */
 public enum EventCode: String, Codable, CustomStringConvertible {
@@ -2757,6 +2762,15 @@ public enum InstanceType: String, Codable, CustomStringConvertible {
     case m5n8xlarge = "m5n.8xlarge"
     case m5nLarge = "m5n.large"
     case m5nXlarge = "m5n.xlarge"
+    case m6g12xlarge = "m6g.12xlarge"
+    case m6g16xlarge = "m6g.16xlarge"
+    case m6g2xlarge = "m6g.2xlarge"
+    case m6g4xlarge = "m6g.4xlarge"
+    case m6g8xlarge = "m6g.8xlarge"
+    case m6gLarge = "m6g.large"
+    case m6gMedium = "m6g.medium"
+    case m6gMetal = "m6g.metal"
+    case m6gXlarge = "m6g.xlarge"
     case p216xlarge = "p2.16xlarge"
     case p28xlarge = "p2.8xlarge"
     case p2Xlarge = "p2.xlarge"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Code generate with Go SDK v1.30.28 models.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
