### PR TITLE
Revert hashable batch error, add extension file 

### DIFF
--- a/Sources/DynamoDBModel/DynamoDBModelStructures+extension.swift
+++ b/Sources/DynamoDBModel/DynamoDBModelStructures+extension.swift
@@ -1,0 +1,28 @@
+// Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
+// swiftlint:disable type_body_length function_body_length generic_type_name cyclomatic_complexity
+// -- Generated Code; do not edit --
+//
+// DynamoDBModelStructures+extension.swift
+// DynamoDBModel
+//
+
+extension BatchStatementError: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.code)
+        hasher.combine(self.message)
+    }
+}

--- a/Sources/DynamoDBModel/DynamoDBModelStructures.swift
+++ b/Sources/DynamoDBModel/DynamoDBModelStructures.swift
@@ -536,7 +536,7 @@ public struct BatchGetItemOutput: Codable, Equatable {
     }
 }
 
-public struct BatchStatementError: Codable, Equatable, Hashable {
+public struct BatchStatementError: Codable, Equatable {
     public var code: BatchStatementErrorCodeEnum?
     public var message: String?
 
@@ -549,11 +549,6 @@ public struct BatchStatementError: Codable, Equatable, Hashable {
     enum CodingKeys: String, CodingKey {
         case code = "Code"
         case message = "Message"
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.code)
-        hasher.combine(self.message)
     }
 
     public func validate() throws {


### PR DESCRIPTION
This reverts commit 013e04525fc65482d9624caa4fb63aca7c326f7a.

*Description of changes:*

Modified auto-generated code. Revert changes, and add extension file


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
