### PR TITLE
Support async APIs on older Apple OSs.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,7 +20,7 @@ jobs:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
       - name: Build
-        run: swift build
+        run: swift build -c release
       - name: Run tests
         run: swift test
   OlderVersionBuild:
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.4.3", "5.3.3", "5.2.5"]
+        swift: ["5.4.3", "5.3.3"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
@@ -36,6 +36,6 @@ jobs:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
       - name: Build
-        run: swift build
+        run: swift build -c release
       - name: Run tests
         run: swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "c13504dd1724b30eefef588ba1bb9082b05fd681",
-          "version": "2.9.1"
+          "revision": "cc2ca1f0d64cfd0f543b23b4f1a95329943ed22c",
+          "version": "2.10.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -137,7 +137,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.9.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.10.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-aws/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.2, 5.3, 5.4 and 5.5 Tested">
+<img src="https://img.shields.io/badge/swift-5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.3, 5.4 and 5.5 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/Sources/SmokeAWSHttp/AWSClientProtocol+asyncSupport.swift
+++ b/Sources/SmokeAWSHttp/AWSClientProtocol+asyncSupport.swift
@@ -15,7 +15,7 @@
 //  SmokeAWSHttp
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import SmokeHTTPClient
 import SmokeAWSCore
@@ -25,7 +25,6 @@ import NIOTransportServices
 import AsyncHTTPClient
 
 public extension AWSClientProtocol {
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeWithoutOutput<InvocationReportingType: HTTPClientInvocationReporting,
                               InputType: HTTPRequestInputProtocol, ErrorType: ConvertableError>(
             httpClient: HTTPOperationsClient,
@@ -61,7 +60,6 @@ public extension AWSClientProtocol {
         }
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeWithOutput<OutputType: HTTPResponseOutputProtocol, InvocationReportingType: HTTPClientInvocationReporting,
                            InputType: HTTPRequestInputProtocol, ErrorType: ConvertableError>(
             httpClient: HTTPOperationsClient,

--- a/Sources/SmokeAWSHttp/MockClientProtocol+asyncSupport.swift
+++ b/Sources/SmokeAWSHttp/MockClientProtocol+asyncSupport.swift
@@ -15,7 +15,7 @@
 //  SmokeAWSHttp
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import NIO
 
@@ -36,7 +36,6 @@ import NIO
  */
 public extension MockClientProtocol {
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockAsyncAwareEventLoopFutureExecuteWithInputWithOutput<InputType, OutputType>(
             input: InputType,
             defaultResult: OutputType,
@@ -68,7 +67,6 @@ public extension MockClientProtocol {
         return promise.futureResult
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockExecuteWithInputWithOutput<InputType, OutputType>(
             input: InputType,
             defaultResult: OutputType,
@@ -86,7 +84,6 @@ public extension MockClientProtocol {
         return defaultResult
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockAsyncAwareEventLoopFutureExecuteWithInputWithoutOutput<InputType>(
             input: InputType,
             eventLoop: EventLoop,
@@ -117,7 +114,6 @@ public extension MockClientProtocol {
         return promise.futureResult
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockExecuteWithInputWithoutOutput<InputType>(
             input: InputType,
             eventLoop: EventLoop,
@@ -136,7 +132,6 @@ public extension MockClientProtocol {
         }
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockAsyncAwareEventLoopFutureExecuteWithoutInputWithOutput<OutputType>(
             defaultResult: OutputType,
             eventLoop: EventLoop,
@@ -167,7 +162,6 @@ public extension MockClientProtocol {
         return promise.futureResult
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockExecuteWithoutInputWithOutput<OutputType>(
             defaultResult: OutputType,
             eventLoop: EventLoop,
@@ -184,7 +178,6 @@ public extension MockClientProtocol {
         return defaultResult
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockAsyncAwareEventLoopFutureExecuteWithoutInputWithoutOutput(
             eventLoop: EventLoop,
             functionOverride: (() async throws -> ())?,
@@ -214,7 +207,6 @@ public extension MockClientProtocol {
         return promise.futureResult
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockExecuteWithoutInputWithoutOutput(
             eventLoop: EventLoop,
             functionOverride: (() async throws -> ())?,

--- a/Sources/SmokeAWSHttp/MockThrowingClientProtocol+asyncSupport.swift
+++ b/Sources/SmokeAWSHttp/MockThrowingClientProtocol+asyncSupport.swift
@@ -15,7 +15,7 @@
 //  SmokeAWSHttp
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import NIO
 
@@ -36,7 +36,6 @@ import NIO
  */
 public extension MockThrowingClientProtocol {
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockThrowingAsyncAwareEventLoopFutureExecuteWithInputWithOutput<InputType, OutputType>(
             input: InputType,
             defaultError: Error,
@@ -68,7 +67,6 @@ public extension MockThrowingClientProtocol {
         return promise.futureResult
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockThrowingExecuteWithInputWithOutput<InputType, OutputType>(
             input: InputType,
             defaultError: Error,
@@ -86,7 +84,6 @@ public extension MockThrowingClientProtocol {
         throw defaultError
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockThrowingAsyncAwareEventLoopFutureExecuteWithInputWithoutOutput<InputType>(
             input: InputType,
             defaultError: Error,
@@ -118,7 +115,6 @@ public extension MockThrowingClientProtocol {
         return promise.futureResult
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockThrowingExecuteWithInputWithoutOutput<InputType>(
             input: InputType,
             defaultError: Error,
@@ -140,7 +136,6 @@ public extension MockThrowingClientProtocol {
         throw defaultError
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockThrowingAsyncAwareEventLoopFutureExecuteWithoutInputWithOutput<OutputType>(
             defaultError: Error,
             eventLoop: EventLoop,
@@ -171,7 +166,6 @@ public extension MockThrowingClientProtocol {
         return promise.futureResult
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockThrowingExecuteWithoutInputWithOutput<OutputType>(
             defaultError: Error,
             eventLoop: EventLoop,
@@ -188,7 +182,6 @@ public extension MockThrowingClientProtocol {
         throw defaultError
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockThrowingAsyncAwareEventLoopFutureExecuteWithoutInputWithoutOutput(
             defaultError: Error,
             eventLoop: EventLoop,
@@ -219,7 +212,6 @@ public extension MockThrowingClientProtocol {
         return promise.futureResult
     }
     
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func mockThrowingExecuteWithoutInputWithoutOutput(
             defaultError: Error,
             eventLoop: EventLoop,

--- a/docs/Support_Policy.md
+++ b/docs/Support_Policy.md
@@ -24,11 +24,10 @@ SmokeAWS has two mechanism for removing support for Swift Toolchain versions-
 Once support has been removed, testing via continuous integration may be removed and no guarantees will be given for compiling the package using this version of the toolchain.
 
 Following these rules, the support level for different Swift Toolchain versions are-
-1. **Swift 5.1 and earlier**: No support.
-2. **Swift 5.2**: Supported for SmokeAWS 2.x. Support to be removed after 26th of October, 2021.
-3. **Swift 5.3**: Supported for SmokeAWS 2.x. Support to be removed after 20th of March, 2022.
-4. **Swift 5.4**: Supported for SmokeAWS 2.x.
-5. **Swift 5.5**: Supported for SmokeAWS 2.x.
+1. **Swift 5.2 and earlier**: No support.
+2. **Swift 5.3**: Supported for SmokeAWS 2.x. Support to be removed after 20th of March, 2022.
+3. **Swift 5.4**: Supported for SmokeAWS 2.x.
+4. **Swift 5.5**: Supported for SmokeAWS 2.x.
 
 # Runtime Support
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Remove Swift 5.2 from CI tests
2. Update support document to indicate no support for Swift 5.2
3. Remove `@available` annotation from async APIs, increase the requirement for non Linux platforms to the upcoming 5.5.2 (which will backport async support to the earlier Apple OSs).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
