### PR TITLE
Add swift-metrics implementation for CloudWatch.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "eb6f99ba41ca10d7e44d4137c79ce8e2f472035c",
-          "version": "2.4.0"
+          "revision": "6619fe6f8e56a85d9a7d9481c27afb2dc5688459",
+          "version": "2.7.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "8f4bfa5bc1951440c15710e9e893721aa4b2765c",
-          "version": "1.1.3"
+          "revision": "296d3308b4b2fa355cfe0de4ca411bf7a1cd8cf8",
+          "version": "1.1.4"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-log",
         "state": {
           "branch": null,
-          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
-          "version": "1.4.0"
+          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
+          "version": "1.4.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "43931b7a7daf8120a487601530c8bc03ce711992",
-          "version": "2.25.1"
+          "revision": "6d3ca7e54e06a69d0f2612c2ce8bb8b7319085a4",
+          "version": "2.26.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "e5b5d191a80667a14827bfeb0ae4a511f7677942",
-          "version": "1.7.0"
+          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
+          "version": "1.8.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "62bf5083df970e67c886210fa5b857eacf044b7c",
-          "version": "2.10.2"
+          "revision": "4c933e955b8797f5a5a90bd2a0fb411fdb11bb94",
+          "version": "2.10.3"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "5a352330c09a323e59ebd99afdf4ca3964c217bc",
-          "version": "1.9.1"
+          "revision": "1d28d48e071727f4558a8a4bb1894472abc47a58",
+          "version": "1.9.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -106,6 +106,9 @@ let package = Package(
         .library(
             name: "SmokeAWSHttp",
             targets: ["SmokeAWSHttp"]),
+        .library(
+            name: "SmokeAWSMetrics",
+            targets: ["SmokeAWSMetrics"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
@@ -113,7 +116,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.4.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.7.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [
@@ -252,6 +255,12 @@ let package = Package(
                 .product(name: "HTTPPathCoding", package: "smoke-http"),
                 .product(name: "HTTPHeadersCoding", package: "smoke-http"),
                 .product(name: "Crypto", package: "swift-crypto"),
+            ]),
+        .target(
+            name: "SmokeAWSMetrics", dependencies: [
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Metrics", package: "swift-metrics"),
+                .target(name: "CloudWatchClient"),
             ]),
         .testTarget(
             name: "S3ClientTests", dependencies: [

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -106,6 +106,9 @@ let package = Package(
         .library(
             name: "SmokeAWSHttp",
             targets: ["SmokeAWSHttp"]),
+        .library(
+            name: "SmokeAWSMetrics",
+            targets: ["SmokeAWSMetrics"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
@@ -113,7 +116,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.4.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.7.0"),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
     ],
     targets: [
@@ -203,6 +206,9 @@ let package = Package(
             dependencies: ["Logging", "NIO", "NIOHTTP1",
                            "SmokeAWSCore", "SmokeHTTPClient", "QueryCoding",
                            "HTTPPathCoding", "HTTPHeadersCoding", "Cryptor"]),
+        .target(
+            name: "SmokeAWSMetrics",
+            dependencies: ["Logging", "Metrics", "CloudWatchClient"]),
         .testTarget(
             name: "S3ClientTests",
             dependencies: ["S3Client"]),

--- a/Sources/SmokeAWSCore/SmokeAWSClientReportingConfiguration.swift
+++ b/Sources/SmokeAWSCore/SmokeAWSClientReportingConfiguration.swift
@@ -52,6 +52,14 @@ public struct SmokeAWSClientReportingConfiguration<OperationIdentifer: Hashable>
         self.latencyTimerMatchingOperations = matchingOperations
     }
     
+    public static var none: Self {
+        return .init(matchingOperations: .none)
+    }
+    
+    public static var all: Self {
+        return .init(matchingOperations: .all)
+    }
+    
     public func reportSuccessForOperation(_ operation: OperationIdentifer) -> Bool {
         return isMatchingOperation(operation, matchingOperations: successCounterMatchingOperations)
     }

--- a/Sources/SmokeAWSHttp/SmokeAWSHTTPClientInvocationReporting.swift
+++ b/Sources/SmokeAWSHttp/SmokeAWSHTTPClientInvocationReporting.swift
@@ -42,6 +42,10 @@ public struct SmokeAWSHTTPClientInvocationReporting<InvocationReportingType: HTT
         return smokeAWSInvocationReporting.eventLoop
     }
     
+    public var outwardsRequestAggregator: OutwardsRequestAggregator? {
+        return smokeAWSInvocationReporting.outwardsRequestAggregator
+    }
+    
     public var internalRequestId: String {
         return smokeAWSInvocationReporting.internalRequestId
     }

--- a/Sources/SmokeAWSMetrics/CloudWatchCounterHandler.swift
+++ b/Sources/SmokeAWSMetrics/CloudWatchCounterHandler.swift
@@ -1,0 +1,67 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  CloudWatchCounterHandler.swift
+//  SmokeAWSMetrics
+//
+
+import Metrics
+import CloudWatchClient
+import CloudWatchModel
+import Logging
+/**
+ Class conforming to `CounterHandler` that emits a CloudWatch metric.
+ */
+public class CloudWatchCounterHandler: CounterHandler {
+    private let cloudWatchClient: CloudWatchClientProtocol
+    private let metricName: String
+    private let namespace: String
+    private let dimensions: [Dimension]?
+    private let logger: Logger
+    
+    public init(cloudWatchClient: CloudWatchClientProtocol,
+                metricName: String,
+                namespace: String,
+                dimensions: [Dimension]?,
+                logger: Logger) {
+        self.cloudWatchClient = cloudWatchClient
+        self.metricName = metricName
+        self.namespace = namespace
+        self.dimensions = dimensions
+        self.logger = logger
+    }
+    
+    public func increment(by increment: Int64) {
+        let metricData = MetricDatum(dimensions: self.dimensions,
+                                     metricName: self.metricName,
+                                     unit: .count,
+                                     value: Double(increment))
+        let input = PutMetricDataInput(metricData: [metricData],
+                                       namespace: self.namespace)
+        do {
+            try self.cloudWatchClient.putMetricDataAsync(input: input, completion: { error in
+                if let error = error {
+                    self.logger.error("Unable to submit metric \(self.metricName) to CloudWatch: \(String(describing: error))")
+                }
+            })
+        } catch {
+            self.logger.error("Unable to submit metric \(self.metricName) to CloudWatch: \(String(describing: error))")
+        }
+    }
+    
+    public func reset() {
+        self.logger.warning("Attempting to reset metric \(self.metricName) which is not supported.")
+    }
+    
+    
+}

--- a/Sources/SmokeAWSMetrics/CloudWatchMetricsFactory.swift
+++ b/Sources/SmokeAWSMetrics/CloudWatchMetricsFactory.swift
@@ -1,0 +1,120 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  CloudWatchMetricsFactory.swift
+//  SmokeAWSMetrics
+//
+
+import Metrics
+import CloudWatchClient
+import CloudWatchModel
+import Logging
+
+/**
+ Class conforming to `MetricsFactory` that emits CloudWatch metrics.
+ */
+public class CloudWatchMetricsFactory: MetricsFactory {
+    private let cloudWatchClient: CloudWatchClientProtocol
+    private let logger: Logger
+    private let namespaceDimension = "Namespace"
+    private let operationNameDimension = "Operation Name"
+    private let metricNameDimension = "Metric Name"
+    
+    private let unknownMetricName = "Unknown Metric"
+    private let unknownNamespace = "Unknown Namespace"
+    
+    public init(cloudWatchClient: CloudWatchClientProtocol,
+                logger: Logger?) {
+        self.cloudWatchClient = cloudWatchClient
+        
+        if let logger = logger {
+            self.logger = logger
+        } else {
+            self.logger = Self.logger
+        }
+    }
+    
+    public static var logger: Logger {
+        var newLogger = Logger(label: "com.amazon.SmokeAWS.SmokeAWSMetrics.CloudWatchMetricsFactory")
+        newLogger[metadataKey: "lifecycle"] = "CloudWatchMetricsFactory"
+        
+        return newLogger
+    }
+    
+    public func makeCounter(label: String, dimensions: [(String, String)]) -> CounterHandler {
+        let (metricName, namespace, cloudWatchDimensions) = getAttributes(dimensions: dimensions)
+        
+        return CloudWatchCounterHandler(cloudWatchClient: self.cloudWatchClient, metricName: metricName,
+                                        namespace: namespace, dimensions: cloudWatchDimensions, logger: self.logger)
+    }
+    
+    public func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> RecorderHandler {
+        let (metricName, namespace, cloudWatchDimensions) = getAttributes(dimensions: dimensions)
+        
+        return CloudWatchRecorderHandler(cloudWatchClient: self.cloudWatchClient, metricName: metricName,
+                                         namespace: namespace, dimensions: cloudWatchDimensions, logger: self.logger)
+    }
+    
+    public func makeTimer(label: String, dimensions: [(String, String)]) -> TimerHandler {
+        let (metricName, namespace, cloudWatchDimensions) = getAttributes(dimensions: dimensions)
+        
+        return CloudWatchTimerHandler(cloudWatchClient: self.cloudWatchClient, metricName: metricName,
+                                      namespace: namespace, dimensions: cloudWatchDimensions, logger: self.logger)
+    }
+    
+    public func destroyCounter(_ handler: CounterHandler) {
+        // nothing to do
+    }
+    
+    public func destroyRecorder(_ handler: RecorderHandler) {
+        // nothing to do
+    }
+    
+    public func destroyTimer(_ handler: TimerHandler) {
+        // nothing to do
+    }
+    
+    private func getAttributes(dimensions: [(String, String)]) -> (metricName: String, namespace: String, cloudWatchDimensions: [Dimension]?) {
+        var dimensionsMap: [String: String] = [:]
+        dimensions.forEach { (key, value) in
+            dimensionsMap[key] = value
+        }
+        
+        let metricName: String
+        if let theMetricName = dimensionsMap[metricNameDimension] {
+            metricName = theMetricName
+            
+            // don't include this in the cloudWatchDimensions
+            dimensionsMap[metricNameDimension] = nil
+        } else {
+            metricName = unknownMetricName
+        }
+        
+        let namespace: String
+        if let theNamespace = dimensionsMap[namespaceDimension] {
+            namespace = theNamespace
+            
+            // don't include this in the cloudWatchDimensions
+            dimensionsMap[metricNameDimension] = nil
+        } else {
+            namespace = unknownNamespace
+        }
+        
+        
+        let cloudWatchDimensions = dimensionsMap.map { (key, value) in
+            return Dimension(name: key, value: value)
+        }
+        
+        return (metricName, namespace, !cloudWatchDimensions.isEmpty ? cloudWatchDimensions : nil)
+    }
+}

--- a/Sources/SmokeAWSMetrics/CloudWatchRecorderHandler.swift
+++ b/Sources/SmokeAWSMetrics/CloudWatchRecorderHandler.swift
@@ -1,0 +1,70 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  CloudWatchRecorderHandler.swift
+//  SmokeAWSMetrics
+//
+
+import Metrics
+import CloudWatchClient
+import CloudWatchModel
+import Logging
+/**
+ Class conforming to `RecorderHandler` that emits a CloudWatch metric.
+ */
+public class CloudWatchRecorderHandler: RecorderHandler {
+    private let cloudWatchClient: CloudWatchClientProtocol
+    private let metricName: String
+    private let namespace: String
+    private let dimensions: [Dimension]?
+    private let logger: Logger
+    
+    public init(cloudWatchClient: CloudWatchClientProtocol,
+                metricName: String,
+                namespace: String,
+                dimensions: [Dimension]?,
+                logger: Logger) {
+        self.cloudWatchClient = cloudWatchClient
+        self.metricName = metricName
+        self.namespace = namespace
+        self.dimensions = dimensions
+        self.logger = logger
+    }
+    
+    public func record(_ value: Int64) {
+        record(Double(value))
+    }
+    
+    public func record(_ value: Double) {
+        let metricData = MetricDatum(dimensions: self.dimensions,
+                                     metricName: self.metricName,
+                                     value: value)
+        let input = PutMetricDataInput(metricData: [metricData],
+                                       namespace: self.namespace)
+        do {
+            try self.cloudWatchClient.putMetricDataAsync(input: input, completion: { error in
+                if let error = error {
+                    self.logger.error("Unable to submit metric \(self.metricName) to CloudWatch: \(String(describing: error))")
+                }
+            })
+        } catch {
+            self.logger.error("Unable to submit metric \(self.metricName) to CloudWatch: \(String(describing: error))")
+        }
+    }
+    
+    public func reset() {
+        self.logger.warning("Attempting to reset metric \(self.metricName) which is not supported.")
+    }
+    
+    
+}

--- a/Sources/SmokeAWSMetrics/CloudWatchTimerHandler.swift
+++ b/Sources/SmokeAWSMetrics/CloudWatchTimerHandler.swift
@@ -1,0 +1,72 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  CloudWatchCounterHandler.swift
+//  SmokeAWSMetrics
+//
+
+import Metrics
+import CloudWatchClient
+import CloudWatchModel
+import Logging
+
+private let microToNanoSecondsFactor: Int64 = 1000
+
+/**
+ Class conforming to `TimerHandler` that emits a CloudWatch metric.
+ */
+public class CloudWatchTimerHandler: TimerHandler {
+    private let cloudWatchClient: CloudWatchClientProtocol
+    private let metricName: String
+    private let namespace: String
+    private let dimensions: [Dimension]?
+    private let logger: Logger
+    
+    public init(cloudWatchClient: CloudWatchClientProtocol,
+                metricName: String,
+                namespace: String,
+                dimensions: [Dimension]?,
+                logger: Logger) {
+        self.cloudWatchClient = cloudWatchClient
+        self.metricName = metricName
+        self.namespace = namespace
+        self.dimensions = dimensions
+        self.logger = logger
+    }
+    
+    public func recordNanoseconds(_ duration: Int64) {
+        let microseconds = duration / microToNanoSecondsFactor
+        
+        let metricData = MetricDatum(dimensions: self.dimensions,
+                                     metricName: self.metricName,
+                                     unit: .microseconds,
+                                     value: Double(microseconds))
+        let input = PutMetricDataInput(metricData: [metricData],
+                                       namespace: self.namespace)
+        do {
+            try self.cloudWatchClient.putMetricDataAsync(input: input, completion: { error in
+                if let error = error {
+                    self.logger.error("Unable to submit metric \(self.metricName) to CloudWatch: \(String(describing: error))")
+                }
+            })
+        } catch {
+            self.logger.error("Unable to submit metric \(self.metricName) to CloudWatch: \(String(describing: error))")
+        }
+    }
+    
+    public func reset() {
+        self.logger.warning("Attempting to reset metric \(self.metricName) which is not supported.")
+    }
+    
+    
+}


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

1. Add swift-metrics implementation for CloudWatch. 
2. Support aggregating info about output requests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
