### PR TITLE
Experimental async/await support. ReportingConfiguration documentation. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,11 @@ matrix:
       env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
 
     # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 ONLY_RUN_SWIFT_LINT=yes USE_APT_GET=no
+#    - os: linux
+#      dist: xenial
+#      sudo: required
+#      services: docker
+#      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 ONLY_RUN_SWIFT_LINT=yes USE_APT_GET=no
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,33 +5,33 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.1-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.3.3-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.1-xenial ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.3.3-xenial ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.1-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.3.3-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.1-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.3.3-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.1-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.3.3-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
 
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2.4-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
 
     - os: linux
       dist: xenial
@@ -39,12 +39,26 @@ matrix:
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.1-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
 
+    # Verify against nightly of upcoming Swift 5.4
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-5.4-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+
+    # Verify against nightly of Swift mainline
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+
     # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
-#    - os: linux
-#      dist: xenial
-#      sudo: required
-#      services: docker
-#      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 ONLY_RUN_SWIFT_LINT=yes USE_APT_GET=no
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 ONLY_RUN_SWIFT_LINT=yes USE_APT_GET=no
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2.5-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.2.4-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
 
     - os: linux
       dist: xenial

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "6619fe6f8e56a85d9a7d9481c27afb2dc5688459",
-          "version": "2.7.0"
+          "revision": "ab695d0c4593c39ac4494ee318703ac329ca2ae8",
+          "version": "2.8.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -113,6 +113,9 @@ let package = Package(
             name: "SmokeAWSHttp",
             targets: ["SmokeAWSHttp"]),
         .library(
+            name: "_SmokeAWSHttpConcurrency",
+            targets: ["_SmokeAWSHttpConcurrency"]),
+        .library(
             name: "SmokeAWSMetrics",
             targets: ["SmokeAWSMetrics"]),
     ],
@@ -122,7 +125,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.7.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.8.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [
@@ -270,6 +273,11 @@ let package = Package(
                 .product(name: "HTTPPathCoding", package: "smoke-http"),
                 .product(name: "HTTPHeadersCoding", package: "smoke-http"),
                 .product(name: "Crypto", package: "swift-crypto"),
+            ]),
+        .target(
+            name: "_SmokeAWSHttpConcurrency", dependencies: [
+                .target(name: "SmokeAWSHttp"),
+                .product(name: "_SmokeHTTPClientConcurrency", package: "smoke-http"),
             ]),
         .target(
             name: "SmokeAWSMetrics", dependencies: [

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -113,9 +113,6 @@ let package = Package(
             name: "SmokeAWSHttp",
             targets: ["SmokeAWSHttp"]),
         .library(
-            name: "_SmokeAWSHttpConcurrency",
-            targets: ["_SmokeAWSHttpConcurrency"]),
-        .library(
             name: "SmokeAWSMetrics",
             targets: ["SmokeAWSMetrics"]),
     ],
@@ -125,7 +122,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.8.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.7.0"),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
     ],
     targets: [
@@ -221,9 +218,6 @@ let package = Package(
             dependencies: ["Logging", "NIO", "NIOHTTP1",
                            "SmokeAWSCore", "SmokeHTTPClient", "QueryCoding",
                            "HTTPPathCoding", "HTTPHeadersCoding", "Cryptor"]),
-        .target(
-            name: "_SmokeAWSHttpConcurrency",
-            dependencies: ["SmokeAWSHttp", "_SmokeHTTPClientConcurrency"]),
         .target(
             name: "SmokeAWSMetrics",
             dependencies: ["Logging", "Metrics", "CloudWatchClient"]),

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -113,6 +113,9 @@ let package = Package(
             name: "SmokeAWSHttp",
             targets: ["SmokeAWSHttp"]),
         .library(
+            name: "_SmokeAWSHttpConcurrency",
+            targets: ["_SmokeAWSHttpConcurrency"]),
+        .library(
             name: "SmokeAWSMetrics",
             targets: ["SmokeAWSMetrics"]),
     ],
@@ -122,7 +125,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.7.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.8.0"),
         .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.0"),
     ],
     targets: [
@@ -218,6 +221,9 @@ let package = Package(
             dependencies: ["Logging", "NIO", "NIOHTTP1",
                            "SmokeAWSCore", "SmokeHTTPClient", "QueryCoding",
                            "HTTPPathCoding", "HTTPHeadersCoding", "Cryptor"]),
+        .target(
+            name: "_SmokeAWSHttpConcurrency",
+            dependencies: ["SmokeAWSHttp", "_SmokeHTTPClientConcurrency"]),
         .target(
             name: "SmokeAWSMetrics",
             dependencies: ["Logging", "Metrics", "CloudWatchClient"]),

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ import SmokeAWSCredentials
         return Log.error("Unable to obtain credentials from the container environment.")
     }
     
