### PR TITLE
Fix concurrency issue in the logger implementations.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "70826d038d5bdc3142a386b735792d87ef7a5dfc",
-          "version": "1.8.1"
+          "revision": "794dc9d42720af97cedd395e8cd2add9173ffd9a",
+          "version": "1.11.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "fba50e336245de832d81484e0514a92a8c8bf8bd",
-          "version": "2.12.0"
+          "revision": "17aa17451ac386da27c8acb85c79323b79dc5304",
+          "version": "2.13.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
-          "version": "1.1.6"
+          "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+          "version": "1.1.7"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
-          "version": "2.2.0"
+          "revision": "1c1408bf8fc21be93713e897d2badf500ea38419",
+          "version": "2.3.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "51c3fc2e4a0fcdf4a25089b288dd65b73df1b0ef",
-          "version": "2.37.0"
+          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
+          "version": "2.40.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-          "version": "1.10.2"
+          "revision": "a75e92bde3683241c15df3dd905b7a6dcac4d551",
+          "version": "1.12.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
-          "version": "1.19.1"
+          "revision": "108ac15087ea9b79abb6f6742699cf31de0e8772",
+          "version": "1.22.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "52a486ff6de9bc3e26bf634c5413c41c5fa89ca5",
-          "version": "2.17.2"
+          "revision": "c30c680c78c99afdabf84805a83c8745387c4ac7",
+          "version": "2.20.2"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
-          "version": "1.11.4"
+          "revision": "2cb54f91ddafc90832c5fa247faf5798d0a7c204",
+          "version": "1.13.0"
         }
       },
       {

--- a/Sources/SmokeAWSCore/CloudwatchJsonStandardErrorLogger.swift
+++ b/Sources/SmokeAWSCore/CloudwatchJsonStandardErrorLogger.swift
@@ -18,7 +18,6 @@
 import Foundation
 import Logging
 
-private var standardError = FileHandle.standardError
 private let sourcesSubString = "Sources/"
 
 /**
@@ -30,6 +29,7 @@ public struct CloudwatchJsonStandardErrorLogger: LogHandler {
     public var logLevel: Logger.Level
     
     private let jsonEncoder: JSONEncoder
+    private let stream: TextOutputStream
     
     private init(minimumLogLevel: Logger.Level) {
         self.logLevel = minimumLogLevel
@@ -39,6 +39,7 @@ public struct CloudwatchJsonStandardErrorLogger: LogHandler {
         theJsonEncoder.outputFormatting = [.sortedKeys]
         
         self.jsonEncoder = theJsonEncoder
+        self.stream = StdioOutputStream.stderr
     }
     
     public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
@@ -99,7 +100,8 @@ public struct CloudwatchJsonStandardErrorLogger: LogHandler {
         
         if let jsonData = try? self.jsonEncoder.encode(codableMetadata),
            let jsonMessage = String(data: jsonData, encoding: .utf8) {
-            print(jsonMessage)
+            var stream = self.stream
+            stream.write("\(jsonMessage)\n")
         }
     }
 }

--- a/Sources/SmokeAWSCore/CloudwatchStandardErrorLogger.swift
+++ b/Sources/SmokeAWSCore/CloudwatchStandardErrorLogger.swift
@@ -18,7 +18,6 @@
 import Foundation
 import Logging
 
-private var standardError = FileHandle.standardError
 private let sourcesSubString = "Sources/"
 
 /**
@@ -29,9 +28,12 @@ public struct CloudwatchStandardErrorLogger: LogHandler {
     public var metadata: Logger.Metadata
     public var logLevel: Logger.Level
     
+    private let stream: TextOutputStream
+    
     private init(minimumLogLevel: Logger.Level) {
         self.logLevel = minimumLogLevel
         self.metadata = [:]
+        self.stream = StdioOutputStream.stderr
     }
     
     public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
@@ -90,8 +92,8 @@ public struct CloudwatchStandardErrorLogger: LogHandler {
             tagString = ""
         }
         
-        print("\(shortFileName):\(line):\(function) [\(levelString)] \(tagString)\(message)",
-            to: &standardError)
+        var stream = self.stream
+        stream.write("\(shortFileName):\(line):\(function) [\(levelString)] \(tagString)\(message)\n")
     }
 }
 

--- a/Sources/SmokeAWSCore/StdioOutputStream.swift
+++ b/Sources/SmokeAWSCore/StdioOutputStream.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2018-2019 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+// Prevent name clashes
+#if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
+let systemStderr = Darwin.stderr
+let systemStdout = Darwin.stdout
+#elseif os(Windows)
+let systemStderr = CRT.stderr
+let systemStdout = CRT.stdout
+#elseif canImport(Glibc)
+let systemStderr = Glibc.stderr!
+let systemStdout = Glibc.stdout!
+#elseif canImport(WASILibc)
+let systemStderr = WASILibc.stderr!
+let systemStdout = WASILibc.stdout!
+#else
+#error("Unsupported runtime")
+#endif
+
+/// A wrapper to facilitate `print`-ing to stderr and stdio that
+/// ensures access to the underlying `FILE` is locked to prevent
+/// cross-thread interleaving of output.
+internal struct StdioOutputStream: TextOutputStream {
+    #if canImport(WASILibc)
+    internal let file: OpaquePointer
+    #else
+    internal let file: UnsafeMutablePointer<FILE>
+    #endif
+    internal let flushMode: FlushMode
+
+    internal func write(_ string: String) {
+        string.withCString { ptr in
+            #if os(Windows)
+            _lock_file(self.file)
+            #elseif canImport(WASILibc)
+            // no file locking on WASI
+            #else
+            flockfile(self.file)
+            #endif
+            defer {
+                #if os(Windows)
+                _unlock_file(self.file)
+                #elseif canImport(WASILibc)
+                // no file locking on WASI
+                #else
+                funlockfile(self.file)
+                #endif
+            }
+            _ = fputs(ptr, self.file)
+            if case .always = self.flushMode {
+                self.flush()
+            }
+        }
+    }
+
+    /// Flush the underlying stream.
+    /// This has no effect when using the `.always` flush mode, which is the default
+    internal func flush() {
+        _ = fflush(self.file)
+    }
+
+    internal static let stderr = StdioOutputStream(file: systemStderr, flushMode: .always)
+    internal static let stdout = StdioOutputStream(file: systemStdout, flushMode: .always)
+
+    /// Defines the flushing strategy for the underlying stream.
+    internal enum FlushMode {
+        case undefined
+        case always
+    }
+}

--- a/Sources/SmokeAWSHttp/AWSClientInvocationDelegate.swift
+++ b/Sources/SmokeAWSHttp/AWSClientInvocationDelegate.swift
@@ -56,12 +56,12 @@ public struct AWSClientInvocationDelegate : HTTPClientInvocationDelegate {
         var headersToBeSigned: [String: String] = [:]
         
         guard let operation = operation else {
-            logger.debug("Operation not found for HTTP header for \(service) request, no headers needed for signing.")
+            logger.trace("Operation not found for HTTP header for \(service) request, no headers needed for signing.")
             return headersToBeSigned
         }
         
         guard let target = target else {
-            logger.debug("Target not found for HTTP header, assigning \(operation) to x-amzn-target header.")
+            logger.trace("Target not found for HTTP header, assigning \(operation) to x-amzn-target header.")
             headersToBeSigned["x-amz-target"] = operation
             return headersToBeSigned
         }

--- a/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/DataAWSHttpClientDelegate.swift
@@ -66,7 +66,8 @@ public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
             cause = typedError
         } else {
             // Convert bodyData to a debug string only if debug logging is enabled
-            invocationReporting.logger.debug("Attempting to decode error data into XML: \(bodyData.debugString)")
+            invocationReporting.logger.trace("Attempting to decode error data from XML to \(ErrorType.self)",
+                                             metadata: ["body": "\(bodyData.debugString)"])
             
             cause = try ErrorWrapper<ErrorType>.errorFromBodyData(errorType: ErrorType.self, bodyData: bodyData)
         }
@@ -154,7 +155,8 @@ public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
             headers: [(String, String)],
             invocationReporting: InvocationReportingType) throws -> OutputType where OutputType: HTTPResponseOutputProtocol {
         // Convert output to a debug string only if debug logging is enabled
-        invocationReporting.logger.debug("Attempting to decode result data: \(output.debugString)")
+        invocationReporting.logger.trace("Attempting to decode result data to \(OutputType.self)",
+                                         metadata: ["body": "\(output.debugString)"])
         
         func bodyDecodableProvider() throws -> OutputType.BodyType {
             // we are expecting a response body

--- a/Sources/SmokeAWSHttp/HTTPClientDelegate+getErrorFromResponseAndBody.swift
+++ b/Sources/SmokeAWSHttp/HTTPClientDelegate+getErrorFromResponseAndBody.swift
@@ -36,7 +36,8 @@ extension HTTPClientDelegate {
         let bodyWithErrorTypeAsJSON = try JSONEncoder.awsCompatibleEncoder().encode(bodyAsStringDictionary)
         
         // Convert bodyWithErrorTypeAsJSON to a debug string only if debug logging is enabled
-        logger.debug("Attempting to decode error data into JSON: \(bodyWithErrorTypeAsJSON.debugString)")
+        logger.trace("Attempting to decode error data from JSON to \(ErrorType.self).",
+                     metadata: ["body": "\(bodyWithErrorTypeAsJSON.debugString)"])
         
         // attempt to get an error of Error type by decoding the body data
         return try JSONDecoder.awsCompatibleDecoder().decode(ErrorType.self, from: bodyWithErrorTypeAsJSON)

--- a/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/JSONAWSHttpClientDelegate.swift
@@ -60,7 +60,8 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
                                                     logger: invocationReporting.logger)
         } else {
             // Convert bodyData to a debug string only if debug logging is enabled
-            invocationReporting.logger.debug("Attempting to decode error data into JSON: \(bodyData.debugString)")
+            invocationReporting.logger.trace("Attempting to decode error data from JSON to \(ErrorType.self)",
+                                             metadata: ["body": "\(bodyData.debugString)"])
             
             // attempt to get an error of Error type by decoding the body data
             cause = try JSONDecoder.awsCompatibleDecoder().decode(ErrorType.self, from: bodyData)
@@ -146,7 +147,8 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
             headers: [(String, String)],
             invocationReporting: InvocationReportingType) throws -> OutputType where OutputType: HTTPResponseOutputProtocol {
         // Convert output to a debug string only if debug logging is enabled
-        invocationReporting.logger.debug("Attempting to decode result data into JSON: \(output.debugString)")
+        invocationReporting.logger.trace("Attempting to decode result data from JSON to \(OutputType.self)",
+                                         metadata: ["body": "\(output.debugString)"])
         
         func bodyDecodableProvider() throws -> OutputType.BodyType {
             // we are expecting a response body

--- a/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
+++ b/Sources/SmokeAWSHttp/XMLAWSHttpClientDelegate.swift
@@ -156,7 +156,8 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
         }
         
         // Convert bodyData to a debug string only if debug logging is enabled
-        invocationReporting.logger.debug("Attempting to decode error data into XML: \(bodyData.debugString)")
+        invocationReporting.logger.trace("Attempting to decode error data from XML to \(ErrorType.self)",
+                                         metadata: ["body": "\(bodyData.debugString)"])
         
         let cause = try ErrorWrapper<ErrorType>.errorFromBodyData(errorType: ErrorType.self, bodyData: bodyData)
         
@@ -250,7 +251,8 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
         }
         
         // Convert output to a debug string only if debug logging is enabled
-        invocationReporting.logger.debug("Attempting to decode result data into XML: \(output.debugString)")
+        invocationReporting.logger.trace("Attempting to decode result data from XML to \(OutputType.self)",
+                                         metadata: ["body": "\(output.debugString)"])
         
         func bodyDecodableProvider() throws -> OutputType.BodyType {
             // we are expecting a response body


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Avoids potential interleaving of log messages from different threads. This uses the same file-locking mechanism as swift-log to achieve this
2. Reduce the severity of log messages emitted and structure logs messages using metadata. This will avoid emitting log when the level is debug or greater.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
