### PR TITLE
Add page size parameter to ListFolder

### DIFF
--- a/Sources/S3Client/S3ClientProtocolV2+listFolder.swift
+++ b/Sources/S3Client/S3ClientProtocolV2+listFolder.swift
@@ -13,7 +13,8 @@ public extension S3ClientProtocolV2 {
     // with the same prefix in the "folder" will be returned.
     func listFolder(
         for objectIdentifier: S3ObjectIdentifier,
-        fileNamePrefixProvider: (String) throws -> String = { _ in "" }) async throws
+        fileNamePrefixProvider: (String) throws -> String = { _ in "" },
+        pageSize: Int? = nil) async throws
     -> [S3ObjectIdentifier] {
         let bucketName = objectIdentifier.bucketName
         let s3Folder = try objectIdentifier.parentPath ?? ""
@@ -27,6 +28,7 @@ public extension S3ClientProtocolV2 {
             let request = ListObjectsV2Request(
                 bucket: bucketName,
                 continuationToken: nextToken,
+                maxKeys: pageSize,
                 prefix: listBucketPrefix)
             let response = try await self.listObjectsV2(input: request)
 

--- a/Tests/S3ClientTests/S3ClientTests.swift
+++ b/Tests/S3ClientTests/S3ClientTests.swift
@@ -325,7 +325,7 @@ class S3ClientTests: XCTestCase {
         )
     }
 
-    func testListFolder_withPaging() async throws {
+    func testListFolder_withPagination() async throws {
         var listObjectsCallCount = 0
         func listObjects(input: ListObjectsV2Request) -> ListObjectsV2Output {
             if listObjectsCallCount > 0 {
@@ -334,6 +334,7 @@ class S3ClientTests: XCTestCase {
                 XCTAssertNil(input.continuationToken)
             }
 
+            XCTAssertEqual(input.maxKeys, 1)
             listObjectsCallCount += 1
 
             let nextToken: NextToken?
@@ -352,7 +353,7 @@ class S3ClientTests: XCTestCase {
         let client = MockS3ClientV2(listObjectsV2: listObjects)
 
         let originalObject = S3ObjectIdentifier(bucketName: "my-bucket", keyPath: "a/b/c/d.ext")
-        let folderObjects = try await client.listFolder(for: originalObject)
+        let folderObjects = try await client.listFolder(for: originalObject, pageSize: 1)
 
         XCTAssertEqual(listObjectsCallCount, 50)
         XCTAssertEqual(folderObjects.count, 50)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add optional page size parameter to `ListFolder` utility function. When not provided, the page size will be the default for the `ListObjectsV2` operation - 1000 items.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
