### PR TITLE
Use a queue to submit metrics to CloudWatch at regular intervals.

### DIFF
--- a/Sources/SmokeAWSMetrics/CloudWatchPendingMetricsQueue.swift
+++ b/Sources/SmokeAWSMetrics/CloudWatchPendingMetricsQueue.swift
@@ -1,0 +1,285 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  CloudWatchPendingMetricsQueue.swift
+//  SmokeAWSMetrics
+//
+
+import Foundation
+import CloudWatchClient
+import CloudWatchModel
+import Logging
+
+private func iso8601DateFormatter() -> DateFormatter {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .iso8601)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+    return formatter
+}
+
+internal extension Date {
+    var iso8601: String {
+        return iso8601DateFormatter().string(from: self)
+    }
+}
+
+internal enum CloudWatchPendingMetricsQueueError: Error {
+    case shutdownAttemptOnUnstartedQueue
+}
+
+private struct Entry {
+    let namespace: String
+    let data: MetricDatum
+}
+
+internal class CloudWatchPendingMetricsQueue {
+    private var pendingEntries: [Entry]
+    private let logger: Logger
+    private let cloudWatchClient: CloudWatchClientProtocol
+    private let shutdownDispatchGroup: DispatchGroup
+    
+    private let accessQueue = DispatchQueue(label: "com.amazon.SmokeAWSMetrics.CloudWatchPendingMetricsQueue.accessQueue")
+    private let queueConsumingTaskIntervalInSeconds = 2
+    private let maximumDataumsPerRequest = 100
+    
+    enum State {
+        case initialized
+        case running
+        case shuttingDown
+        case shutDown
+    }
+    private var state: State = .initialized
+    private var stateLock: NSLock = NSLock()
+    
+    init(cloudWatchClient: CloudWatchClientProtocol, logger: Logger) {
+        self.pendingEntries = []
+        self.cloudWatchClient = cloudWatchClient
+        self.logger = logger
+        
+        self.shutdownDispatchGroup = DispatchGroup()
+        // enter the DispatchGroup during initialization so waiting for the
+        // shutdown of an initalized or started queue will wait
+        shutdownDispatchGroup.enter()
+    }
+    
+    /**
+     Starts the submission queue.
+     */
+    func start() throws {
+        guard updateOnStart() else {
+            // nothing to do; already started
+            return
+        }
+        
+        submitQueueConsumingTask()
+        
+        self.logger.info("CloudWatchPendingMetricsQueue started.")
+    }
+    
+    /**
+     Initiates the process of shutting down the queue.
+     */
+    func shutdown() throws {
+        _ = try updateOnShutdownStart()
+    }
+    
+    /**
+     Blocks until the queue has been shutdown.
+     */
+    func waitUntilShutdown() throws {
+        if !isShutdown() {
+            shutdownDispatchGroup.wait()
+        }
+    }
+    
+    func submit(namespace: String, data: MetricDatum) {
+        let entry = Entry(namespace: namespace, data: data)
+        
+        self.accessQueue.async {
+            self.pendingEntries.append(entry)
+        }
+    }
+    
+    
+    private func submitQueueConsumingTask() {
+        let deadline = DispatchTime.now() + .seconds(queueConsumingTaskIntervalInSeconds)
+        
+        let newWorker = { [unowned self] in
+            let isQueueShuttingDown = self.isShuttingDown()
+            
+            // if another queue consuming task should be scheduled
+            if !isQueueShuttingDown {
+                self.submitQueueConsumingTask()
+            }
+            
+            let currentPendingEntries = self.pendingEntries
+            self.pendingEntries = []
+            
+            if !currentPendingEntries.isEmpty {
+                // transform the list of pending entries into a map keyed by namespace
+                var namespacedEntryMap: [String: [MetricDatum]] = [:]
+                currentPendingEntries.forEach { entry in
+                    if var dataList = namespacedEntryMap[entry.namespace] {
+                        dataList.append(entry.data)
+                        namespacedEntryMap[entry.namespace] = dataList
+                    } else {
+                        namespacedEntryMap[entry.namespace] = [entry.data]
+                    }
+                }
+                
+                // for each namespace, kick off calls to CloudWatch
+                namespacedEntryMap.forEach { (namespace, dataList) in
+                    let chunkedList = dataList.chunked(by: self.maximumDataumsPerRequest)
+                    
+                    chunkedList.forEach { dataListChunk in
+                        let input = PutMetricDataInput(metricData: dataListChunk, namespace: namespace)
+                        do {
+                            try self.cloudWatchClient.putMetricDataAsync(input: input, completion: { error in
+                                if let error = error {
+                                    self.logger.error("Unable to submit metrics to CloudWatch: \(String(describing: error))")
+                                }
+                            })
+                        } catch {
+                            self.logger.error("Unable to submit metrics to CloudWatch: \(String(describing: error))")
+                        }
+                    }
+                }
+            }
+            
+            // shutdown the queue if required
+            if isQueueShuttingDown {
+                self.updateStateOnShutdownComplete()
+                
+                // release any waiters for shutdown
+                self.shutdownDispatchGroup.leave()
+            }
+            
+        }
+        
+        self.accessQueue.asyncAfter(deadline: deadline, qos: .unspecified,
+                                            flags: [], execute: newWorker)
+    }
+    
+    
+    
+    /**
+     Updates the Lifecycle state on a start request.
+
+     - Returns: if the start request should be acted upon (and the queue started).
+                Will be false if the queue is already running, shutting down or has completed shutting down.
+     */
+    private func updateOnStart() -> Bool {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        if case .initialized = state {
+            state = .running
+            
+            return true
+        }
+        
+        return false
+    }
+    
+    /**
+     Updates the Lifecycle state on a shutdown request.
+
+     - Returns: if the shutdown request should be acted upon (and the queue shutdown).
+                Will be false if the queue is already shutting down or has completed shutting down.
+     - Throws: if the queue has never been started.
+     */
+    private func updateOnShutdownStart() throws -> Bool {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        let doShutdownServer: Bool
+        switch state {
+        case .initialized:
+            throw CloudWatchPendingMetricsQueueError.shutdownAttemptOnUnstartedQueue
+        case .running:
+            state = .shuttingDown
+            
+            doShutdownServer = true
+        case .shuttingDown, .shutDown:
+            // nothing to do; already shutting down or shutdown
+            doShutdownServer = false
+        }
+        
+        return doShutdownServer
+    }
+    
+    /**
+     Updates the Lifecycle state on shutdown completion.
+     */
+    private func updateStateOnShutdownComplete() {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        guard case .shuttingDown = state else {
+            fatalError("CloudWatchPendingMetricsQueue shutdown completed when in unexpected state: \(state)")
+        }
+        state = .shutDown
+    }
+    
+    /**
+     Indicates if the queue is currently shutdown.
+
+     - Returns: if the queue is currently shutdown.
+     */
+    private func isShutdown() -> Bool {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        if case .shutDown = state {
+            return true
+        }
+        
+        return false
+    }
+    
+    /**
+     Indicates if the queue is currently shutting down.
+
+     - Returns: if the queue is currently shutting down.
+     */
+    private func isShuttingDown() -> Bool {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        if case .shuttingDown = state {
+            return true
+        }
+        
+        return false
+    }
+}
+
+extension Array {
+    func chunked(by chunkSize: Int) -> [[Element]] {
+        return stride(from: 0, to: self.count, by: chunkSize).map {
+            Array(self[$0..<Swift.min($0 + chunkSize, self.count)])
+        }
+    }
+}

