### PR TITLE
Code generate with Go SDK v1.38.40 models.

### DIFF
--- a/Sources/CloudformationModel/CloudformationModelDefaultInstances.swift
+++ b/Sources/CloudformationModel/CloudformationModelDefaultInstances.swift
@@ -1387,6 +1387,7 @@ public extension GetTemplateSummaryInput {
      */
     static let __default: CloudformationModel.GetTemplateSummaryInput = {
         let defaultInstance = CloudformationModel.GetTemplateSummaryInput(
+            callAs: nil,
             stackName: nil,
             stackSetName: nil,
             templateBody: nil,

--- a/Sources/CloudformationModel/CloudformationModelStructures.swift
+++ b/Sources/CloudformationModel/CloudformationModelStructures.swift
@@ -2294,15 +2294,18 @@ public struct GetTemplateOutputForGetTemplate: Codable, Equatable {
 }
 
 public struct GetTemplateSummaryInput: Codable, Equatable {
+    public var callAs: CallAs?
     public var stackName: StackNameOrId?
     public var stackSetName: StackSetNameOrId?
     public var templateBody: TemplateBody?
     public var templateURL: TemplateURL?
 
-    public init(stackName: StackNameOrId? = nil,
+    public init(callAs: CallAs? = nil,
+                stackName: StackNameOrId? = nil,
                 stackSetName: StackSetNameOrId? = nil,
                 templateBody: TemplateBody? = nil,
                 templateURL: TemplateURL? = nil) {
+        self.callAs = callAs
         self.stackName = stackName
         self.stackSetName = stackSetName
         self.templateBody = templateBody
@@ -2310,6 +2313,7 @@ public struct GetTemplateSummaryInput: Codable, Equatable {
     }
 
     enum CodingKeys: String, CodingKey {
+        case callAs = "CallAs"
         case stackName = "StackName"
         case stackSetName = "StackSetName"
         case templateBody = "TemplateBody"

--- a/Sources/ElasticComputeCloudModel/ElasticComputeCloudModelStructures.swift
+++ b/Sources/ElasticComputeCloudModel/ElasticComputeCloudModelStructures.swift
@@ -17903,7 +17903,6 @@ public struct FleetLaunchTemplateConfigRequest: Codable, Equatable {
 
     public func validate() throws {
         try launchTemplateSpecification?.validate()
-        try overrides?.validateAsFleetLaunchTemplateOverridesListRequest()
     }
 }
 

--- a/Sources/ElasticComputeCloudModel/ElasticComputeCloudModelTypes.swift
+++ b/Sources/ElasticComputeCloudModel/ElasticComputeCloudModelTypes.swift
@@ -3300,10 +3300,14 @@ public enum InstanceType: String, Codable, CustomStringConvertible {
     case t4gNano = "t4g.nano"
     case t4gSmall = "t4g.small"
     case t4gXlarge = "t4g.xlarge"
+    case u12tb1112xlarge = "u-12tb1.112xlarge"
     case u12tb1Metal = "u-12tb1.metal"
     case u18tb1Metal = "u-18tb1.metal"
     case u24tb1Metal = "u-24tb1.metal"
+    case u6tb1112xlarge = "u-6tb1.112xlarge"
+    case u6tb156xlarge = "u-6tb1.56xlarge"
     case u6tb1Metal = "u-6tb1.metal"
+    case u9tb1112xlarge = "u-9tb1.112xlarge"
     case u9tb1Metal = "u-9tb1.metal"
     case x116xlarge = "x1.16xlarge"
     case x132xlarge = "x1.32xlarge"
@@ -7892,21 +7896,6 @@ extension Array where Element == ElasticComputeCloudModel.FleetLaunchTemplateCon
 
         if self.count > 50 {
             throw ElasticComputeCloudError.validationError(reason: "The provided value to FleetLaunchTemplateConfigListRequest violated the maximum length constraint.")
-        }
-    }
-}
-
-/**
- Validation for the FleetLaunchTemplateOverridesListRequest field.
-*/
-extension Array where Element == ElasticComputeCloudModel.FleetLaunchTemplateOverridesRequest {
-    public func validateAsFleetLaunchTemplateOverridesListRequest() throws {
-        if self.count < 0 {
-            throw ElasticComputeCloudError.validationError(reason: "The provided value to FleetLaunchTemplateOverridesListRequest violated the minimum length constraint.")
-        }
-
-        if self.count > 50 {
-            throw ElasticComputeCloudError.validationError(reason: "The provided value to FleetLaunchTemplateOverridesListRequest violated the maximum length constraint.")
         }
     }
 }

--- a/Sources/ElasticContainerModel/ElasticContainerModelDefaultInstances.swift
+++ b/Sources/ElasticContainerModel/ElasticContainerModelDefaultInstances.swift
@@ -1124,6 +1124,18 @@ public extension EnvironmentFile {
     }()
 }
 
+public extension EphemeralStorage {
+    /**
+     Default instance of the EphemeralStorage structure.
+     */
+    static let __default: ElasticContainerModel.EphemeralStorage = {
+        let defaultInstance = ElasticContainerModel.EphemeralStorage(
+            sizeInGiB: 0)
+
+        return defaultInstance
+    }()
+}
+
 public extension ExecuteCommandConfiguration {
     /**
      Default instance of the ExecuteCommandConfiguration structure.
@@ -2015,6 +2027,7 @@ public extension RegisterTaskDefinitionRequest {
         let defaultInstance = ElasticContainerModel.RegisterTaskDefinitionRequest(
             containerDefinitions: [],
             cpu: nil,
+            ephemeralStorage: nil,
             executionRoleArn: nil,
             family: "value",
             inferenceAccelerators: nil,
@@ -2551,6 +2564,7 @@ public extension Task {
             createdAt: nil,
             desiredStatus: nil,
             enableExecuteCommand: nil,
+            ephemeralStorage: nil,
             executionStoppedAt: nil,
             group: nil,
             healthStatus: nil,
@@ -2587,6 +2601,7 @@ public extension TaskDefinition {
             containerDefinitions: nil,
             cpu: nil,
             deregisteredAt: nil,
+            ephemeralStorage: nil,
             executionRoleArn: nil,
             family: nil,
             inferenceAccelerators: nil,
@@ -2631,6 +2646,7 @@ public extension TaskOverride {
         let defaultInstance = ElasticContainerModel.TaskOverride(
             containerOverrides: nil,
             cpu: nil,
+            ephemeralStorage: nil,
             executionRoleArn: nil,
             inferenceAcceleratorOverrides: nil,
             memory: nil,

--- a/Sources/ElasticContainerModel/ElasticContainerModelStructures.swift
+++ b/Sources/ElasticContainerModel/ElasticContainerModelStructures.swift
@@ -2017,6 +2017,21 @@ public struct EnvironmentFile: Codable, Equatable {
     }
 }
 
+public struct EphemeralStorage: Codable, Equatable {
+    public var sizeInGiB: Integer
+
+    public init(sizeInGiB: Integer) {
+        self.sizeInGiB = sizeInGiB
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case sizeInGiB
+    }
+
+    public func validate() throws {
+    }
+}
+
 public struct ExecuteCommandConfiguration: Codable, Equatable {
     public var kmsKeyId: String?
     public var logConfiguration: ExecuteCommandLogConfiguration?
@@ -3444,6 +3459,7 @@ public struct RegisterContainerInstanceResponse: Codable, Equatable {
 public struct RegisterTaskDefinitionRequest: Codable, Equatable {
     public var containerDefinitions: ContainerDefinitions
     public var cpu: String?
+    public var ephemeralStorage: EphemeralStorage?
     public var executionRoleArn: String?
     public var family: String
     public var inferenceAccelerators: InferenceAccelerators?
@@ -3460,6 +3476,7 @@ public struct RegisterTaskDefinitionRequest: Codable, Equatable {
 
     public init(containerDefinitions: ContainerDefinitions,
                 cpu: String? = nil,
+                ephemeralStorage: EphemeralStorage? = nil,
                 executionRoleArn: String? = nil,
                 family: String,
                 inferenceAccelerators: InferenceAccelerators? = nil,
@@ -3475,6 +3492,7 @@ public struct RegisterTaskDefinitionRequest: Codable, Equatable {
                 volumes: VolumeList? = nil) {
         self.containerDefinitions = containerDefinitions
         self.cpu = cpu
+        self.ephemeralStorage = ephemeralStorage
         self.executionRoleArn = executionRoleArn
         self.family = family
         self.inferenceAccelerators = inferenceAccelerators
@@ -3493,6 +3511,7 @@ public struct RegisterTaskDefinitionRequest: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case containerDefinitions
         case cpu
+        case ephemeralStorage
         case executionRoleArn
         case family
         case inferenceAccelerators
@@ -3509,6 +3528,7 @@ public struct RegisterTaskDefinitionRequest: Codable, Equatable {
     }
 
     public func validate() throws {
+        try ephemeralStorage?.validate()
         try proxyConfiguration?.validate()
         try tags?.validateAsTags()
     }
@@ -4404,6 +4424,7 @@ public struct Task: Codable, Equatable {
     public var createdAt: Timestamp?
     public var desiredStatus: String?
     public var enableExecuteCommand: Boolean?
+    public var ephemeralStorage: EphemeralStorage?
     public var executionStoppedAt: Timestamp?
     public var group: String?
     public var healthStatus: HealthStatus?
@@ -4439,6 +4460,7 @@ public struct Task: Codable, Equatable {
                 createdAt: Timestamp? = nil,
                 desiredStatus: String? = nil,
                 enableExecuteCommand: Boolean? = nil,
+                ephemeralStorage: EphemeralStorage? = nil,
                 executionStoppedAt: Timestamp? = nil,
                 group: String? = nil,
                 healthStatus: HealthStatus? = nil,
@@ -4473,6 +4495,7 @@ public struct Task: Codable, Equatable {
         self.createdAt = createdAt
         self.desiredStatus = desiredStatus
         self.enableExecuteCommand = enableExecuteCommand
+        self.ephemeralStorage = ephemeralStorage
         self.executionStoppedAt = executionStoppedAt
         self.group = group
         self.healthStatus = healthStatus
@@ -4510,6 +4533,7 @@ public struct Task: Codable, Equatable {
         case createdAt
         case desiredStatus
         case enableExecuteCommand
+        case ephemeralStorage
         case executionStoppedAt
         case group
         case healthStatus
@@ -4534,6 +4558,7 @@ public struct Task: Codable, Equatable {
     }
 
     public func validate() throws {
+        try ephemeralStorage?.validate()
         try overrides?.validate()
         try tags?.validateAsTags()
     }
@@ -4544,6 +4569,7 @@ public struct TaskDefinition: Codable, Equatable {
     public var containerDefinitions: ContainerDefinitions?
     public var cpu: String?
     public var deregisteredAt: Timestamp?
+    public var ephemeralStorage: EphemeralStorage?
     public var executionRoleArn: String?
     public var family: String?
     public var inferenceAccelerators: InferenceAccelerators?
@@ -4567,6 +4593,7 @@ public struct TaskDefinition: Codable, Equatable {
                 containerDefinitions: ContainerDefinitions? = nil,
                 cpu: String? = nil,
                 deregisteredAt: Timestamp? = nil,
+                ephemeralStorage: EphemeralStorage? = nil,
                 executionRoleArn: String? = nil,
                 family: String? = nil,
                 inferenceAccelerators: InferenceAccelerators? = nil,
@@ -4589,6 +4616,7 @@ public struct TaskDefinition: Codable, Equatable {
         self.containerDefinitions = containerDefinitions
         self.cpu = cpu
         self.deregisteredAt = deregisteredAt
+        self.ephemeralStorage = ephemeralStorage
         self.executionRoleArn = executionRoleArn
         self.family = family
         self.inferenceAccelerators = inferenceAccelerators
@@ -4614,6 +4642,7 @@ public struct TaskDefinition: Codable, Equatable {
         case containerDefinitions
         case cpu
         case deregisteredAt
+        case ephemeralStorage
         case executionRoleArn
         case family
         case inferenceAccelerators
@@ -4635,6 +4664,7 @@ public struct TaskDefinition: Codable, Equatable {
     }
 
     public func validate() throws {
+        try ephemeralStorage?.validate()
         try proxyConfiguration?.validate()
     }
 }
@@ -4661,6 +4691,7 @@ public struct TaskDefinitionPlacementConstraint: Codable, Equatable {
 public struct TaskOverride: Codable, Equatable {
     public var containerOverrides: ContainerOverrides?
     public var cpu: String?
+    public var ephemeralStorage: EphemeralStorage?
     public var executionRoleArn: String?
     public var inferenceAcceleratorOverrides: InferenceAcceleratorOverrides?
     public var memory: String?
@@ -4668,12 +4699,14 @@ public struct TaskOverride: Codable, Equatable {
 
     public init(containerOverrides: ContainerOverrides? = nil,
                 cpu: String? = nil,
+                ephemeralStorage: EphemeralStorage? = nil,
                 executionRoleArn: String? = nil,
                 inferenceAcceleratorOverrides: InferenceAcceleratorOverrides? = nil,
                 memory: String? = nil,
                 taskRoleArn: String? = nil) {
         self.containerOverrides = containerOverrides
         self.cpu = cpu
+        self.ephemeralStorage = ephemeralStorage
         self.executionRoleArn = executionRoleArn
         self.inferenceAcceleratorOverrides = inferenceAcceleratorOverrides
         self.memory = memory
@@ -4683,6 +4716,7 @@ public struct TaskOverride: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case containerOverrides
         case cpu
+        case ephemeralStorage
         case executionRoleArn
         case inferenceAcceleratorOverrides
         case memory
@@ -4690,6 +4724,7 @@ public struct TaskOverride: Codable, Equatable {
     }
 
     public func validate() throws {
+        try ephemeralStorage?.validate()
     }
 }
 

--- a/docs/Support_Policy.md
+++ b/docs/Support_Policy.md
@@ -1,5 +1,5 @@
 ---
-date: 2021-04-26 15:00
+date: 2021-05-14 15:00
 description: Support Policy for SmokeAWS.
 tags: support policy
 ---
@@ -24,16 +24,15 @@ SmokeAWS has two mechanism for removing support for Swift Toolchain versions-
 Once support has been removed, testing via continuous integration may be removed and no guarantees will be given for compiling the package using this version of the toolchain.
 
 Following these rules, the support level for different Swift Toolchain versions are-
-1. **Swift 5.0 and earlier**: No support.
-2. **Swift 5.1**: Supported for SmokeAWS 2.x. Support to be removed after 12th of May, 2021.
-3. **Swift 5.2**: Supported for SmokeAWS 2.x. Support to be removed after 26th of October, 2021.
-4. **Swift 5.3**: Supported for SmokeAWS 2.x.
-5. **Swift 5.4**: Supported for SmokeAWS 2.x.
+1. **Swift 5.1 and earlier**: No support.
+2. **Swift 5.2**: Supported for SmokeAWS 2.x. Support to be removed after 26th of October, 2021.
+3. **Swift 5.3**: Supported for SmokeAWS 2.x.
+4. **Swift 5.4**: Supported for SmokeAWS 2.x.
 
 # Runtime Support
 
 SmokeAWS will provide support for the following runtimes, verifying this support using continuous integration of all changes for these runtimes.  Verification of support through continuous integration for each of these runtimes will occur for five years from their release, unless otherwise stated-
-1. **Ubuntu 16.04**: CI verification to be removed after April, 2021.
+1. **Ubuntu 16.04 and earlier**: No support.
 2. **Ubuntu 18.04**: CI verification to be removed after April, 2023.
 3. **Ubuntu 20.04**: CI verification to be removed after April, 2025.
 4. **Amazon Linux 2**: CI verification to be removed after June, 2023.
@@ -43,14 +42,5 @@ SmokeAWS will provide support for the following runtimes, verifying this support
 
 Currently, SmokeAWS supports macOS as a development environment and will provide support for **at least** the two most recent macOS versions. For these two versions of macOS, SmokeAWS will ensure debug support as long as XCode does.
 
-Following these rules, the support level for different macOS versions are-
-
-SmokeAWS 2.x
-* when compiling under Swift 5.2, ***macOS Catalina (10.15)*** or higher is required[1]
-* when compiling under Swift 5.1, ***macOS High Sierra (10.13)*** or higher is required
-
-SmokeAWS 1.x
-* ***macOS Sierra (10.12)*** or higher is required
-
-[1] Swift 5.2 is shipped with XCode 11.4 which requires a Mac running macOS Catalina 10.15.2 or later and therefore SmokeAWS doesn't support the combination of Swift 5.2 with earlier versions of macOS
+Following these rules, SmokeAWS currently requires ***macOS Catalina (10.15)*** or higher.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Code generate with Go SDK v1.38.40 models.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
