### PR TITLE
updated swift-http for swift 5.8

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "7a38547e6ef16b53238ac2b41340cd00c07caa93",
-          "version": "2.15.0"
+          "revision": "f0a8debc8048afd30540ea3f2c80e3486530aa17",
+          "version": "2.19.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -137,7 +137,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.12.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.19.1"),
         .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Swift 5.8 introduced compilation errors and warnings. Updating smoke-http to 2.19.1 fixes them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
