### PR TITLE
Do not create promises when they wont be used.

### DIFF
--- a/Sources/SmokeAWSHttp/MockClientProtocol.swift
+++ b/Sources/SmokeAWSHttp/MockClientProtocol.swift
@@ -31,9 +31,9 @@ public extension MockClientProtocol {
             eventLoop: EventLoop,
             functionOverride: ((InputType) throws -> OutputType)?,
             eventLoopFutureFunctionOverride: ((InputType) -> EventLoopFuture<OutputType>)?) -> EventLoopFuture<OutputType> {
-        let promise = eventLoop.makePromise(of: OutputType.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: OutputType.self)
+            
             do {
                 let overrideResult = try functionOverride(input)
                 promise.succeed(overrideResult)
@@ -48,6 +48,7 @@ public extension MockClientProtocol {
             return eventLoopFutureFunctionOverride(input)
         }
 
+        let promise = eventLoop.makePromise(of: OutputType.self)
         promise.succeed(defaultResult)
         
         return promise.futureResult
@@ -58,9 +59,8 @@ public extension MockClientProtocol {
             eventLoop: EventLoop,
             functionOverride: ((InputType) throws -> ())?,
             eventLoopFutureFunctionOverride: ((InputType) -> EventLoopFuture<Void>)?) -> EventLoopFuture<Void> {
-        let promise = eventLoop.makePromise(of: Void.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: Void.self)
             do {
                 try functionOverride(input)
                 promise.succeed(())
@@ -75,6 +75,7 @@ public extension MockClientProtocol {
             return eventLoopFutureFunctionOverride(input)
         }
 
+        let promise = eventLoop.makePromise(of: Void.self)
         promise.succeed(())
         
         return promise.futureResult
@@ -85,9 +86,9 @@ public extension MockClientProtocol {
             eventLoop: EventLoop,
             functionOverride: (() throws -> OutputType)?,
             eventLoopFutureFunctionOverride: (() -> EventLoopFuture<OutputType>)?) -> EventLoopFuture<OutputType> {
-        let promise = eventLoop.makePromise(of: OutputType.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: OutputType.self)
+            
             do {
                 let overrideResult = try functionOverride()
                 promise.succeed(overrideResult)
@@ -102,6 +103,7 @@ public extension MockClientProtocol {
             return eventLoopFutureFunctionOverride()
         }
 
+        let promise = eventLoop.makePromise(of: OutputType.self)
         promise.succeed(defaultResult)
         
         return promise.futureResult
@@ -111,9 +113,9 @@ public extension MockClientProtocol {
             eventLoop: EventLoop,
             functionOverride: (() throws -> ())?,
             eventLoopFutureFunctionOverride: (() -> EventLoopFuture<Void>)?) -> EventLoopFuture<Void> {
-        let promise = eventLoop.makePromise(of: Void.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: Void.self)
+            
             do {
                 try functionOverride()
                 promise.succeed(())
@@ -128,6 +130,7 @@ public extension MockClientProtocol {
             return eventLoopFutureFunctionOverride()
         }
 
+        let promise = eventLoop.makePromise(of: Void.self)
         promise.succeed(())
         
         return promise.futureResult

--- a/Sources/SmokeAWSHttp/MockThrowingClientProtocol.swift
+++ b/Sources/SmokeAWSHttp/MockThrowingClientProtocol.swift
@@ -32,9 +32,9 @@ public extension MockThrowingClientProtocol {
             eventLoop: EventLoop,
             functionOverride: ((InputType) throws -> OutputType)?,
             eventLoopFutureFunctionOverride: ((InputType) -> EventLoopFuture<OutputType>)?) -> EventLoopFuture<OutputType> {
-        let promise = eventLoop.makePromise(of: OutputType.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: OutputType.self)
+            
             do {
                 let overrideResult = try functionOverride(input)
                 promise.succeed(overrideResult)
@@ -49,6 +49,7 @@ public extension MockThrowingClientProtocol {
             return eventLoopFutureFunctionOverride(input)
         }
 
+        let promise = eventLoop.makePromise(of: OutputType.self)
         promise.fail(defaultError)
         
         return promise.futureResult
@@ -60,9 +61,9 @@ public extension MockThrowingClientProtocol {
             eventLoop: EventLoop,
             functionOverride: ((InputType) throws -> ())?,
             eventLoopFutureFunctionOverride: ((InputType) -> EventLoopFuture<Void>)?) -> EventLoopFuture<Void> {
-        let promise = eventLoop.makePromise(of: Void.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: Void.self)
+            
             do {
                 try functionOverride(input)
                 promise.succeed(())
@@ -77,6 +78,7 @@ public extension MockThrowingClientProtocol {
             return eventLoopFutureFunctionOverride(input)
         }
 
+        let promise = eventLoop.makePromise(of: Void.self)
         promise.fail(defaultError)
         
         return promise.futureResult
@@ -87,9 +89,9 @@ public extension MockThrowingClientProtocol {
             eventLoop: EventLoop,
             functionOverride: (() throws -> OutputType)?,
             eventLoopFutureFunctionOverride: (() -> EventLoopFuture<OutputType>)?) -> EventLoopFuture<OutputType> {
-        let promise = eventLoop.makePromise(of: OutputType.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: OutputType.self)
+            
             do {
                 let overrideResult = try functionOverride()
                 promise.succeed(overrideResult)
@@ -104,6 +106,7 @@ public extension MockThrowingClientProtocol {
             return eventLoopFutureFunctionOverride()
         }
 
+        let promise = eventLoop.makePromise(of: OutputType.self)
         promise.fail(defaultError)
         
         return promise.futureResult
@@ -114,9 +117,9 @@ public extension MockThrowingClientProtocol {
             eventLoop: EventLoop,
             functionOverride: (() throws -> ())?,
             eventLoopFutureFunctionOverride: (() -> EventLoopFuture<Void>)?) -> EventLoopFuture<Void> {
-        let promise = eventLoop.makePromise(of: Void.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: Void.self)
+            
             do {
                 try functionOverride()
                 promise.succeed(())
@@ -131,6 +134,7 @@ public extension MockThrowingClientProtocol {
             return eventLoopFutureFunctionOverride()
         }
 
+        let promise = eventLoop.makePromise(of: Void.self)
         promise.fail(defaultError)
         
         return promise.futureResult

--- a/Sources/_SmokeAWSHttpConcurrency/MockClientProtocol.swift
+++ b/Sources/_SmokeAWSHttpConcurrency/MockClientProtocol.swift
@@ -32,9 +32,9 @@ public extension MockClientProtocol {
             eventLoop: EventLoop,
             functionOverride: ((InputType) async throws -> OutputType)?,
             eventLoopFutureFunctionOverride: ((InputType) -> EventLoopFuture<OutputType>)?) -> EventLoopFuture<OutputType> {
-        let promise = eventLoop.makePromise(of: OutputType.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: OutputType.self)
+            
             Task {
                 do {
                     let overrideResult = try await functionOverride(input)
@@ -51,6 +51,7 @@ public extension MockClientProtocol {
             return eventLoopFutureFunctionOverride(input)
         }
 
+        let promise = eventLoop.makePromise(of: OutputType.self)
         promise.succeed(defaultResult)
         
         return promise.futureResult
@@ -80,9 +81,9 @@ public extension MockClientProtocol {
             eventLoop: EventLoop,
             functionOverride: ((InputType) async throws -> ())?,
             eventLoopFutureFunctionOverride: ((InputType) -> EventLoopFuture<Void>)?) -> EventLoopFuture<Void> {
-        let promise = eventLoop.makePromise(of: Void.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: Void.self)
+            
             Task {
                 do {
                     try await functionOverride(input)
@@ -99,6 +100,7 @@ public extension MockClientProtocol {
             return eventLoopFutureFunctionOverride(input)
         }
 
+        let promise = eventLoop.makePromise(of: Void.self)
         promise.succeed(())
         
         return promise.futureResult
@@ -129,9 +131,9 @@ public extension MockClientProtocol {
             eventLoop: EventLoop,
             functionOverride: (() async throws -> OutputType)?,
             eventLoopFutureFunctionOverride: (() -> EventLoopFuture<OutputType>)?) -> EventLoopFuture<OutputType> {
-        let promise = eventLoop.makePromise(of: OutputType.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: OutputType.self)
+            
             Task {
                 do {
                     let overrideResult = try await functionOverride()
@@ -148,6 +150,7 @@ public extension MockClientProtocol {
             return eventLoopFutureFunctionOverride()
         }
 
+        let promise = eventLoop.makePromise(of: OutputType.self)
         promise.succeed(defaultResult)
         
         return promise.futureResult
@@ -175,9 +178,9 @@ public extension MockClientProtocol {
             eventLoop: EventLoop,
             functionOverride: (() async throws -> ())?,
             eventLoopFutureFunctionOverride: (() -> EventLoopFuture<Void>)?) -> EventLoopFuture<Void> {
-        let promise = eventLoop.makePromise(of: Void.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: Void.self)
+            
             Task {
                 do {
                     try await functionOverride()
@@ -194,6 +197,7 @@ public extension MockClientProtocol {
             return eventLoopFutureFunctionOverride()
         }
 
+        let promise = eventLoop.makePromise(of: Void.self)
         promise.succeed(())
         
         return promise.futureResult

--- a/Sources/_SmokeAWSHttpConcurrency/MockThrowingClientProtocol.swift
+++ b/Sources/_SmokeAWSHttpConcurrency/MockThrowingClientProtocol.swift
@@ -32,9 +32,9 @@ public extension MockThrowingClientProtocol {
             eventLoop: EventLoop,
             functionOverride: ((InputType) async throws -> OutputType)?,
             eventLoopFutureFunctionOverride: ((InputType) -> EventLoopFuture<OutputType>)?) -> EventLoopFuture<OutputType> {
-        let promise = eventLoop.makePromise(of: OutputType.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: OutputType.self)
+            
             Task {
                 do {
                     let overrideResult = try await functionOverride(input)
@@ -51,6 +51,7 @@ public extension MockThrowingClientProtocol {
             return eventLoopFutureFunctionOverride(input)
         }
 
+        let promise = eventLoop.makePromise(of: OutputType.self)
         promise.fail(defaultError)
         
         return promise.futureResult
@@ -81,9 +82,9 @@ public extension MockThrowingClientProtocol {
             eventLoop: EventLoop,
             functionOverride: ((InputType) async throws -> ())?,
             eventLoopFutureFunctionOverride: ((InputType) -> EventLoopFuture<Void>)?) -> EventLoopFuture<Void> {
-        let promise = eventLoop.makePromise(of: Void.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: Void.self)
+            
             Task {
                 do {
                     try await functionOverride(input)
@@ -100,6 +101,7 @@ public extension MockThrowingClientProtocol {
             return eventLoopFutureFunctionOverride(input)
         }
 
+        let promise = eventLoop.makePromise(of: Void.self)
         promise.fail(defaultError)
         
         return promise.futureResult
@@ -133,9 +135,9 @@ public extension MockThrowingClientProtocol {
             eventLoop: EventLoop,
             functionOverride: (() async throws -> OutputType)?,
             eventLoopFutureFunctionOverride: (() -> EventLoopFuture<OutputType>)?) -> EventLoopFuture<OutputType> {
-        let promise = eventLoop.makePromise(of: OutputType.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: OutputType.self)
+            
             Task {
                 do {
                     let overrideResult = try await functionOverride()
@@ -152,6 +154,7 @@ public extension MockThrowingClientProtocol {
             return eventLoopFutureFunctionOverride()
         }
 
+        let promise = eventLoop.makePromise(of: OutputType.self)
         promise.fail(defaultError)
         
         return promise.futureResult
@@ -180,9 +183,9 @@ public extension MockThrowingClientProtocol {
             eventLoop: EventLoop,
             functionOverride: (() async throws -> ())?,
             eventLoopFutureFunctionOverride: (() -> EventLoopFuture<Void>)?) -> EventLoopFuture<Void> {
-        let promise = eventLoop.makePromise(of: Void.self)
-        
         if let functionOverride = functionOverride {
+            let promise = eventLoop.makePromise(of: Void.self)
+            
             Task {
                 do {
                     try await functionOverride()
@@ -199,6 +202,7 @@ public extension MockThrowingClientProtocol {
             return eventLoopFutureFunctionOverride()
         }
 
+        let promise = eventLoop.makePromise(of: Void.self)
         promise.fail(defaultError)
         
         return promise.futureResult


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Do not create promises when they wont be used; when the `EventLoopFuture`-returning implementation override is returned. This will cause a fatal error when debugging[1].

[1] https://github.com/apple/swift-nio/blob/main/Sources/NIOCore/EventLoopFuture.swift#L420


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
