### PR TITLE
Add option to enable/disable pretty printing in awsCompatibleEncoder

### DIFF
--- a/Sources/SmokeAWSCore/JSONDecoder+awsCompatibleEncoder.swift
+++ b/Sources/SmokeAWSCore/JSONDecoder+awsCompatibleEncoder.swift
@@ -17,20 +17,22 @@
 
 import Foundation
 
-private func createEncoder() -> JSONEncoder {
+private func createEncoder(withPrettyPrinting: Bool = true) -> JSONEncoder {
     let jsonEncoder = JSONEncoder()
     if #available(OSX 10.12, *) {
         jsonEncoder.dateEncodingStrategy = .iso8601
     }
 
-    jsonEncoder.outputFormatting = .prettyPrinted
+    if withPrettyPrinting {
+        jsonEncoder.outputFormatting = .prettyPrinted
+    }
     
     return jsonEncoder
 }
 
 public extension JSONEncoder {
     /// Return a AWS compatible JSON Encoder
-    static func awsCompatibleEncoder() -> JSONEncoder {
-        return createEncoder()
+    static func awsCompatibleEncoder(withPrettyPrinting: Bool = true) -> JSONEncoder {
+        return createEncoder(withPrettyPrinting: withPrettyPrinting)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds option to enable or disable pretty printing in the `awsCompatibleEncoder`. By default pretty printing will be enabled but this allows clients to disable pretty printing if needed (in the case of reducing JSON payload size).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