--- a/Sources/SmokeAWSMetrics/CloudWatchPendingMetricsQueue.swift
+++ b/Sources/SmokeAWSMetrics/CloudWatchPendingMetricsQueue.swift
@@ -52,6 +52,8 @@ internal class CloudWatchPendingMetricsQueue {
     
     private let accessQueue = DispatchQueue(label: "com.amazon.SmokeAWSMetrics.CloudWatchPendingMetricsQueue.accessQueue")
     private let queueConsumingTaskIntervalInSeconds = 2
+    // CloudWatch has a limit of 20 Dataums per request
+    // https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
     private let maximumDataumsPerRequest = 20
     
     enum State {

--- a/Sources/SmokeAWSMetrics/CloudWatchPendingMetricsQueue.swift
+++ b/Sources/SmokeAWSMetrics/CloudWatchPendingMetricsQueue.swift
@@ -52,7 +52,7 @@ internal class CloudWatchPendingMetricsQueue {
     
     private let accessQueue = DispatchQueue(label: "com.amazon.SmokeAWSMetrics.CloudWatchPendingMetricsQueue.accessQueue")
     private let queueConsumingTaskIntervalInSeconds = 2
-    private let maximumDataumsPerRequest = 100
+    private let maximumDataumsPerRequest = 20
     
     enum State {
         case initialized

--- a/Sources/SmokeAWSMetrics/CloudWatchTimerHandler.swift
+++ b/Sources/SmokeAWSMetrics/CloudWatchTimerHandler.swift
@@ -15,6 +15,7 @@
 //  SmokeAWSMetrics
 //
 
+import Foundation
 import Metrics
 import CloudWatchClient
 import CloudWatchModel
@@ -25,48 +26,38 @@ private let microToNanoSecondsFactor: Int64 = 1000
 /**
  Class conforming to `TimerHandler` that emits a CloudWatch metric.
  */
-public class CloudWatchTimerHandler: TimerHandler {
-    private let cloudWatchClient: CloudWatchClientProtocol
+internal class CloudWatchTimerHandler: TimerHandler {
+    private let cloudWatchPendingMetricsQueue: CloudWatchPendingMetricsQueue
     private let metricName: String
     private let namespace: String
-    private let dimensions: [Dimension]?
+    private let dimensions: [CloudWatchModel.Dimension]?
     private let logger: Logger
     
-    public init(cloudWatchClient: CloudWatchClientProtocol,
+    init(cloudWatchPendingMetricsQueue: CloudWatchPendingMetricsQueue,
                 metricName: String,
                 namespace: String,
-                dimensions: [Dimension]?,
+                dimensions: [CloudWatchModel.Dimension]?,
                 logger: Logger) {
-        self.cloudWatchClient = cloudWatchClient
+        self.cloudWatchPendingMetricsQueue = cloudWatchPendingMetricsQueue
         self.metricName = metricName
         self.namespace = namespace
         self.dimensions = dimensions
         self.logger = logger
     }
     
-    public func recordNanoseconds(_ duration: Int64) {
+    func recordNanoseconds(_ duration: Int64) {
         let microseconds = duration / microToNanoSecondsFactor
         
         let metricData = MetricDatum(dimensions: self.dimensions,
                                      metricName: self.metricName,
+                                     timestamp: Date().iso8601,
                                      unit: .microseconds,
                                      value: Double(microseconds))
-        let input = PutMetricDataInput(metricData: [metricData],
-                                       namespace: self.namespace)
-        do {
-            try self.cloudWatchClient.putMetricDataAsync(input: input, completion: { error in
-                if let error = error {
-                    self.logger.error("Unable to submit metric \(self.metricName) to CloudWatch: \(String(describing: error))")
-                }
-            })
-        } catch {
-            self.logger.error("Unable to submit metric \(self.metricName) to CloudWatch: \(String(describing: error))")
-        }
+        
+        self.cloudWatchPendingMetricsQueue.submit(namespace: self.namespace, data: metricData)
     }
     
-    public func reset() {
+    func reset() {
         self.logger.warning("Attempting to reset metric \(self.metricName) which is not supported.")
     }
-    
-    
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* To reduce the calls being made to the CloudWatch service, serialise all metrics received into a queue that is drained at a regular interval (2 seconds) with metrics in the same namespace being combined into a single CloudWatch call (up to a maximum of 100 metric payloads per call).

Also cleaned up some access controls; only `CloudWatchMetricsFactory` needs to be public.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
