### PR TITLE
Move async function support into SmokeAWSHttp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,28 @@ matrix:
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+
+    - os: linux
+      dist: bionic
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.4.3-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
       
     - os: linux
       dist: bionic
@@ -28,19 +34,12 @@ matrix:
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.3.3-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
 
-    # Verify next version of Swift (5.5)
+    # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-5.5-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
-
-    # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
-#    - os: linux
-#      dist: bionic
-#      sudo: required
-#      services: docker
-#      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 ONLY_RUN_SWIFT_LINT=yes USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 ONLY_RUN_SWIFT_LINT=yes USE_APT_GET=no
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,12 @@ matrix:
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.3.3-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
 
-    # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
-    - os: linux
-      dist: bionic
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 ONLY_RUN_SWIFT_LINT=yes USE_APT_GET=no
+#    # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
+#    - os: linux
+#      dist: bionic
+#      sudo: required
+#      services: docker
+#      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 ONLY_RUN_SWIFT_LINT=yes USE_APT_GET=no
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "8ccba7328d178ac05a1a9803cf3f2c6660d2f826",
-          "version": "1.3.0"
+          "revision": "8fa7f082b155ea325bcf7b2dbffaf81d4eea1ae4",
+          "version": "1.5.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "0f0ac49e96208b709a58a5e5d59d05bab44957aa",
-          "version": "2.8.5"
+          "revision": "95e473c7db33ca6b4e805245c0cf14580a302a3c",
+          "version": "2.9.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "e382458581b05839a571c578e90060fff499f101",
-          "version": "2.1.1"
+          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
+          "version": "2.2.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "d79e33308b0ac83326b0ead0ea6446e604b8162d",
-          "version": "2.30.0"
+          "revision": "6aa9347d9bc5bbfe6a84983aec955c17ffea96ef",
+          "version": "2.33.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
-          "version": "1.8.0"
+          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
+          "version": "1.10.2"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "6363cdf6d2fb863e82434f3c4618f4e896e37569",
-          "version": "2.13.1"
+          "revision": "044f90dfa0a7015446b40f5e578b06343ae1affe",
+          "version": "2.16.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "657537c2cf1845f8d5201ecc4e48f21f21841128",
-          "version": "1.10.0"
+          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
+          "version": "1.11.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -126,12 +126,12 @@ let package = Package(
             targets: ["SmokeAWSMetrics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.8.5"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.9.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [
@@ -292,7 +292,6 @@ let package = Package(
         .target(
             name: "_SmokeAWSHttpConcurrency", dependencies: [
                 .target(name: "SmokeAWSHttp"),
-                .product(name: "_SmokeHTTPClientConcurrency", package: "smoke-http"),
             ]),
         .target(
             name: "SmokeAWSMetrics", dependencies: [

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://travis-ci.com/amzn/smoke-aws.svg?branch=master" alt="Build - Master Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4-orange.svg?style=flat" alt="Swift 5.2, 5.3 and 5.4 Tested">
+<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.2, 5.3, 5.4 and 5.5 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/Sources/SmokeAWSHttp/AWSClientProtocol+asyncSupport.swift
+++ b/Sources/SmokeAWSHttp/AWSClientProtocol+asyncSupport.swift
@@ -23,7 +23,6 @@ import NIO
 import NIOHTTP1
 import NIOTransportServices
 import AsyncHTTPClient
-import SmokeAWSHttp
 
 public extension AWSClientProtocol {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/SmokeAWSHttp/AWSClientProtocol+asyncSupport.swift
+++ b/Sources/SmokeAWSHttp/AWSClientProtocol+asyncSupport.swift
@@ -1,8 +1,21 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
-//  AWSClientProtocol.swift
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AWSClientProtocol+asyncSupport.swift
+//  SmokeAWSHttp
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import SmokeHTTPClient
 import SmokeAWSCore
@@ -11,7 +24,6 @@ import NIOHTTP1
 import NIOTransportServices
 import AsyncHTTPClient
 import SmokeAWSHttp
-import _SmokeHTTPClientConcurrency
 
 public extension AWSClientProtocol {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/SmokeAWSHttp/AWSQueryClientProtocol+asyncSupport.swift
+++ b/Sources/SmokeAWSHttp/AWSQueryClientProtocol+asyncSupport.swift
@@ -1,14 +1,26 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
-//  AWSClientProtocol.swift
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AWSQueryClientProtocol+asyncSupport.swift
+//  SmokeAWSHttp
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import SmokeHTTPClient
 import SmokeAWSCore
 import NIO
 import SmokeAWSHttp
-import _SmokeHTTPClientConcurrency
 
 public extension AWSQueryClientProtocol {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/SmokeAWSHttp/AWSQueryClientProtocol+asyncSupport.swift
+++ b/Sources/SmokeAWSHttp/AWSQueryClientProtocol+asyncSupport.swift
@@ -20,7 +20,6 @@
 import SmokeHTTPClient
 import SmokeAWSCore
 import NIO
-import SmokeAWSHttp
 
 public extension AWSQueryClientProtocol {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)

--- a/Sources/SmokeAWSHttp/MockClientProtocol+asyncSupport.swift
+++ b/Sources/SmokeAWSHttp/MockClientProtocol+asyncSupport.swift
@@ -18,7 +18,6 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 
 import NIO
-import SmokeAWSHttp
 
 /**
  Implementations for a mock service client.

--- a/Sources/SmokeAWSHttp/MockThrowingClientProtocol+asyncSupport.swift
+++ b/Sources/SmokeAWSHttp/MockThrowingClientProtocol+asyncSupport.swift
@@ -18,7 +18,6 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 
 import NIO
-import SmokeAWSHttp
 
 /**
  Implementations for a mock service client.

--- a/Sources/_SmokeAWSHttpConcurrency/Export.swift
+++ b/Sources/_SmokeAWSHttpConcurrency/Export.swift
@@ -1,0 +1,18 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  Export.swift
+//  _SmokeAWSHttpConcurrency
+//
+
+@_exported import SmokeAWSHttp


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Update CI and README for Swift 5.5
2. Move async function APIs into SmokeAWSHttp
3. Re-export SmokeAWSHttp as _SmokeAWSHttpConcurrency to avoid breaking anyone who imported the under-scored package.
4. Update swift-nio dependency.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
