### PR TITLE
Add async shutdown methods for CloudWatchMetricsFactory and S3Object.

### DIFF
--- a/Sources/SmokeAWSMetrics/CloudWatchMetricsFactory.swift
+++ b/Sources/SmokeAWSMetrics/CloudWatchMetricsFactory.swift
@@ -60,6 +60,12 @@ public class CloudWatchMetricsFactory: MetricsFactory {
         try self.cloudWatchPendingMetricsQueue.waitUntilShutdown()
     }
     
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    public func untilShutdown() async throws {
+        try await self.cloudWatchPendingMetricsQueue.untilShutdown()
+    }
+#endif
+    
     public static var logger: Logger {
         var newLogger = Logger(label: "com.amazon.SmokeAWS.SmokeAWSMetrics.CloudWatchMetricsFactory")
         newLogger[metadataKey: "lifecycle"] = "CloudWatchMetricsFactory"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add async shutdown methods for CloudWatchMetricsFactory and S3Object.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
