### PR TITLE
Correctly exclude CloudWatch metric namespace from its dimensions

### DIFF
--- a/Sources/SmokeAWSMetrics/CloudWatchMetricsFactory.swift
+++ b/Sources/SmokeAWSMetrics/CloudWatchMetricsFactory.swift
@@ -121,7 +121,7 @@ public class CloudWatchMetricsFactory: MetricsFactory {
             namespace = theNamespace
             
             // don't include this in the cloudWatchDimensions
-            dimensionsMap[metricNameDimension] = nil
+            dimensionsMap[namespaceDimension] = nil
         } else {
             namespace = unknownNamespace
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
