### PR TITLE
Use http response code for fallback retry behaviour.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -113,7 +113,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.1.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.3.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -113,7 +113,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.1.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.3.0"),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
@@ -29,12 +29,12 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
+private extension SmokeHTTPClient.HTTPClientError {
     func isRetriable() -> Bool {
-        if let typedError = self as? CloudWatchError {
-            return typedError.isRetriable()
+        if let typedError = self.cause as? CloudWatchError, let isRetriable = typedError.isRetriable() {
+            return isRetriable
         } else {
-            return true
+            return self.isRetriableAccordingToCategory
         }
     }
 }
@@ -49,7 +49,7 @@ public struct AWSCloudWatchClientGenerator {
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: CloudWatchOperationsReporting

--- a/Sources/CloudformationClient/AWSCloudformationClient.swift
+++ b/Sources/CloudformationClient/AWSCloudformationClient.swift
@@ -39,20 +39,6 @@ public enum CloudformationClientError: Swift.Error {
     public static func asUnrecognizedError(error: Swift.Error) -> CloudformationError {
         return error.asUnrecognizedCloudformationError()
     }
-
-    func isRetriable() -> Bool {
-        return false
-    }
-}
-
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? CloudformationError {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
 }
 
 /**
@@ -66,7 +52,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
@@ -117,7 +103,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
                 httpClient: HTTPOperationsClient,
                 service: String,
                 apiVersion: String,
-                retryOnErrorProvider: @escaping (Swift.Error) -> Bool,
+                retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool,
                 retryConfiguration: HTTPClientRetryConfiguration,
                 operationsReporting: CloudformationOperationsReporting) {
         self.httpClient = httpClient

--- a/Sources/CloudformationClient/AWSCloudformationClientGenerator.swift
+++ b/Sources/CloudformationClient/AWSCloudformationClientGenerator.swift
@@ -29,16 +29,6 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? CloudformationError {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
-}
-
 /**
  AWS Client Generator for the Cloudformation service.
  */
@@ -49,7 +39,7 @@ public struct AWSCloudformationClientGenerator {
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: CloudformationOperationsReporting

--- a/Sources/DynamoDBClient/AWSDynamoDBClientGenerator.swift
+++ b/Sources/DynamoDBClient/AWSDynamoDBClientGenerator.swift
@@ -29,12 +29,12 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
+private extension SmokeHTTPClient.HTTPClientError {
     func isRetriable() -> Bool {
-        if let typedError = self as? DynamoDBError {
-            return typedError.isRetriable()
+        if let typedError = self.cause as? DynamoDBError, let isRetriable = typedError.isRetriable() {
+            return isRetriable
         } else {
-            return true
+            return self.isRetriableAccordingToCategory
         }
     }
 }
@@ -48,7 +48,7 @@ public struct AWSDynamoDBClientGenerator {
     let service: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: DynamoDBOperationsReporting

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
@@ -39,20 +39,6 @@ public enum ElasticComputeCloudClientError: Swift.Error {
     public static func asUnrecognizedError(error: Swift.Error) -> ElasticComputeCloudError {
         return error.asUnrecognizedElasticComputeCloudError()
     }
-
-    func isRetriable() -> Bool {
-        return false
-    }
-}
-
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? ElasticComputeCloudError {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
 }
 
 /**
@@ -66,7 +52,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
@@ -117,7 +103,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
                 httpClient: HTTPOperationsClient,
                 service: String,
                 apiVersion: String,
-                retryOnErrorProvider: @escaping (Swift.Error) -> Bool,
+                retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool,
                 retryConfiguration: HTTPClientRetryConfiguration,
                 operationsReporting: ElasticComputeCloudOperationsReporting) {
         self.httpClient = httpClient

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClientGenerator.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClientGenerator.swift
@@ -29,16 +29,6 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? ElasticComputeCloudError {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
-}
-
 /**
  AWS Client Generator for the ElasticComputeCloud service.
  */
@@ -49,7 +39,7 @@ public struct AWSElasticComputeCloudClientGenerator {
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: ElasticComputeCloudOperationsReporting

--- a/Sources/ElasticContainerClient/AWSElasticContainerClientGenerator.swift
+++ b/Sources/ElasticContainerClient/AWSElasticContainerClientGenerator.swift
@@ -29,12 +29,12 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
+private extension SmokeHTTPClient.HTTPClientError {
     func isRetriable() -> Bool {
-        if let typedError = self as? ElasticContainerError {
-            return typedError.isRetriable()
+        if let typedError = self.cause as? ElasticContainerError, let isRetriable = typedError.isRetriable() {
+            return isRetriable
         } else {
-            return true
+            return self.isRetriableAccordingToCategory
         }
     }
 }
@@ -48,7 +48,7 @@ public struct AWSElasticContainerClientGenerator {
     let service: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: ElasticContainerOperationsReporting

--- a/Sources/RDSClient/AWSRDSClient.swift
+++ b/Sources/RDSClient/AWSRDSClient.swift
@@ -39,20 +39,6 @@ public enum RDSClientError: Swift.Error {
     public static func asUnrecognizedError(error: Swift.Error) -> RDSError {
         return error.asUnrecognizedRDSError()
     }
-
-    func isRetriable() -> Bool {
-        return false
-    }
-}
-
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? RDSError {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
 }
 
 /**
@@ -66,7 +52,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
@@ -115,7 +101,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
                 httpClient: HTTPOperationsClient,
                 service: String,
                 apiVersion: String,
-                retryOnErrorProvider: @escaping (Swift.Error) -> Bool,
+                retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool,
                 retryConfiguration: HTTPClientRetryConfiguration,
                 operationsReporting: RDSOperationsReporting) {
         self.httpClient = httpClient

--- a/Sources/RDSClient/AWSRDSClientGenerator.swift
+++ b/Sources/RDSClient/AWSRDSClientGenerator.swift
@@ -29,16 +29,6 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? RDSError {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
-}
-
 /**
  AWS Client Generator for the RDS service.
  */
@@ -49,7 +39,7 @@ public struct AWSRDSClientGenerator {
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: RDSOperationsReporting

--- a/Sources/RDSDataClient/AWSRDSDataClient.swift
+++ b/Sources/RDSDataClient/AWSRDSDataClient.swift
@@ -39,20 +39,6 @@ public enum RDSDataClientError: Swift.Error {
     public static func asUnrecognizedError(error: Swift.Error) -> RDSDataError {
         return error.asUnrecognizedRDSDataError()
     }
-
-    func isRetriable() -> Bool {
-        return false
-    }
-}
-
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? RDSDataError {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
 }
 
 /**
@@ -65,7 +51,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
     let service: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
@@ -113,7 +99,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
                 httpClient: HTTPOperationsClient,
                 service: String,
                 target: String?,
-                retryOnErrorProvider: @escaping (Swift.Error) -> Bool,
+                retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool,
                 retryConfiguration: HTTPClientRetryConfiguration,
                 operationsReporting: RDSDataOperationsReporting) {
         self.httpClient = httpClient

--- a/Sources/RDSDataClient/AWSRDSDataClientGenerator.swift
+++ b/Sources/RDSDataClient/AWSRDSDataClientGenerator.swift
@@ -29,16 +29,6 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? RDSDataError {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
-}
-
 /**
  AWS Client Generator for the RDSData service.
  */
@@ -48,7 +38,7 @@ public struct AWSRDSDataClientGenerator {
     let service: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: RDSDataOperationsReporting

--- a/Sources/S3Client/AWSS3Client.swift
+++ b/Sources/S3Client/AWSS3Client.swift
@@ -39,20 +39,6 @@ public enum S3ClientError: Swift.Error {
     public static func asUnrecognizedError(error: Swift.Error) -> S3Error {
         return error.asUnrecognizedS3Error()
     }
-
-    func isRetriable() -> Bool {
-        return false
-    }
-}
-
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? S3Error {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
 }
 
 /**
@@ -66,7 +52,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
     let service: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
@@ -123,7 +109,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
                 httpClient: HTTPOperationsClient, dataHttpClient: HTTPOperationsClient,
                 service: String,
                 target: String?,
-                retryOnErrorProvider: @escaping (Swift.Error) -> Bool,
+                retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool,
                 retryConfiguration: HTTPClientRetryConfiguration,
                 operationsReporting: S3OperationsReporting) {
         self.httpClient = httpClient

--- a/Sources/S3Client/AWSS3ClientGenerator.swift
+++ b/Sources/S3Client/AWSS3ClientGenerator.swift
@@ -29,16 +29,6 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? S3Error {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
-}
-
 /**
  AWS Client Generator for the S3 service.
  */
@@ -49,7 +39,7 @@ public struct AWSS3ClientGenerator {
     let service: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: S3OperationsReporting

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
@@ -39,20 +39,6 @@ public enum SecurityTokenClientError: Swift.Error {
     public static func asUnrecognizedError(error: Swift.Error) -> SecurityTokenError {
         return error.asUnrecognizedSecurityTokenError()
     }
-
-    func isRetriable() -> Bool {
-        return false
-    }
-}
-
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? SecurityTokenError {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
 }
 
 /**
@@ -66,7 +52,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
@@ -115,7 +101,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
                 httpClient: HTTPOperationsClient,
                 service: String,
                 apiVersion: String,
-                retryOnErrorProvider: @escaping (Swift.Error) -> Bool,
+                retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool,
                 retryConfiguration: HTTPClientRetryConfiguration,
                 operationsReporting: SecurityTokenOperationsReporting) {
         self.httpClient = httpClient

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClientGenerator.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClientGenerator.swift
@@ -29,16 +29,6 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
-    func isRetriable() -> Bool {
-        if let typedError = self as? SecurityTokenError {
-            return typedError.isRetriable()
-        } else {
-            return true
-        }
-    }
-}
-
 /**
  AWS Client Generator for the SecurityToken service.
  */
@@ -49,7 +39,7 @@ public struct AWSSecurityTokenClientGenerator {
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: SecurityTokenOperationsReporting

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClientGenerator.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClientGenerator.swift
@@ -29,12 +29,12 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
+private extension SmokeHTTPClient.HTTPClientError {
     func isRetriable() -> Bool {
-        if let typedError = self as? SimpleNotificationError {
-            return typedError.isRetriable()
+        if let typedError = self.cause as? SimpleNotificationError, let isRetriable = typedError.isRetriable() {
+            return isRetriable
         } else {
-            return true
+            return self.isRetriableAccordingToCategory
         }
     }
 }
@@ -49,7 +49,7 @@ public struct AWSSimpleNotificationClientGenerator {
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: SimpleNotificationOperationsReporting

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
@@ -40,22 +40,22 @@ public enum SimpleQueueClientError: Swift.Error {
         return error.asUnrecognizedSimpleQueueError()
     }
 
-    func isRetriable() -> Bool {
+    func isRetriable() -> Bool? {
         switch self {
         case .overLimit:
             return true
         default:
-            return false
+            return nil
         }
     }
 }
 
-private extension Swift.Error {
+private extension SmokeHTTPClient.HTTPClientError {
     func isRetriable() -> Bool {
-        if let typedError = self as? SimpleQueueError {
-            return typedError.isRetriable()
+        if let typedError = self.cause as? SimpleQueueError, let isRetriable = typedError.isRetriable() {
+            return isRetriable
         } else {
-            return true
+            return self.isRetriableAccordingToCategory
         }
     }
 }
@@ -72,7 +72,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
@@ -132,7 +132,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
                 httpClient: HTTPOperationsClient, listHttpClient: HTTPOperationsClient,
                 service: String,
                 apiVersion: String,
-                retryOnErrorProvider: @escaping (Swift.Error) -> Bool,
+                retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool,
                 retryConfiguration: HTTPClientRetryConfiguration,
                 operationsReporting: SimpleQueueOperationsReporting) {
         self.httpClient = httpClient

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClientGenerator.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClientGenerator.swift
@@ -29,12 +29,12 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
+private extension SmokeHTTPClient.HTTPClientError {
     func isRetriable() -> Bool {
-        if let typedError = self as? SimpleQueueError {
-            return typedError.isRetriable()
+        if let typedError = self.cause as? SimpleQueueError, let isRetriable = typedError.isRetriable() {
+            return isRetriable
         } else {
-            return true
+            return self.isRetriableAccordingToCategory
         }
     }
 }
@@ -50,7 +50,7 @@ public struct AWSSimpleQueueClientGenerator {
     let apiVersion: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: SimpleQueueOperationsReporting

--- a/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClientGenerator.swift
+++ b/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClientGenerator.swift
@@ -29,12 +29,12 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
+private extension SmokeHTTPClient.HTTPClientError {
     func isRetriable() -> Bool {
-        if let typedError = self as? SimpleWorkflowError {
-            return typedError.isRetriable()
+        if let typedError = self.cause as? SimpleWorkflowError, let isRetriable = typedError.isRetriable() {
+            return isRetriable
         } else {
-            return true
+            return self.isRetriableAccordingToCategory
         }
     }
 }
@@ -48,7 +48,7 @@ public struct AWSSimpleWorkflowClientGenerator {
     let service: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: SimpleWorkflowOperationsReporting

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
@@ -40,22 +40,22 @@ public enum StepFunctionsClientError: Swift.Error {
         return error.asUnrecognizedStepFunctionsError()
     }
 
-    func isRetriable() -> Bool {
+    func isRetriable() -> Bool? {
         switch self {
         case .activityLimitExceeded, .activityWorkerLimitExceeded, .executionLimitExceeded, .stateMachineLimitExceeded:
             return true
         default:
-            return false
+            return nil
         }
     }
 }
 
-private extension Swift.Error {
+private extension SmokeHTTPClient.HTTPClientError {
     func isRetriable() -> Bool {
-        if let typedError = self as? StepFunctionsError {
-            return typedError.isRetriable()
+        if let typedError = self.cause as? StepFunctionsError, let isRetriable = typedError.isRetriable() {
+            return isRetriable
         } else {
-            return true
+            return self.isRetriableAccordingToCategory
         }
     }
 }
@@ -70,7 +70,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
     let service: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
     
     public let reporting: InvocationReportingType
@@ -118,7 +118,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
                 httpClient: HTTPOperationsClient,
                 service: String,
                 target: String?,
-                retryOnErrorProvider: @escaping (Swift.Error) -> Bool,
+                retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool,
                 retryConfiguration: HTTPClientRetryConfiguration,
                 operationsReporting: StepFunctionsOperationsReporting) {
         self.httpClient = httpClient

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClientGenerator.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClientGenerator.swift
@@ -29,12 +29,12 @@ import NIOHTTP1
 import AsyncHTTPClient
 import Logging
 
-private extension Swift.Error {
+private extension SmokeHTTPClient.HTTPClientError {
     func isRetriable() -> Bool {
-        if let typedError = self as? StepFunctionsError {
-            return typedError.isRetriable()
+        if let typedError = self.cause as? StepFunctionsError, let isRetriable = typedError.isRetriable() {
+            return isRetriable
         } else {
-            return true
+            return self.isRetriableAccordingToCategory
         }
     }
 }
@@ -48,7 +48,7 @@ public struct AWSStepFunctionsClientGenerator {
     let service: String
     let target: String?
     let retryConfiguration: HTTPClientRetryConfiguration
-    let retryOnErrorProvider: (Swift.Error) -> Bool
+    let retryOnErrorProvider: (SmokeHTTPClient.HTTPClientError) -> Bool
     let credentialsProvider: CredentialsProvider
 
     let operationsReporting: StepFunctionsOperationsReporting


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Fix an error were the error type check was being performed on the HTTPClientError instance (and failing) rather that the client error cause. This was causing requests to be retried in error.
2. Change the fallback retry behaviour to depend on the http response code - 400s are not retried, other errors are retried.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
