### PR TITLE
Make BatchStatementError hashable

### DIFF
--- a/Sources/DynamoDBModel/DynamoDBModelStructures.swift
+++ b/Sources/DynamoDBModel/DynamoDBModelStructures.swift
@@ -536,7 +536,7 @@ public struct BatchGetItemOutput: Codable, Equatable {
     }
 }
 
-public struct BatchStatementError: Codable, Equatable {
+public struct BatchStatementError: Codable, Equatable, Hashable {
     public var code: BatchStatementErrorCodeEnum?
     public var message: String?
 
@@ -549,6 +549,11 @@ public struct BatchStatementError: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case code = "Code"
         case message = "Message"
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.code)
+        hasher.combine(self.message)
     }
 
     public func validate() throws {


### PR DESCRIPTION

*Description of changes:*

Make BatchStatementError Hashable. The db batch statement throws errors, the message and code is pair unique.. Make it hash-able to avoid duplication

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