-    // for the EC2 clients, only emit the retry count metric
+    // optional: for the EC2 clients, only emit the retry count metric
     // only report 5XX error counts for DescribeInstances (even if additional operations are added in the future)
     // only report 4XX error counts for operations other than DescribeInstances (including if they are added in the future)
     let reportingConfiguration = SmokeAWSClientReportingConfiguration<ElasticComputeCloudModelOperations>(
@@ -151,10 +151,10 @@ import SmokeAWSCredentials
         credentialsProvider: credentialsProvider,
         awsRegion: region,
         endpointHostName: ec2EndpointHostName,
-        connectionTimeoutSeconds: connectionTimeoutSeconds,
-        retryConfiguration: retryConfiguration,
-        eventLoopProvider: .createNew,
-        reportingConfiguration: reportingConfiguration)
+        connectionTimeoutSeconds: connectionTimeoutSeconds, // optional
+        retryConfiguration: retryConfiguration,             // optional
+        eventLoopProvider: .createNew,                      // optional
+        reportingConfiguration: reportingConfiguration)     // optional
 ```
 
 The inputs to this constructor are-

--- a/Sources/SmokeAWSCore/SmokeAWSClientReportingConfiguration.swift
+++ b/Sources/SmokeAWSCore/SmokeAWSClientReportingConfiguration.swift
@@ -19,6 +19,8 @@ import Foundation
 
 public struct SmokeAWSClientReportingConfiguration<OperationIdentifer: Hashable> {
     
+    // TODO: Remove non-inclusive language
+    // https://github.com/amzn/smoke-aws/issues/84
     public enum MatchingOperations {
         case all
         case whitelist(Set<OperationIdentifer>)
@@ -58,6 +60,14 @@ public struct SmokeAWSClientReportingConfiguration<OperationIdentifer: Hashable>
     
     public static var all: Self {
         return .init(matchingOperations: .all)
+    }
+    
+    public static func onlyForOperations(_ operations: Set<OperationIdentifer>) -> Self {
+        return .init(matchingOperations: .whitelist(operations))
+    }
+
+    public static func exceptForOperations(_ operations: Set<OperationIdentifer>) -> Self {
+        return .init(matchingOperations: .blacklist(operations))
     }
     
     public func reportSuccessForOperation(_ operation: OperationIdentifer) -> Bool {

--- a/Sources/_SmokeAWSHttpConcurrency/AWSClientProtocol.swift
+++ b/Sources/_SmokeAWSHttpConcurrency/AWSClientProtocol.swift
@@ -1,0 +1,107 @@
+//
+//  AWSClientProtocol.swift
+//
+
+#if compiler(>=5.5) && $AsyncAwait
+
+import SmokeHTTPClient
+import SmokeAWSCore
+import NIO
+import NIOHTTP1
+import NIOTransportServices
+import AsyncHTTPClient
+import SmokeAWSHttp
+import _SmokeHTTPClientConcurrency
+
+public extension AWSClientProtocol {
+    func executeWithoutOutput<InvocationReportingType: HTTPClientInvocationReporting,
+                              InputType: HTTPRequestInputProtocol, ErrorType: ConvertableError>(
+            httpClient: HTTPOperationsClient,
+            endpointPath: String = "/",
+            httpMethod: HTTPMethod = .POST,
+            requestInput: InputType,
+            operation: String,
+            reporting: InvocationReportingType,
+            signAllHeaders: Bool = false,
+            errorType: ErrorType.Type) async throws {
+        let handlerDelegate = AWSClientInvocationDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: operation,
+                    target: target,
+                    signAllHeaders: signAllHeaders)
+
+        let invocationContext = HTTPClientInvocationContext(reporting: reporting,
+                                                            handlerDelegate: handlerDelegate)
+
+        do {
+            return try await httpClient.executeRetriableWithoutOutput(
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: requestInput,
+                invocationContext: invocationContext,
+                retryConfiguration: retryConfiguration,
+                retryOnError: retryOnErrorProvider)
+        } catch {
+            let typedError: ErrorType = error.asTypedError()
+            throw typedError
+        }
+    }
+    
+    func executeWithOutput<OutputType: HTTPResponseOutputProtocol, InvocationReportingType: HTTPClientInvocationReporting,
+                           InputType: HTTPRequestInputProtocol, ErrorType: ConvertableError>(
+            httpClient: HTTPOperationsClient,
+            endpointPath: String = "/",
+            httpMethod: HTTPMethod = .POST,
+            requestInput: InputType,
+            operation: String,
+            reporting: InvocationReportingType,
+            signAllHeaders: Bool = false,
+            errorType: ErrorType.Type) async throws -> OutputType {
+        let handlerDelegate = AWSClientInvocationDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    operation: operation,
+                    target: target,
+                    signAllHeaders: signAllHeaders)
+
+        let invocationContext = HTTPClientInvocationContext(reporting: reporting,
+                                                            handlerDelegate: handlerDelegate)
+
+        do {
+            return try await httpClient.executeRetriableWithOutput(
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: requestInput,
+                invocationContext: invocationContext,
+                retryConfiguration: retryConfiguration,
+                retryOnError: retryOnErrorProvider)
+        } catch {
+            let typedError: ErrorType = error.asTypedError()
+            throw typedError
+        }
+    }
+}
+
+public struct AWSClientHelper {
+    public static func getEventLoop(eventLoopGroupProvider: HTTPClient.EventLoopGroupProvider) -> EventLoopGroup {
+        switch eventLoopGroupProvider {
+        case .shared(let group):
+            return group
+        case .createNew:
+            #if canImport(Network)
+                if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+                    return NIOTSEventLoopGroup()
+                } else {
+                    return MultiThreadedEventLoopGroup(numberOfThreads: 1)
+                }
+            #else
+                return MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            #endif
+        }
+    }
+}
+
+#endif

--- a/Sources/_SmokeAWSHttpConcurrency/AWSQueryClientProtocol.swift
+++ b/Sources/_SmokeAWSHttpConcurrency/AWSQueryClientProtocol.swift
@@ -1,0 +1,85 @@
+//
+//  AWSClientProtocol.swift
+//
+
+#if compiler(>=5.5) && $AsyncAwait
+
+import SmokeHTTPClient
+import SmokeAWSCore
+import NIO
+import SmokeAWSHttp
+import _SmokeHTTPClientConcurrency
+
+public extension AWSQueryClientProtocol {
+    func executeWithoutOutput<InvocationReportingType: HTTPClientInvocationReporting,
+                              WrappedInputType: HTTPRequestInputProtocol, ErrorType: ConvertableError>(
+            httpClient: HTTPOperationsClient,
+            wrappedInput: WrappedInputType,
+            action: String,
+            reporting: InvocationReportingType,
+            errorType: ErrorType.Type) async throws {
+        let handlerDelegate = AWSClientInvocationDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    target: target)
+        
+        let invocationContext = HTTPClientInvocationContext(reporting: reporting,
+                                                            handlerDelegate: handlerDelegate)
+        
+        let requestInput = QueryWrapperHTTPRequestInput(
+            wrappedInput: wrappedInput,
+            action: action,
+            version: apiVersion)
+
+        do {
+            return try await httpClient.executeRetriableWithoutOutput(
+                endpointPath: "/",
+                httpMethod: .POST,
+                input: requestInput,
+                invocationContext: invocationContext,
+                retryConfiguration: retryConfiguration,
+                retryOnError: retryOnErrorProvider)
+        } catch {
+            let typedError: ErrorType = error.asTypedError()
+            throw typedError
+        }
+    }
+        
+    func executeWithOutput<OutputType: HTTPResponseOutputProtocol, InvocationReportingType: HTTPClientInvocationReporting,
+                                WrappedInputType: HTTPRequestInputProtocol, ErrorType: ConvertableError>(
+            httpClient: HTTPOperationsClient,
+            wrappedInput: WrappedInputType,
+            action: String,
+            reporting: InvocationReportingType,
+            errorType: ErrorType.Type) async throws -> OutputType {
+        let handlerDelegate = AWSClientInvocationDelegate(
+                    credentialsProvider: credentialsProvider,
+                    awsRegion: awsRegion,
+                    service: service,
+                    target: target)
+        
+        let invocationContext = HTTPClientInvocationContext(reporting: reporting,
+                                                            handlerDelegate: handlerDelegate)
+        
+        let requestInput = QueryWrapperHTTPRequestInput(
+            wrappedInput: wrappedInput,
+            action: action,
+            version: apiVersion)
+
+        do {
+            return try await httpClient.executeRetriableWithOutput(
+                endpointPath: "/",
+                httpMethod: .POST,
+                input: requestInput,
+                invocationContext: invocationContext,
+                retryConfiguration: retryConfiguration,
+                retryOnError: retryOnErrorProvider)
+        } catch {
+            let typedError: ErrorType = error.asTypedError()
+            throw typedError
+        }
+    }
+}
+
+#endif

--- a/docs/Support_Policy.md
+++ b/docs/Support_Policy.md
@@ -1,5 +1,5 @@
 ---
-date: 2020-12-11 13:00
+date: 2021-04-26 15:00
 description: Support Policy for SmokeAWS.
 tags: support policy
 ---
@@ -25,9 +25,10 @@ Once support has been removed, testing via continuous integration may be removed
 
 Following these rules, the support level for different Swift Toolchain versions are-
 1. **Swift 5.0 and earlier**: No support.
-5. **Swift 5.1**: Supported for SmokeAWS 2.x. Support to be removed after 12th of May, 2021.
-6. **Swift 5.2**: Supported for SmokeAWS 2.x.
-7. **Swift 5.3**: Supported for SmokeAWS 2.x.
+2. **Swift 5.1**: Supported for SmokeAWS 2.x. Support to be removed after 12th of May, 2021.
+3. **Swift 5.2**: Supported for SmokeAWS 2.x. Support to be removed after 26th of October, 2021.
+4. **Swift 5.3**: Supported for SmokeAWS 2.x.
+5. **Swift 5.4**: Supported for SmokeAWS 2.x.
 
 # Runtime Support
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add experimental async/await support. This doesn't yet add support to the generated clients in this package but will allow other generated clients to test out async/await support.
2. Add details to the README on how to configure the reporting configuration for clients.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
