### PR TITLE
Support large SNS payloads

### DIFF
--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
@@ -86,7 +86,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
                 endpointPort: Int = 443,
                 requiresTLS: Bool? = nil,
                 service: String = "sns",
-                contentType: String = "application/octet-stream",
+                contentType: String = "application/x-www-form-urlencoded; charset=utf-8",
                 apiVersion: String = "2010-03-31",
                 connectionTimeoutSeconds: Int64 = 10,
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
@@ -95,7 +95,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>() ) {
         let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: useTLS)
+        let clientDelegate = FormEncodedXMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(
             endpointHostName: endpointHostName,

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClientGenerator.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClientGenerator.swift
@@ -60,7 +60,7 @@ public struct AWSSimpleNotificationClientGenerator {
                 endpointPort: Int = 443,
                 requiresTLS: Bool? = nil,
                 service: String = "sns",
-                contentType: String = "application/octet-stream",
+                contentType: String = "application/x-www-form-urlencoded; charset=utf-8",
                 apiVersion: String = "2010-03-31",
                 connectionTimeoutSeconds: Int64 = 10,
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
@@ -69,7 +69,7 @@ public struct AWSSimpleNotificationClientGenerator {
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>
                     = SmokeAWSClientReportingConfiguration<SimpleNotificationModelOperations>() ) {
         let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
-        let clientDelegate = XMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: useTLS)
+        let clientDelegate = FormEncodedXMLAWSHttpClientDelegate<SimpleNotificationError>(requiresTLS: useTLS)
 
         self.httpClient = HTTPOperationsClient(
             endpointHostName: endpointHostName,

--- a/Sources/SmokeAWSHttp/FormEncodedXMLAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/FormEncodedXMLAWSHttpClientDelegate.swift
@@ -1,0 +1,139 @@
+// Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  FormEncodedXMLAWSHttpClientDelegate.swift
+//  SmokeAWSHttp
+//
+
+import Foundation
+import NIOHTTP1
+import NIOSSL
+import XMLCoding
+import SmokeAWSCore
+import SmokeHTTPClient
+import QueryCoding
+import HTTPHeadersCoding
+import HTTPPathCoding
+import AsyncHTTPClient
+
+/**
+ Struct conforming to the AWSHttpClientDelegate protocol that encodes request query items into the body and
+ decodes response body from XML. The generic ErrorType is used to generate errors based
+ on the decoding a XML error payload from the response body.
+ */
+public struct FormEncodedXMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClientDelegate {
+    private let clientDelegate: XMLAWSHttpClientDelegate<ErrorType>
+
+    private let inputQueryMapEncodingStrategy: QueryEncoder.MapEncodingStrategy
+    private let inputQueryListEncodingStrategy: QueryEncoder.ListEncodingStrategy
+    private let inputQueryKeyEncodingStrategy: QueryEncoder.KeyEncodingStrategy
+    private let inputQueryKeyEncodeTransformStrategy: QueryEncoder.KeyEncodeTransformStrategy
+
+    public init(requiresTLS: Bool, inputBodyRootKey: String? = nil,
+                outputListDecodingStrategy: XMLDecoder.ListDecodingStrategy? = nil,
+                outputMapDecodingStrategy: XMLDecoder.MapDecodingStrategy? = nil,
+                inputQueryMapDecodingStrategy: QueryEncoder.MapEncodingStrategy = .singleQueryEntry,
+                inputQueryListEncodingStrategy: QueryEncoder.ListEncodingStrategy = .expandListWithIndex,
+                inputQueryKeyEncodingStrategy: QueryEncoder.KeyEncodingStrategy = .useAsShapeSeparator("."),
+                inputQueryKeyEncodeTransformStrategy: QueryEncoder.KeyEncodeTransformStrategy = .none) {
+        self.clientDelegate = XMLAWSHttpClientDelegate<ErrorType>(
+            requiresTLS: requiresTLS,
+            inputBodyRootKey: inputBodyRootKey,
+            outputListDecodingStrategy: outputListDecodingStrategy,
+            outputMapDecodingStrategy: outputMapDecodingStrategy,
+            inputQueryMapDecodingStrategy: inputQueryMapDecodingStrategy,
+            inputQueryListEncodingStrategy: inputQueryListEncodingStrategy,
+            inputQueryKeyEncodingStrategy: inputQueryKeyEncodingStrategy,
+            inputQueryKeyEncodeTransformStrategy: inputQueryKeyEncodeTransformStrategy)
+
+        self.inputQueryMapEncodingStrategy = inputQueryMapDecodingStrategy
+        self.inputQueryListEncodingStrategy = inputQueryListEncodingStrategy
+        self.inputQueryKeyEncodingStrategy = inputQueryKeyEncodingStrategy
+        self.inputQueryKeyEncodeTransformStrategy = inputQueryKeyEncodeTransformStrategy
+    }
+
+    public func getResponseError<InvocationReportingType: HTTPClientInvocationReporting>(
+            response: HTTPClient.Response,
+            responseComponents: HTTPResponseComponents,
+            invocationReporting: InvocationReportingType) throws -> SmokeHTTPClient.HTTPClientError {
+        return try self.clientDelegate.getResponseError(response: response,
+                                                        responseComponents: responseComponents,
+                                                        invocationReporting: invocationReporting)
+    }
+
+    public func encodeInputAndQueryString<InputType, InvocationReportingType: HTTPClientInvocationReporting>(
+        input: InputType,
+        httpPath: String,
+        invocationReporting: InvocationReportingType) throws -> HTTPRequestComponents where InputType: HTTPRequestInputProtocol {
+            let pathPostfix = input.pathPostfix ?? ""
+
+            let pathTemplate = "\(httpPath)\(pathPostfix)"
+            let path: String
+            if let pathEncodable = input.pathEncodable {
+                path = try HTTPPathEncoder().encode(pathEncodable,
+                                                    withTemplate: pathTemplate)
+            } else {
+                path = pathTemplate
+            }
+
+            let additionalHeaders: [(String, String)]
+            if let additionalHeadersEncodable = input.additionalHeadersEncodable {
+                let headersEncoder = HTTPHeadersEncoder(keyEncodingStrategy: .noSeparator)
+                let headers = try headersEncoder.encode(additionalHeadersEncodable)
+
+                additionalHeaders = headers.compactMap { entry in
+                    guard let value = entry.1 else {
+                        return nil
+                    }
+
+                    return (entry.0, value)
+                }
+            } else {
+                additionalHeaders = []
+            }
+
+            guard let queryEncodable = input.queryEncodable else {
+                throw SmokeAWSError.invalidRequest("Input must be query encodable.")
+            }
+
+            let queryEncoder = QueryEncoder(
+                keyEncodingStrategy: self.inputQueryKeyEncodingStrategy,
+                mapEncodingStrategy: self.inputQueryMapEncodingStrategy,
+                listEncodingStrategy: self.inputQueryListEncodingStrategy,
+                keyEncodeTransformStrategy: self.inputQueryKeyEncodeTransformStrategy)
+
+            let encodedQuery = try queryEncoder.encode(queryEncodable,
+                                                       allowedCharacterSet: .uriAWSQueryValueAllowed)
+
+            guard !encodedQuery.isEmpty else {
+                throw SmokeAWSError.invalidRequest("Input must have query items.")
+            }
+
+            return HTTPRequestComponents(pathWithQuery: path,
+                                         additionalHeaders: additionalHeaders,
+                                         body: Data(encodedQuery.utf8))
+    }
+
+    public func decodeOutput<OutputType, InvocationReportingType: HTTPClientInvocationReporting>(
+            output: Data?,
+            headers: [(String, String)],
+            invocationReporting: InvocationReportingType) throws -> OutputType where OutputType: HTTPResponseOutputProtocol {
+        return try self.clientDelegate.decodeOutput(output: output,
+                                                    headers: headers,
+                                                    invocationReporting: invocationReporting)
+    }
+
+    public func getTLSConfiguration() -> TLSConfiguration? {
+        return self.clientDelegate.getTLSConfiguration()
+    }
+}

--- a/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
@@ -193,7 +193,7 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
             } else {
                 additionalHeaders = []
             }
-            
+
             let body: Data
             if let bodyEncodable = input.bodyEncodable {
                 let encoder = XMLEncoder.awsCompatibleEncoder()
@@ -207,7 +207,7 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
             } else {
                 body = Data()
             }
-            
+
             let query: String
             if let queryEncodable = input.queryEncodable {
                 let queryEncoder = QueryEncoder(
@@ -215,10 +215,10 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
                     mapEncodingStrategy: self.inputQueryMapEncodingStrategy,
                     listEncodingStrategy: self.inputQueryListEncodingStrategy,
                     keyEncodeTransformStrategy: self.inputQueryKeyEncodeTransformStrategy)
-  
+
                 let encodedQuery = try queryEncoder.encode(queryEncodable,
                                                            allowedCharacterSet: .uriAWSQueryValueAllowed)
-                
+
                 if !encodedQuery.isEmpty {
                     query = "?" + encodedQuery
                 } else {
@@ -227,7 +227,7 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
             } else {
                 query = ""
             }
-            
+
             let pathWithQuery = path + query
             
             return HTTPRequestComponents(pathWithQuery: pathWithQuery,


### PR DESCRIPTION
Current SNS sends message payload in request query string. This has a limitation of 16KB.

This change adds a new XML encoder that puts a query string into request body.

This PR is meant to gather feedback. There are some TODO items remaining.

TODO:
* The generator is not updated to override content-type to `application/x-www-form-urlencoded; charset=utf-8`
   * Added this functionality in this PR https://github.com/amzn/smoke-aws-generate/pull/59
* I tested SNS Publish and nothing else.
* I kept the change to SNS to limit the blast radius. However, I think SQS and other "query" services would have the same limitation. And may need the same solution. But it's a large scope. And I wanted to avoid that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
