### PR TITLE
Add CI support for Swift 5.6, drop 5.3.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04]
-        swift: ["5.5"]
+        swift: ["5.6.1"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
+      - uses: fwal/setup-swift@v1.15.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -28,10 +28,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.4.3", "5.3.3"]
+        swift: ["5.5.3", "5.4.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
+      - uses: fwal/setup-swift@v1.15.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-aws/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.3, 5.4 and 5.5 Tested">
+<img src="https://img.shields.io/badge/swift-5.4|5.5|5.6-orange.svg?style=flat" alt="Swift 5.4, 5.5 and 5.6 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/docs/Support_Policy.md
+++ b/docs/Support_Policy.md
@@ -24,10 +24,10 @@ SmokeAWS has two mechanism for removing support for Swift Toolchain versions-
 Once support has been removed, testing via continuous integration may be removed and no guarantees will be given for compiling the package using this version of the toolchain.
 
 Following these rules, the support level for different Swift Toolchain versions are-
-1. **Swift 5.2 and earlier**: No support.
-2. **Swift 5.3**: Supported for SmokeAWS 2.x. Support to be removed after 20th of March, 2022.
-3. **Swift 5.4**: Supported for SmokeAWS 2.x.
+1. **Swift 5.3 and earlier**: No support.
+3. **Swift 5.4**: Supported for SmokeAWS 2.x. Support to be removed after 14th of September, 2022.
 4. **Swift 5.5**: Supported for SmokeAWS 2.x.
+4. **Swift 5.6**: Supported for SmokeAWS 2.x.
 
 # Runtime Support
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add CI support for Swift 5.6, drop 5.3.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
