### PR TITLE
Use AWSClientInvocationDelegate convenience function.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ jobs:
   run-codeql-linux:
     name: Run CodeQL on Linux
     runs-on: ubuntu-latest
+    container: swift:5.8
     permissions:
       security-events: write
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        swift: ["5.8"]
+        swift: ["5.9"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.23.0
+      - uses: swift-actions/setup-swift@v1.25.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -28,10 +28,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.7.3"]
+        swift: ["5.8.1", "5.7.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.23.0
+      - uses: swift-actions/setup-swift@v1.25.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws-support.git",
         "state": {
           "branch": null,
-          "revision": "276620e7599e94b680cfc2b1c2285e0016850860",
-          "version": "1.2.2"
+          "revision": "c46cd7e8b8f32d6629d57a8b2b58d6622bd898be",
+          "version": "1.7.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "3ec0cea2402f4c16303a4378f62eae8a83d0ee12",
-          "version": "2.20.0"
+          "revision": "d37f4c40e3f00a880fc09b7927f8a2fbf4c5d018",
+          "version": "2.22.5"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -144,7 +144,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
         .package(url: "https://github.com/amzn/smoke-http.git", from: "2.19.1"),
-        .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.0.0"),
+        .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.7.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-aws/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.7|5.8-orange.svg?style=flat" alt="Swift 5.7 and 5.8 Tested">
+<img src="https://img.shields.io/badge/swift-5.7|5.8-orange.svg?style=flat" alt="Swift 5.7, 5.8 and 5.9 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-20.04|22.04-yellow.svg?style=flat" alt="Ubuntu 20.04 and 22.04 Tested">
 <a href="https://gitter.im/SmokeServerSide">

--- a/Sources/AppConfigClient/AWSAppConfigClient.swift
+++ b/Sources/AppConfigClient/AWSAppConfigClient.swift
@@ -3158,7 +3158,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func createApplication(
             input: AppConfigModel.CreateApplicationRequest) async throws -> AppConfigModel.Application {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3194,7 +3194,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func createConfigurationProfile(
             input: AppConfigModel.CreateConfigurationProfileRequest) async throws -> AppConfigModel.ConfigurationProfile {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3230,7 +3230,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func createDeploymentStrategy(
             input: AppConfigModel.CreateDeploymentStrategyRequest) async throws -> AppConfigModel.DeploymentStrategy {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3266,7 +3266,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func createEnvironment(
             input: AppConfigModel.CreateEnvironmentRequest) async throws -> AppConfigModel.Environment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3302,7 +3302,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func createExtension(
             input: AppConfigModel.CreateExtensionRequest) async throws -> AppConfigModel.Extension {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3338,7 +3338,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func createExtensionAssociation(
             input: AppConfigModel.CreateExtensionAssociationRequest) async throws -> AppConfigModel.ExtensionAssociation {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3374,7 +3374,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func createHostedConfigurationVersion(
             input: AppConfigModel.CreateHostedConfigurationVersionRequest) async throws -> AppConfigModel.HostedConfigurationVersion {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3408,7 +3408,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func deleteApplication(
             input: AppConfigModel.DeleteApplicationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3442,7 +3442,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func deleteConfigurationProfile(
             input: AppConfigModel.DeleteConfigurationProfileRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3476,7 +3476,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func deleteDeploymentStrategy(
             input: AppConfigModel.DeleteDeploymentStrategyRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3510,7 +3510,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func deleteEnvironment(
             input: AppConfigModel.DeleteEnvironmentRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3544,7 +3544,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func deleteExtension(
             input: AppConfigModel.DeleteExtensionRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3578,7 +3578,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func deleteExtensionAssociation(
             input: AppConfigModel.DeleteExtensionAssociationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3612,7 +3612,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func deleteHostedConfigurationVersion(
             input: AppConfigModel.DeleteHostedConfigurationVersionRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3648,7 +3648,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getApplication(
             input: AppConfigModel.GetApplicationRequest) async throws -> AppConfigModel.Application {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3684,7 +3684,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getConfiguration(
             input: AppConfigModel.GetConfigurationRequest) async throws -> AppConfigModel.Configuration {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3720,7 +3720,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getConfigurationProfile(
             input: AppConfigModel.GetConfigurationProfileRequest) async throws -> AppConfigModel.ConfigurationProfile {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3756,7 +3756,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getDeployment(
             input: AppConfigModel.GetDeploymentRequest) async throws -> AppConfigModel.Deployment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3792,7 +3792,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getDeploymentStrategy(
             input: AppConfigModel.GetDeploymentStrategyRequest) async throws -> AppConfigModel.DeploymentStrategy {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3828,7 +3828,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getEnvironment(
             input: AppConfigModel.GetEnvironmentRequest) async throws -> AppConfigModel.Environment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3864,7 +3864,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getExtension(
             input: AppConfigModel.GetExtensionRequest) async throws -> AppConfigModel.Extension {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3900,7 +3900,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getExtensionAssociation(
             input: AppConfigModel.GetExtensionAssociationRequest) async throws -> AppConfigModel.ExtensionAssociation {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3936,7 +3936,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getHostedConfigurationVersion(
             input: AppConfigModel.GetHostedConfigurationVersionRequest) async throws -> AppConfigModel.HostedConfigurationVersion {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3972,7 +3972,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listApplications(
             input: AppConfigModel.ListApplicationsRequest) async throws -> AppConfigModel.Applications {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4008,7 +4008,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listConfigurationProfiles(
             input: AppConfigModel.ListConfigurationProfilesRequest) async throws -> AppConfigModel.ConfigurationProfiles {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4044,7 +4044,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listDeploymentStrategies(
             input: AppConfigModel.ListDeploymentStrategiesRequest) async throws -> AppConfigModel.DeploymentStrategies {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4080,7 +4080,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listDeployments(
             input: AppConfigModel.ListDeploymentsRequest) async throws -> AppConfigModel.Deployments {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4116,7 +4116,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listEnvironments(
             input: AppConfigModel.ListEnvironmentsRequest) async throws -> AppConfigModel.Environments {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4152,7 +4152,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listExtensionAssociations(
             input: AppConfigModel.ListExtensionAssociationsRequest) async throws -> AppConfigModel.ExtensionAssociations {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4188,7 +4188,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listExtensions(
             input: AppConfigModel.ListExtensionsRequest) async throws -> AppConfigModel.Extensions {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4224,7 +4224,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listHostedConfigurationVersions(
             input: AppConfigModel.ListHostedConfigurationVersionsRequest) async throws -> AppConfigModel.HostedConfigurationVersions {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4260,7 +4260,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listTagsForResource(
             input: AppConfigModel.ListTagsForResourceRequest) async throws -> AppConfigModel.ResourceTags {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4296,7 +4296,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func startDeployment(
             input: AppConfigModel.StartDeploymentRequest) async throws -> AppConfigModel.Deployment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4332,7 +4332,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func stopDeployment(
             input: AppConfigModel.StopDeploymentRequest) async throws -> AppConfigModel.Deployment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4366,7 +4366,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func tagResource(
             input: AppConfigModel.TagResourceRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4400,7 +4400,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func untagResource(
             input: AppConfigModel.UntagResourceRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4436,7 +4436,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func updateApplication(
             input: AppConfigModel.UpdateApplicationRequest) async throws -> AppConfigModel.Application {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4472,7 +4472,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func updateConfigurationProfile(
             input: AppConfigModel.UpdateConfigurationProfileRequest) async throws -> AppConfigModel.ConfigurationProfile {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4508,7 +4508,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func updateDeploymentStrategy(
             input: AppConfigModel.UpdateDeploymentStrategyRequest) async throws -> AppConfigModel.DeploymentStrategy {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4544,7 +4544,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func updateEnvironment(
             input: AppConfigModel.UpdateEnvironmentRequest) async throws -> AppConfigModel.Environment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4580,7 +4580,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func updateExtension(
             input: AppConfigModel.UpdateExtensionRequest) async throws -> AppConfigModel.Extension {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4616,7 +4616,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func updateExtensionAssociation(
             input: AppConfigModel.UpdateExtensionAssociationRequest) async throws -> AppConfigModel.ExtensionAssociation {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4650,7 +4650,7 @@ public struct AWSAppConfigClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func validateConfiguration(
             input: AppConfigModel.ValidateConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/CloudWatchClient/AWSCloudWatchClient.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClient.swift
@@ -3118,7 +3118,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func deleteAlarms(
             input: CloudWatchModel.DeleteAlarmsInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3158,7 +3158,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func deleteAnomalyDetector(
             input: CloudWatchModel.DeleteAnomalyDetectorInput) async throws -> CloudWatchModel.DeleteAnomalyDetectorOutputForDeleteAnomalyDetector {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3198,7 +3198,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func deleteDashboards(
             input: CloudWatchModel.DeleteDashboardsInput) async throws -> CloudWatchModel.DeleteDashboardsOutputForDeleteDashboards {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3238,7 +3238,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func deleteInsightRules(
             input: CloudWatchModel.DeleteInsightRulesInput) async throws -> CloudWatchModel.DeleteInsightRulesOutputForDeleteInsightRules {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3278,7 +3278,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func deleteMetricStream(
             input: CloudWatchModel.DeleteMetricStreamInput) async throws -> CloudWatchModel.DeleteMetricStreamOutputForDeleteMetricStream {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3318,7 +3318,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func describeAlarmHistory(
             input: CloudWatchModel.DescribeAlarmHistoryInput) async throws -> CloudWatchModel.DescribeAlarmHistoryOutputForDescribeAlarmHistory {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3358,7 +3358,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func describeAlarms(
             input: CloudWatchModel.DescribeAlarmsInput) async throws -> CloudWatchModel.DescribeAlarmsOutputForDescribeAlarms {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3397,7 +3397,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func describeAlarmsForMetric(
             input: CloudWatchModel.DescribeAlarmsForMetricInput) async throws -> CloudWatchModel.DescribeAlarmsForMetricOutputForDescribeAlarmsForMetric {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3437,7 +3437,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func describeAnomalyDetectors(
             input: CloudWatchModel.DescribeAnomalyDetectorsInput) async throws -> CloudWatchModel.DescribeAnomalyDetectorsOutputForDescribeAnomalyDetectors {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3477,7 +3477,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func describeInsightRules(
             input: CloudWatchModel.DescribeInsightRulesInput) async throws -> CloudWatchModel.DescribeInsightRulesOutputForDescribeInsightRules {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3514,7 +3514,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func disableAlarmActions(
             input: CloudWatchModel.DisableAlarmActionsInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3554,7 +3554,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func disableInsightRules(
             input: CloudWatchModel.DisableInsightRulesInput) async throws -> CloudWatchModel.DisableInsightRulesOutputForDisableInsightRules {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3591,7 +3591,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func enableAlarmActions(
             input: CloudWatchModel.EnableAlarmActionsInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3631,7 +3631,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func enableInsightRules(
             input: CloudWatchModel.EnableInsightRulesInput) async throws -> CloudWatchModel.EnableInsightRulesOutputForEnableInsightRules {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3671,7 +3671,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func getDashboard(
             input: CloudWatchModel.GetDashboardInput) async throws -> CloudWatchModel.GetDashboardOutputForGetDashboard {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3711,7 +3711,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func getInsightRuleReport(
             input: CloudWatchModel.GetInsightRuleReportInput) async throws -> CloudWatchModel.GetInsightRuleReportOutputForGetInsightRuleReport {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3751,7 +3751,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func getMetricData(
             input: CloudWatchModel.GetMetricDataInput) async throws -> CloudWatchModel.GetMetricDataOutputForGetMetricData {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3791,7 +3791,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func getMetricStatistics(
             input: CloudWatchModel.GetMetricStatisticsInput) async throws -> CloudWatchModel.GetMetricStatisticsOutputForGetMetricStatistics {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3831,7 +3831,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func getMetricStream(
             input: CloudWatchModel.GetMetricStreamInput) async throws -> CloudWatchModel.GetMetricStreamOutputForGetMetricStream {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3870,7 +3870,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func getMetricWidgetImage(
             input: CloudWatchModel.GetMetricWidgetImageInput) async throws -> CloudWatchModel.GetMetricWidgetImageOutputForGetMetricWidgetImage {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3910,7 +3910,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func listDashboards(
             input: CloudWatchModel.ListDashboardsInput) async throws -> CloudWatchModel.ListDashboardsOutputForListDashboards {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3950,7 +3950,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func listManagedInsightRules(
             input: CloudWatchModel.ListManagedInsightRulesInput) async throws -> CloudWatchModel.ListManagedInsightRulesOutputForListManagedInsightRules {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3990,7 +3990,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func listMetricStreams(
             input: CloudWatchModel.ListMetricStreamsInput) async throws -> CloudWatchModel.ListMetricStreamsOutputForListMetricStreams {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4030,7 +4030,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func listMetrics(
             input: CloudWatchModel.ListMetricsInput) async throws -> CloudWatchModel.ListMetricsOutputForListMetrics {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4070,7 +4070,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func listTagsForResource(
             input: CloudWatchModel.ListTagsForResourceInput) async throws -> CloudWatchModel.ListTagsForResourceOutputForListTagsForResource {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4110,7 +4110,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func putAnomalyDetector(
             input: CloudWatchModel.PutAnomalyDetectorInput) async throws -> CloudWatchModel.PutAnomalyDetectorOutputForPutAnomalyDetector {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4148,7 +4148,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func putCompositeAlarm(
             input: CloudWatchModel.PutCompositeAlarmInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4188,7 +4188,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func putDashboard(
             input: CloudWatchModel.PutDashboardInput) async throws -> CloudWatchModel.PutDashboardOutputForPutDashboard {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4228,7 +4228,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func putInsightRule(
             input: CloudWatchModel.PutInsightRuleInput) async throws -> CloudWatchModel.PutInsightRuleOutputForPutInsightRule {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4268,7 +4268,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func putManagedInsightRules(
             input: CloudWatchModel.PutManagedInsightRulesInput) async throws -> CloudWatchModel.PutManagedInsightRulesOutputForPutManagedInsightRules {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4306,7 +4306,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func putMetricAlarm(
             input: CloudWatchModel.PutMetricAlarmInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4344,7 +4344,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func putMetricData(
             input: CloudWatchModel.PutMetricDataInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4384,7 +4384,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func putMetricStream(
             input: CloudWatchModel.PutMetricStreamInput) async throws -> CloudWatchModel.PutMetricStreamOutputForPutMetricStream {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4422,7 +4422,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func setAlarmState(
             input: CloudWatchModel.SetAlarmStateInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4462,7 +4462,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func startMetricStreams(
             input: CloudWatchModel.StartMetricStreamsInput) async throws -> CloudWatchModel.StartMetricStreamsOutputForStartMetricStreams {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4502,7 +4502,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func stopMetricStreams(
             input: CloudWatchModel.StopMetricStreamsInput) async throws -> CloudWatchModel.StopMetricStreamsOutputForStopMetricStreams {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4542,7 +4542,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func tagResource(
             input: CloudWatchModel.TagResourceInput) async throws -> CloudWatchModel.TagResourceOutputForTagResource {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4582,7 +4582,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
      */
     public func untagResource(
             input: CloudWatchModel.UntagResourceInput) async throws -> CloudWatchModel.UntagResourceOutputForUntagResource {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/CloudformationClient/AWSCloudformationClient.swift
+++ b/Sources/CloudformationClient/AWSCloudformationClient.swift
@@ -5591,7 +5591,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func activateOrganizationsAccess(
             input: CloudformationModel.ActivateOrganizationsAccessInput) async throws -> CloudformationModel.ActivateOrganizationsAccessOutputForActivateOrganizationsAccess {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5631,7 +5631,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func activateType(
             input: CloudformationModel.ActivateTypeInput) async throws -> CloudformationModel.ActivateTypeOutputForActivateType {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5671,7 +5671,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func batchDescribeTypeConfigurations(
             input: CloudformationModel.BatchDescribeTypeConfigurationsInput) async throws -> CloudformationModel.BatchDescribeTypeConfigurationsOutputForBatchDescribeTypeConfigurations {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5709,7 +5709,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func cancelUpdateStack(
             input: CloudformationModel.CancelUpdateStackInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5749,7 +5749,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func continueUpdateRollback(
             input: CloudformationModel.ContinueUpdateRollbackInput) async throws -> CloudformationModel.ContinueUpdateRollbackOutputForContinueUpdateRollback {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5789,7 +5789,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func createChangeSet(
             input: CloudformationModel.CreateChangeSetInput) async throws -> CloudformationModel.CreateChangeSetOutputForCreateChangeSet {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5829,7 +5829,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func createStack(
             input: CloudformationModel.CreateStackInput) async throws -> CloudformationModel.CreateStackOutputForCreateStack {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5869,7 +5869,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func createStackInstances(
             input: CloudformationModel.CreateStackInstancesInput) async throws -> CloudformationModel.CreateStackInstancesOutputForCreateStackInstances {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5909,7 +5909,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func createStackSet(
             input: CloudformationModel.CreateStackSetInput) async throws -> CloudformationModel.CreateStackSetOutputForCreateStackSet {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5949,7 +5949,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func deactivateOrganizationsAccess(
             input: CloudformationModel.DeactivateOrganizationsAccessInput) async throws -> CloudformationModel.DeactivateOrganizationsAccessOutputForDeactivateOrganizationsAccess {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5989,7 +5989,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func deactivateType(
             input: CloudformationModel.DeactivateTypeInput) async throws -> CloudformationModel.DeactivateTypeOutputForDeactivateType {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6029,7 +6029,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func deleteChangeSet(
             input: CloudformationModel.DeleteChangeSetInput) async throws -> CloudformationModel.DeleteChangeSetOutputForDeleteChangeSet {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6067,7 +6067,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func deleteStack(
             input: CloudformationModel.DeleteStackInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6107,7 +6107,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func deleteStackInstances(
             input: CloudformationModel.DeleteStackInstancesInput) async throws -> CloudformationModel.DeleteStackInstancesOutputForDeleteStackInstances {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6147,7 +6147,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func deleteStackSet(
             input: CloudformationModel.DeleteStackSetInput) async throws -> CloudformationModel.DeleteStackSetOutputForDeleteStackSet {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6187,7 +6187,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func deregisterType(
             input: CloudformationModel.DeregisterTypeInput) async throws -> CloudformationModel.DeregisterTypeOutputForDeregisterType {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6226,7 +6226,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeAccountLimits(
             input: CloudformationModel.DescribeAccountLimitsInput) async throws -> CloudformationModel.DescribeAccountLimitsOutputForDescribeAccountLimits {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6266,7 +6266,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeChangeSet(
             input: CloudformationModel.DescribeChangeSetInput) async throws -> CloudformationModel.DescribeChangeSetOutputForDescribeChangeSet {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6306,7 +6306,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeChangeSetHooks(
             input: CloudformationModel.DescribeChangeSetHooksInput) async throws -> CloudformationModel.DescribeChangeSetHooksOutputForDescribeChangeSetHooks {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6346,7 +6346,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeOrganizationsAccess(
             input: CloudformationModel.DescribeOrganizationsAccessInput) async throws -> CloudformationModel.DescribeOrganizationsAccessOutputForDescribeOrganizationsAccess {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6386,7 +6386,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describePublisher(
             input: CloudformationModel.DescribePublisherInput) async throws -> CloudformationModel.DescribePublisherOutputForDescribePublisher {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6425,7 +6425,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeStackDriftDetectionStatus(
             input: CloudformationModel.DescribeStackDriftDetectionStatusInput) async throws -> CloudformationModel.DescribeStackDriftDetectionStatusOutputForDescribeStackDriftDetectionStatus {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6464,7 +6464,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeStackEvents(
             input: CloudformationModel.DescribeStackEventsInput) async throws -> CloudformationModel.DescribeStackEventsOutputForDescribeStackEvents {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6504,7 +6504,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeStackInstance(
             input: CloudformationModel.DescribeStackInstanceInput) async throws -> CloudformationModel.DescribeStackInstanceOutputForDescribeStackInstance {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6543,7 +6543,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeStackResource(
             input: CloudformationModel.DescribeStackResourceInput) async throws -> CloudformationModel.DescribeStackResourceOutputForDescribeStackResource {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6582,7 +6582,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeStackResourceDrifts(
             input: CloudformationModel.DescribeStackResourceDriftsInput) async throws -> CloudformationModel.DescribeStackResourceDriftsOutputForDescribeStackResourceDrifts {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6621,7 +6621,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeStackResources(
             input: CloudformationModel.DescribeStackResourcesInput) async throws -> CloudformationModel.DescribeStackResourcesOutputForDescribeStackResources {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6661,7 +6661,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeStackSet(
             input: CloudformationModel.DescribeStackSetInput) async throws -> CloudformationModel.DescribeStackSetOutputForDescribeStackSet {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6701,7 +6701,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeStackSetOperation(
             input: CloudformationModel.DescribeStackSetOperationInput) async throws -> CloudformationModel.DescribeStackSetOperationOutputForDescribeStackSetOperation {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6740,7 +6740,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeStacks(
             input: CloudformationModel.DescribeStacksInput) async throws -> CloudformationModel.DescribeStacksOutputForDescribeStacks {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6780,7 +6780,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeType(
             input: CloudformationModel.DescribeTypeInput) async throws -> CloudformationModel.DescribeTypeOutputForDescribeType {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6820,7 +6820,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeTypeRegistration(
             input: CloudformationModel.DescribeTypeRegistrationInput) async throws -> CloudformationModel.DescribeTypeRegistrationOutputForDescribeTypeRegistration {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6859,7 +6859,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func detectStackDrift(
             input: CloudformationModel.DetectStackDriftInput) async throws -> CloudformationModel.DetectStackDriftOutputForDetectStackDrift {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6898,7 +6898,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func detectStackResourceDrift(
             input: CloudformationModel.DetectStackResourceDriftInput) async throws -> CloudformationModel.DetectStackResourceDriftOutputForDetectStackResourceDrift {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6938,7 +6938,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func detectStackSetDrift(
             input: CloudformationModel.DetectStackSetDriftInput) async throws -> CloudformationModel.DetectStackSetDriftOutputForDetectStackSetDrift {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6977,7 +6977,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func estimateTemplateCost(
             input: CloudformationModel.EstimateTemplateCostInput) async throws -> CloudformationModel.EstimateTemplateCostOutputForEstimateTemplateCost {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7017,7 +7017,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func executeChangeSet(
             input: CloudformationModel.ExecuteChangeSetInput) async throws -> CloudformationModel.ExecuteChangeSetOutputForExecuteChangeSet {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7056,7 +7056,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func getStackPolicy(
             input: CloudformationModel.GetStackPolicyInput) async throws -> CloudformationModel.GetStackPolicyOutputForGetStackPolicy {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7096,7 +7096,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func getTemplate(
             input: CloudformationModel.GetTemplateInput) async throws -> CloudformationModel.GetTemplateOutputForGetTemplate {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7136,7 +7136,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func getTemplateSummary(
             input: CloudformationModel.GetTemplateSummaryInput) async throws -> CloudformationModel.GetTemplateSummaryOutputForGetTemplateSummary {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7176,7 +7176,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func importStacksToStackSet(
             input: CloudformationModel.ImportStacksToStackSetInput) async throws -> CloudformationModel.ImportStacksToStackSetOutputForImportStacksToStackSet {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7215,7 +7215,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listChangeSets(
             input: CloudformationModel.ListChangeSetsInput) async throws -> CloudformationModel.ListChangeSetsOutputForListChangeSets {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7254,7 +7254,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listExports(
             input: CloudformationModel.ListExportsInput) async throws -> CloudformationModel.ListExportsOutputForListExports {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7293,7 +7293,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listImports(
             input: CloudformationModel.ListImportsInput) async throws -> CloudformationModel.ListImportsOutputForListImports {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7333,7 +7333,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listStackInstanceResourceDrifts(
             input: CloudformationModel.ListStackInstanceResourceDriftsInput) async throws -> CloudformationModel.ListStackInstanceResourceDriftsOutputForListStackInstanceResourceDrifts {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7373,7 +7373,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listStackInstances(
             input: CloudformationModel.ListStackInstancesInput) async throws -> CloudformationModel.ListStackInstancesOutputForListStackInstances {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7412,7 +7412,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listStackResources(
             input: CloudformationModel.ListStackResourcesInput) async throws -> CloudformationModel.ListStackResourcesOutputForListStackResources {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7452,7 +7452,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listStackSetOperationResults(
             input: CloudformationModel.ListStackSetOperationResultsInput) async throws -> CloudformationModel.ListStackSetOperationResultsOutputForListStackSetOperationResults {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7492,7 +7492,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listStackSetOperations(
             input: CloudformationModel.ListStackSetOperationsInput) async throws -> CloudformationModel.ListStackSetOperationsOutputForListStackSetOperations {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7531,7 +7531,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listStackSets(
             input: CloudformationModel.ListStackSetsInput) async throws -> CloudformationModel.ListStackSetsOutputForListStackSets {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7570,7 +7570,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listStacks(
             input: CloudformationModel.ListStacksInput) async throws -> CloudformationModel.ListStacksOutputForListStacks {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7610,7 +7610,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listTypeRegistrations(
             input: CloudformationModel.ListTypeRegistrationsInput) async throws -> CloudformationModel.ListTypeRegistrationsOutputForListTypeRegistrations {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7650,7 +7650,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listTypeVersions(
             input: CloudformationModel.ListTypeVersionsInput) async throws -> CloudformationModel.ListTypeVersionsOutputForListTypeVersions {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7690,7 +7690,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listTypes(
             input: CloudformationModel.ListTypesInput) async throws -> CloudformationModel.ListTypesOutputForListTypes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7730,7 +7730,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func publishType(
             input: CloudformationModel.PublishTypeInput) async throws -> CloudformationModel.PublishTypeOutputForPublishType {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7770,7 +7770,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func recordHandlerProgress(
             input: CloudformationModel.RecordHandlerProgressInput) async throws -> CloudformationModel.RecordHandlerProgressOutputForRecordHandlerProgress {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7810,7 +7810,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func registerPublisher(
             input: CloudformationModel.RegisterPublisherInput) async throws -> CloudformationModel.RegisterPublisherOutputForRegisterPublisher {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7850,7 +7850,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func registerType(
             input: CloudformationModel.RegisterTypeInput) async throws -> CloudformationModel.RegisterTypeOutputForRegisterType {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7890,7 +7890,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func rollbackStack(
             input: CloudformationModel.RollbackStackInput) async throws -> CloudformationModel.RollbackStackOutputForRollbackStack {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7927,7 +7927,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func setStackPolicy(
             input: CloudformationModel.SetStackPolicyInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7967,7 +7967,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func setTypeConfiguration(
             input: CloudformationModel.SetTypeConfigurationInput) async throws -> CloudformationModel.SetTypeConfigurationOutputForSetTypeConfiguration {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8007,7 +8007,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func setTypeDefaultVersion(
             input: CloudformationModel.SetTypeDefaultVersionInput) async throws -> CloudformationModel.SetTypeDefaultVersionOutputForSetTypeDefaultVersion {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8044,7 +8044,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func signalResource(
             input: CloudformationModel.SignalResourceInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8084,7 +8084,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func stopStackSetOperation(
             input: CloudformationModel.StopStackSetOperationInput) async throws -> CloudformationModel.StopStackSetOperationOutputForStopStackSetOperation {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8124,7 +8124,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func testType(
             input: CloudformationModel.TestTypeInput) async throws -> CloudformationModel.TestTypeOutputForTestType {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8164,7 +8164,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func updateStack(
             input: CloudformationModel.UpdateStackInput) async throws -> CloudformationModel.UpdateStackOutputForUpdateStack {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8204,7 +8204,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func updateStackInstances(
             input: CloudformationModel.UpdateStackInstancesInput) async throws -> CloudformationModel.UpdateStackInstancesOutputForUpdateStackInstances {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8244,7 +8244,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func updateStackSet(
             input: CloudformationModel.UpdateStackSetInput) async throws -> CloudformationModel.UpdateStackSetOutputForUpdateStackSet {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8283,7 +8283,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func updateTerminationProtection(
             input: CloudformationModel.UpdateTerminationProtectionInput) async throws -> CloudformationModel.UpdateTerminationProtectionOutputForUpdateTerminationProtection {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8322,7 +8322,7 @@ public struct AWSCloudformationClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func validateTemplate(
             input: CloudformationModel.ValidateTemplateInput) async throws -> CloudformationModel.ValidateTemplateOutputForValidateTemplate {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/CodePipelineClient/AWSCodePipelineClient.swift
+++ b/Sources/CodePipelineClient/AWSCodePipelineClient.swift
@@ -2864,7 +2864,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func acknowledgeJob(
             input: CodePipelineModel.AcknowledgeJobInput) async throws -> CodePipelineModel.AcknowledgeJobOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2900,7 +2900,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func acknowledgeThirdPartyJob(
             input: CodePipelineModel.AcknowledgeThirdPartyJobInput) async throws -> CodePipelineModel.AcknowledgeThirdPartyJobOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2936,7 +2936,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func createCustomActionType(
             input: CodePipelineModel.CreateCustomActionTypeInput) async throws -> CodePipelineModel.CreateCustomActionTypeOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2972,7 +2972,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func createPipeline(
             input: CodePipelineModel.CreatePipelineInput) async throws -> CodePipelineModel.CreatePipelineOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3006,7 +3006,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func deleteCustomActionType(
             input: CodePipelineModel.DeleteCustomActionTypeInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3040,7 +3040,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func deletePipeline(
             input: CodePipelineModel.DeletePipelineInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3076,7 +3076,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func deleteWebhook(
             input: CodePipelineModel.DeleteWebhookInput) async throws -> CodePipelineModel.DeleteWebhookOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3112,7 +3112,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func deregisterWebhookWithThirdParty(
             input: CodePipelineModel.DeregisterWebhookWithThirdPartyInput) async throws -> CodePipelineModel.DeregisterWebhookWithThirdPartyOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3146,7 +3146,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func disableStageTransition(
             input: CodePipelineModel.DisableStageTransitionInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3180,7 +3180,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func enableStageTransition(
             input: CodePipelineModel.EnableStageTransitionInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3216,7 +3216,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func getActionType(
             input: CodePipelineModel.GetActionTypeInput) async throws -> CodePipelineModel.GetActionTypeOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3252,7 +3252,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func getJobDetails(
             input: CodePipelineModel.GetJobDetailsInput) async throws -> CodePipelineModel.GetJobDetailsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3288,7 +3288,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func getPipeline(
             input: CodePipelineModel.GetPipelineInput) async throws -> CodePipelineModel.GetPipelineOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3324,7 +3324,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func getPipelineExecution(
             input: CodePipelineModel.GetPipelineExecutionInput) async throws -> CodePipelineModel.GetPipelineExecutionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3360,7 +3360,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func getPipelineState(
             input: CodePipelineModel.GetPipelineStateInput) async throws -> CodePipelineModel.GetPipelineStateOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3396,7 +3396,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func getThirdPartyJobDetails(
             input: CodePipelineModel.GetThirdPartyJobDetailsInput) async throws -> CodePipelineModel.GetThirdPartyJobDetailsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3432,7 +3432,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func listActionExecutions(
             input: CodePipelineModel.ListActionExecutionsInput) async throws -> CodePipelineModel.ListActionExecutionsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3468,7 +3468,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func listActionTypes(
             input: CodePipelineModel.ListActionTypesInput) async throws -> CodePipelineModel.ListActionTypesOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3504,7 +3504,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func listPipelineExecutions(
             input: CodePipelineModel.ListPipelineExecutionsInput) async throws -> CodePipelineModel.ListPipelineExecutionsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3540,7 +3540,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func listPipelines(
             input: CodePipelineModel.ListPipelinesInput) async throws -> CodePipelineModel.ListPipelinesOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3576,7 +3576,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func listTagsForResource(
             input: CodePipelineModel.ListTagsForResourceInput) async throws -> CodePipelineModel.ListTagsForResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3612,7 +3612,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func listWebhooks(
             input: CodePipelineModel.ListWebhooksInput) async throws -> CodePipelineModel.ListWebhooksOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3648,7 +3648,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func pollForJobs(
             input: CodePipelineModel.PollForJobsInput) async throws -> CodePipelineModel.PollForJobsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3684,7 +3684,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func pollForThirdPartyJobs(
             input: CodePipelineModel.PollForThirdPartyJobsInput) async throws -> CodePipelineModel.PollForThirdPartyJobsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3720,7 +3720,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func putActionRevision(
             input: CodePipelineModel.PutActionRevisionInput) async throws -> CodePipelineModel.PutActionRevisionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3756,7 +3756,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func putApprovalResult(
             input: CodePipelineModel.PutApprovalResultInput) async throws -> CodePipelineModel.PutApprovalResultOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3790,7 +3790,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func putJobFailureResult(
             input: CodePipelineModel.PutJobFailureResultInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3824,7 +3824,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func putJobSuccessResult(
             input: CodePipelineModel.PutJobSuccessResultInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3858,7 +3858,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func putThirdPartyJobFailureResult(
             input: CodePipelineModel.PutThirdPartyJobFailureResultInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3892,7 +3892,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func putThirdPartyJobSuccessResult(
             input: CodePipelineModel.PutThirdPartyJobSuccessResultInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3928,7 +3928,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func putWebhook(
             input: CodePipelineModel.PutWebhookInput) async throws -> CodePipelineModel.PutWebhookOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3964,7 +3964,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func registerWebhookWithThirdParty(
             input: CodePipelineModel.RegisterWebhookWithThirdPartyInput) async throws -> CodePipelineModel.RegisterWebhookWithThirdPartyOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4000,7 +4000,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func retryStageExecution(
             input: CodePipelineModel.RetryStageExecutionInput) async throws -> CodePipelineModel.RetryStageExecutionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4036,7 +4036,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func startPipelineExecution(
             input: CodePipelineModel.StartPipelineExecutionInput) async throws -> CodePipelineModel.StartPipelineExecutionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4072,7 +4072,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func stopPipelineExecution(
             input: CodePipelineModel.StopPipelineExecutionInput) async throws -> CodePipelineModel.StopPipelineExecutionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4108,7 +4108,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func tagResource(
             input: CodePipelineModel.TagResourceInput) async throws -> CodePipelineModel.TagResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4144,7 +4144,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func untagResource(
             input: CodePipelineModel.UntagResourceInput) async throws -> CodePipelineModel.UntagResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4178,7 +4178,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func updateActionType(
             input: CodePipelineModel.UpdateActionTypeInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4214,7 +4214,7 @@ public struct AWSCodePipelineClient<InvocationReportingType: HTTPClientCoreInvoc
      */
     public func updatePipeline(
             input: CodePipelineModel.UpdatePipelineInput) async throws -> CodePipelineModel.UpdatePipelineOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/DynamoDBClient/AWSDynamoDBClient.swift
+++ b/Sources/DynamoDBClient/AWSDynamoDBClient.swift
@@ -3882,7 +3882,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func batchExecuteStatement(
             input: DynamoDBModel.BatchExecuteStatementInput) async throws -> DynamoDBModel.BatchExecuteStatementOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3918,7 +3918,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func batchGetItem(
             input: DynamoDBModel.BatchGetItemInput) async throws -> DynamoDBModel.BatchGetItemOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3954,7 +3954,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func batchWriteItem(
             input: DynamoDBModel.BatchWriteItemInput) async throws -> DynamoDBModel.BatchWriteItemOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3990,7 +3990,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func createBackup(
             input: DynamoDBModel.CreateBackupInput) async throws -> DynamoDBModel.CreateBackupOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4026,7 +4026,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func createGlobalTable(
             input: DynamoDBModel.CreateGlobalTableInput) async throws -> DynamoDBModel.CreateGlobalTableOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4062,7 +4062,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func createTable(
             input: DynamoDBModel.CreateTableInput) async throws -> DynamoDBModel.CreateTableOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4098,7 +4098,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func deleteBackup(
             input: DynamoDBModel.DeleteBackupInput) async throws -> DynamoDBModel.DeleteBackupOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4134,7 +4134,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func deleteItem(
             input: DynamoDBModel.DeleteItemInput) async throws -> DynamoDBModel.DeleteItemOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4170,7 +4170,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func deleteTable(
             input: DynamoDBModel.DeleteTableInput) async throws -> DynamoDBModel.DeleteTableOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4206,7 +4206,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeBackup(
             input: DynamoDBModel.DescribeBackupInput) async throws -> DynamoDBModel.DescribeBackupOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4242,7 +4242,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeContinuousBackups(
             input: DynamoDBModel.DescribeContinuousBackupsInput) async throws -> DynamoDBModel.DescribeContinuousBackupsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4278,7 +4278,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeContributorInsights(
             input: DynamoDBModel.DescribeContributorInsightsInput) async throws -> DynamoDBModel.DescribeContributorInsightsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4313,7 +4313,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeEndpoints(
             input: DynamoDBModel.DescribeEndpointsRequest) async throws -> DynamoDBModel.DescribeEndpointsResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4349,7 +4349,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeExport(
             input: DynamoDBModel.DescribeExportInput) async throws -> DynamoDBModel.DescribeExportOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4385,7 +4385,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeGlobalTable(
             input: DynamoDBModel.DescribeGlobalTableInput) async throws -> DynamoDBModel.DescribeGlobalTableOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4421,7 +4421,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeGlobalTableSettings(
             input: DynamoDBModel.DescribeGlobalTableSettingsInput) async throws -> DynamoDBModel.DescribeGlobalTableSettingsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4457,7 +4457,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeImport(
             input: DynamoDBModel.DescribeImportInput) async throws -> DynamoDBModel.DescribeImportOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4493,7 +4493,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeKinesisStreamingDestination(
             input: DynamoDBModel.DescribeKinesisStreamingDestinationInput) async throws -> DynamoDBModel.DescribeKinesisStreamingDestinationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4529,7 +4529,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeLimits(
             input: DynamoDBModel.DescribeLimitsInput) async throws -> DynamoDBModel.DescribeLimitsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4565,7 +4565,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeTable(
             input: DynamoDBModel.DescribeTableInput) async throws -> DynamoDBModel.DescribeTableOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4601,7 +4601,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeTableReplicaAutoScaling(
             input: DynamoDBModel.DescribeTableReplicaAutoScalingInput) async throws -> DynamoDBModel.DescribeTableReplicaAutoScalingOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4637,7 +4637,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func describeTimeToLive(
             input: DynamoDBModel.DescribeTimeToLiveInput) async throws -> DynamoDBModel.DescribeTimeToLiveOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4673,7 +4673,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func disableKinesisStreamingDestination(
             input: DynamoDBModel.KinesisStreamingDestinationInput) async throws -> DynamoDBModel.KinesisStreamingDestinationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4709,7 +4709,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func enableKinesisStreamingDestination(
             input: DynamoDBModel.KinesisStreamingDestinationInput) async throws -> DynamoDBModel.KinesisStreamingDestinationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4745,7 +4745,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func executeStatement(
             input: DynamoDBModel.ExecuteStatementInput) async throws -> DynamoDBModel.ExecuteStatementOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4781,7 +4781,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func executeTransaction(
             input: DynamoDBModel.ExecuteTransactionInput) async throws -> DynamoDBModel.ExecuteTransactionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4817,7 +4817,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func exportTableToPointInTime(
             input: DynamoDBModel.ExportTableToPointInTimeInput) async throws -> DynamoDBModel.ExportTableToPointInTimeOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4853,7 +4853,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func getItem(
             input: DynamoDBModel.GetItemInput) async throws -> DynamoDBModel.GetItemOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4889,7 +4889,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func importTable(
             input: DynamoDBModel.ImportTableInput) async throws -> DynamoDBModel.ImportTableOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4925,7 +4925,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func listBackups(
             input: DynamoDBModel.ListBackupsInput) async throws -> DynamoDBModel.ListBackupsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4961,7 +4961,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func listContributorInsights(
             input: DynamoDBModel.ListContributorInsightsInput) async throws -> DynamoDBModel.ListContributorInsightsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4997,7 +4997,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func listExports(
             input: DynamoDBModel.ListExportsInput) async throws -> DynamoDBModel.ListExportsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5033,7 +5033,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func listGlobalTables(
             input: DynamoDBModel.ListGlobalTablesInput) async throws -> DynamoDBModel.ListGlobalTablesOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5069,7 +5069,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func listImports(
             input: DynamoDBModel.ListImportsInput) async throws -> DynamoDBModel.ListImportsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5105,7 +5105,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func listTables(
             input: DynamoDBModel.ListTablesInput) async throws -> DynamoDBModel.ListTablesOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5141,7 +5141,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func listTagsOfResource(
             input: DynamoDBModel.ListTagsOfResourceInput) async throws -> DynamoDBModel.ListTagsOfResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5177,7 +5177,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func putItem(
             input: DynamoDBModel.PutItemInput) async throws -> DynamoDBModel.PutItemOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5213,7 +5213,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func query(
             input: DynamoDBModel.QueryInput) async throws -> DynamoDBModel.QueryOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5249,7 +5249,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func restoreTableFromBackup(
             input: DynamoDBModel.RestoreTableFromBackupInput) async throws -> DynamoDBModel.RestoreTableFromBackupOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5285,7 +5285,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func restoreTableToPointInTime(
             input: DynamoDBModel.RestoreTableToPointInTimeInput) async throws -> DynamoDBModel.RestoreTableToPointInTimeOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5321,7 +5321,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func scan(
             input: DynamoDBModel.ScanInput) async throws -> DynamoDBModel.ScanOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5355,7 +5355,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func tagResource(
             input: DynamoDBModel.TagResourceInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5391,7 +5391,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func transactGetItems(
             input: DynamoDBModel.TransactGetItemsInput) async throws -> DynamoDBModel.TransactGetItemsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5427,7 +5427,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func transactWriteItems(
             input: DynamoDBModel.TransactWriteItemsInput) async throws -> DynamoDBModel.TransactWriteItemsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5461,7 +5461,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func untagResource(
             input: DynamoDBModel.UntagResourceInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5497,7 +5497,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func updateContinuousBackups(
             input: DynamoDBModel.UpdateContinuousBackupsInput) async throws -> DynamoDBModel.UpdateContinuousBackupsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5533,7 +5533,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func updateContributorInsights(
             input: DynamoDBModel.UpdateContributorInsightsInput) async throws -> DynamoDBModel.UpdateContributorInsightsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5569,7 +5569,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func updateGlobalTable(
             input: DynamoDBModel.UpdateGlobalTableInput) async throws -> DynamoDBModel.UpdateGlobalTableOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5605,7 +5605,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func updateGlobalTableSettings(
             input: DynamoDBModel.UpdateGlobalTableSettingsInput) async throws -> DynamoDBModel.UpdateGlobalTableSettingsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5641,7 +5641,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func updateItem(
             input: DynamoDBModel.UpdateItemInput) async throws -> DynamoDBModel.UpdateItemOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5677,7 +5677,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func updateTable(
             input: DynamoDBModel.UpdateTableInput) async throws -> DynamoDBModel.UpdateTableOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5713,7 +5713,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func updateTableReplicaAutoScaling(
             input: DynamoDBModel.UpdateTableReplicaAutoScalingInput) async throws -> DynamoDBModel.UpdateTableReplicaAutoScalingOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5749,7 +5749,7 @@ public struct AWSDynamoDBClient<InvocationReportingType: HTTPClientCoreInvocatio
      */
     public func updateTimeToLive(
             input: DynamoDBModel.UpdateTimeToLiveInput) async throws -> DynamoDBModel.UpdateTimeToLiveOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/ECRClient/AWSECRClient.swift
+++ b/Sources/ECRClient/AWSECRClient.swift
@@ -3031,7 +3031,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func batchCheckLayerAvailability(
             input: ECRModel.BatchCheckLayerAvailabilityRequest) async throws -> ECRModel.BatchCheckLayerAvailabilityResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3067,7 +3067,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func batchDeleteImage(
             input: ECRModel.BatchDeleteImageRequest) async throws -> ECRModel.BatchDeleteImageResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3103,7 +3103,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func batchGetImage(
             input: ECRModel.BatchGetImageRequest) async throws -> ECRModel.BatchGetImageResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3139,7 +3139,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func batchGetRepositoryScanningConfiguration(
             input: ECRModel.BatchGetRepositoryScanningConfigurationRequest) async throws -> ECRModel.BatchGetRepositoryScanningConfigurationResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3175,7 +3175,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func completeLayerUpload(
             input: ECRModel.CompleteLayerUploadRequest) async throws -> ECRModel.CompleteLayerUploadResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3211,7 +3211,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createPullThroughCacheRule(
             input: ECRModel.CreatePullThroughCacheRuleRequest) async throws -> ECRModel.CreatePullThroughCacheRuleResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3247,7 +3247,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createRepository(
             input: ECRModel.CreateRepositoryRequest) async throws -> ECRModel.CreateRepositoryResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3283,7 +3283,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteLifecyclePolicy(
             input: ECRModel.DeleteLifecyclePolicyRequest) async throws -> ECRModel.DeleteLifecyclePolicyResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3319,7 +3319,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deletePullThroughCacheRule(
             input: ECRModel.DeletePullThroughCacheRuleRequest) async throws -> ECRModel.DeletePullThroughCacheRuleResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3355,7 +3355,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteRegistryPolicy(
             input: ECRModel.DeleteRegistryPolicyRequest) async throws -> ECRModel.DeleteRegistryPolicyResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3391,7 +3391,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteRepository(
             input: ECRModel.DeleteRepositoryRequest) async throws -> ECRModel.DeleteRepositoryResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3427,7 +3427,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteRepositoryPolicy(
             input: ECRModel.DeleteRepositoryPolicyRequest) async throws -> ECRModel.DeleteRepositoryPolicyResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3463,7 +3463,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeImageReplicationStatus(
             input: ECRModel.DescribeImageReplicationStatusRequest) async throws -> ECRModel.DescribeImageReplicationStatusResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3499,7 +3499,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeImageScanFindings(
             input: ECRModel.DescribeImageScanFindingsRequest) async throws -> ECRModel.DescribeImageScanFindingsResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3535,7 +3535,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeImages(
             input: ECRModel.DescribeImagesRequest) async throws -> ECRModel.DescribeImagesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3571,7 +3571,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describePullThroughCacheRules(
             input: ECRModel.DescribePullThroughCacheRulesRequest) async throws -> ECRModel.DescribePullThroughCacheRulesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3607,7 +3607,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeRegistry(
             input: ECRModel.DescribeRegistryRequest) async throws -> ECRModel.DescribeRegistryResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3643,7 +3643,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeRepositories(
             input: ECRModel.DescribeRepositoriesRequest) async throws -> ECRModel.DescribeRepositoriesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3679,7 +3679,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func getAuthorizationToken(
             input: ECRModel.GetAuthorizationTokenRequest) async throws -> ECRModel.GetAuthorizationTokenResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3715,7 +3715,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func getDownloadUrlForLayer(
             input: ECRModel.GetDownloadUrlForLayerRequest) async throws -> ECRModel.GetDownloadUrlForLayerResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3751,7 +3751,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func getLifecyclePolicy(
             input: ECRModel.GetLifecyclePolicyRequest) async throws -> ECRModel.GetLifecyclePolicyResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3787,7 +3787,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func getLifecyclePolicyPreview(
             input: ECRModel.GetLifecyclePolicyPreviewRequest) async throws -> ECRModel.GetLifecyclePolicyPreviewResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3823,7 +3823,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func getRegistryPolicy(
             input: ECRModel.GetRegistryPolicyRequest) async throws -> ECRModel.GetRegistryPolicyResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3859,7 +3859,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func getRegistryScanningConfiguration(
             input: ECRModel.GetRegistryScanningConfigurationRequest) async throws -> ECRModel.GetRegistryScanningConfigurationResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3895,7 +3895,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func getRepositoryPolicy(
             input: ECRModel.GetRepositoryPolicyRequest) async throws -> ECRModel.GetRepositoryPolicyResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3931,7 +3931,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func initiateLayerUpload(
             input: ECRModel.InitiateLayerUploadRequest) async throws -> ECRModel.InitiateLayerUploadResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3967,7 +3967,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func listImages(
             input: ECRModel.ListImagesRequest) async throws -> ECRModel.ListImagesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4003,7 +4003,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func listTagsForResource(
             input: ECRModel.ListTagsForResourceRequest) async throws -> ECRModel.ListTagsForResourceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4039,7 +4039,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func putImage(
             input: ECRModel.PutImageRequest) async throws -> ECRModel.PutImageResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4075,7 +4075,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func putImageScanningConfiguration(
             input: ECRModel.PutImageScanningConfigurationRequest) async throws -> ECRModel.PutImageScanningConfigurationResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4111,7 +4111,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func putImageTagMutability(
             input: ECRModel.PutImageTagMutabilityRequest) async throws -> ECRModel.PutImageTagMutabilityResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4147,7 +4147,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func putLifecyclePolicy(
             input: ECRModel.PutLifecyclePolicyRequest) async throws -> ECRModel.PutLifecyclePolicyResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4183,7 +4183,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func putRegistryPolicy(
             input: ECRModel.PutRegistryPolicyRequest) async throws -> ECRModel.PutRegistryPolicyResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4219,7 +4219,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func putRegistryScanningConfiguration(
             input: ECRModel.PutRegistryScanningConfigurationRequest) async throws -> ECRModel.PutRegistryScanningConfigurationResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4255,7 +4255,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func putReplicationConfiguration(
             input: ECRModel.PutReplicationConfigurationRequest) async throws -> ECRModel.PutReplicationConfigurationResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4291,7 +4291,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func setRepositoryPolicy(
             input: ECRModel.SetRepositoryPolicyRequest) async throws -> ECRModel.SetRepositoryPolicyResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4327,7 +4327,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func startImageScan(
             input: ECRModel.StartImageScanRequest) async throws -> ECRModel.StartImageScanResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4363,7 +4363,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func startLifecyclePolicyPreview(
             input: ECRModel.StartLifecyclePolicyPreviewRequest) async throws -> ECRModel.StartLifecyclePolicyPreviewResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4399,7 +4399,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func tagResource(
             input: ECRModel.TagResourceRequest) async throws -> ECRModel.TagResourceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4435,7 +4435,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func untagResource(
             input: ECRModel.UntagResourceRequest) async throws -> ECRModel.UntagResourceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4471,7 +4471,7 @@ public struct AWSECRClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func uploadLayerPart(
             input: ECRModel.UploadLayerPartRequest) async throws -> ECRModel.UploadLayerPartResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
+++ b/Sources/ElasticComputeCloudClient/AWSElasticComputeCloudClient.swift
@@ -45600,7 +45600,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func acceptAddressTransfer(
             input: ElasticComputeCloudModel.AcceptAddressTransferRequest) async throws -> ElasticComputeCloudModel.AcceptAddressTransferResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -45639,7 +45639,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func acceptReservedInstancesExchangeQuote(
             input: ElasticComputeCloudModel.AcceptReservedInstancesExchangeQuoteRequest) async throws -> ElasticComputeCloudModel.AcceptReservedInstancesExchangeQuoteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -45678,7 +45678,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func acceptTransitGatewayMulticastDomainAssociations(
             input: ElasticComputeCloudModel.AcceptTransitGatewayMulticastDomainAssociationsRequest) async throws -> ElasticComputeCloudModel.AcceptTransitGatewayMulticastDomainAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -45717,7 +45717,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func acceptTransitGatewayPeeringAttachment(
             input: ElasticComputeCloudModel.AcceptTransitGatewayPeeringAttachmentRequest) async throws -> ElasticComputeCloudModel.AcceptTransitGatewayPeeringAttachmentResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -45756,7 +45756,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func acceptTransitGatewayVpcAttachment(
             input: ElasticComputeCloudModel.AcceptTransitGatewayVpcAttachmentRequest) async throws -> ElasticComputeCloudModel.AcceptTransitGatewayVpcAttachmentResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -45795,7 +45795,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func acceptVpcEndpointConnections(
             input: ElasticComputeCloudModel.AcceptVpcEndpointConnectionsRequest) async throws -> ElasticComputeCloudModel.AcceptVpcEndpointConnectionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -45834,7 +45834,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func acceptVpcPeeringConnection(
             input: ElasticComputeCloudModel.AcceptVpcPeeringConnectionRequest) async throws -> ElasticComputeCloudModel.AcceptVpcPeeringConnectionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -45873,7 +45873,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func advertiseByoipCidr(
             input: ElasticComputeCloudModel.AdvertiseByoipCidrRequest) async throws -> ElasticComputeCloudModel.AdvertiseByoipCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -45912,7 +45912,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func allocateAddress(
             input: ElasticComputeCloudModel.AllocateAddressRequest) async throws -> ElasticComputeCloudModel.AllocateAddressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -45951,7 +45951,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func allocateHosts(
             input: ElasticComputeCloudModel.AllocateHostsRequest) async throws -> ElasticComputeCloudModel.AllocateHostsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -45990,7 +45990,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func allocateIpamPoolCidr(
             input: ElasticComputeCloudModel.AllocateIpamPoolCidrRequest) async throws -> ElasticComputeCloudModel.AllocateIpamPoolCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46029,7 +46029,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func applySecurityGroupsToClientVpnTargetNetwork(
             input: ElasticComputeCloudModel.ApplySecurityGroupsToClientVpnTargetNetworkRequest) async throws -> ElasticComputeCloudModel.ApplySecurityGroupsToClientVpnTargetNetworkResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46068,7 +46068,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func assignIpv6Addresses(
             input: ElasticComputeCloudModel.AssignIpv6AddressesRequest) async throws -> ElasticComputeCloudModel.AssignIpv6AddressesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46107,7 +46107,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func assignPrivateIpAddresses(
             input: ElasticComputeCloudModel.AssignPrivateIpAddressesRequest) async throws -> ElasticComputeCloudModel.AssignPrivateIpAddressesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46146,7 +46146,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func assignPrivateNatGatewayAddress(
             input: ElasticComputeCloudModel.AssignPrivateNatGatewayAddressRequest) async throws -> ElasticComputeCloudModel.AssignPrivateNatGatewayAddressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46185,7 +46185,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateAddress(
             input: ElasticComputeCloudModel.AssociateAddressRequest) async throws -> ElasticComputeCloudModel.AssociateAddressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46224,7 +46224,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateClientVpnTargetNetwork(
             input: ElasticComputeCloudModel.AssociateClientVpnTargetNetworkRequest) async throws -> ElasticComputeCloudModel.AssociateClientVpnTargetNetworkResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46261,7 +46261,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateDhcpOptions(
             input: ElasticComputeCloudModel.AssociateDhcpOptionsRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46300,7 +46300,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateEnclaveCertificateIamRole(
             input: ElasticComputeCloudModel.AssociateEnclaveCertificateIamRoleRequest) async throws -> ElasticComputeCloudModel.AssociateEnclaveCertificateIamRoleResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46339,7 +46339,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateIamInstanceProfile(
             input: ElasticComputeCloudModel.AssociateIamInstanceProfileRequest) async throws -> ElasticComputeCloudModel.AssociateIamInstanceProfileResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46378,7 +46378,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateInstanceEventWindow(
             input: ElasticComputeCloudModel.AssociateInstanceEventWindowRequest) async throws -> ElasticComputeCloudModel.AssociateInstanceEventWindowResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46417,7 +46417,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateIpamResourceDiscovery(
             input: ElasticComputeCloudModel.AssociateIpamResourceDiscoveryRequest) async throws -> ElasticComputeCloudModel.AssociateIpamResourceDiscoveryResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46456,7 +46456,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateNatGatewayAddress(
             input: ElasticComputeCloudModel.AssociateNatGatewayAddressRequest) async throws -> ElasticComputeCloudModel.AssociateNatGatewayAddressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46495,7 +46495,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateRouteTable(
             input: ElasticComputeCloudModel.AssociateRouteTableRequest) async throws -> ElasticComputeCloudModel.AssociateRouteTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46534,7 +46534,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateSubnetCidrBlock(
             input: ElasticComputeCloudModel.AssociateSubnetCidrBlockRequest) async throws -> ElasticComputeCloudModel.AssociateSubnetCidrBlockResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46573,7 +46573,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateTransitGatewayMulticastDomain(
             input: ElasticComputeCloudModel.AssociateTransitGatewayMulticastDomainRequest) async throws -> ElasticComputeCloudModel.AssociateTransitGatewayMulticastDomainResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46612,7 +46612,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateTransitGatewayPolicyTable(
             input: ElasticComputeCloudModel.AssociateTransitGatewayPolicyTableRequest) async throws -> ElasticComputeCloudModel.AssociateTransitGatewayPolicyTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46651,7 +46651,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateTransitGatewayRouteTable(
             input: ElasticComputeCloudModel.AssociateTransitGatewayRouteTableRequest) async throws -> ElasticComputeCloudModel.AssociateTransitGatewayRouteTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46690,7 +46690,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateTrunkInterface(
             input: ElasticComputeCloudModel.AssociateTrunkInterfaceRequest) async throws -> ElasticComputeCloudModel.AssociateTrunkInterfaceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46729,7 +46729,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func associateVpcCidrBlock(
             input: ElasticComputeCloudModel.AssociateVpcCidrBlockRequest) async throws -> ElasticComputeCloudModel.AssociateVpcCidrBlockResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46768,7 +46768,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func attachClassicLinkVpc(
             input: ElasticComputeCloudModel.AttachClassicLinkVpcRequest) async throws -> ElasticComputeCloudModel.AttachClassicLinkVpcResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46805,7 +46805,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func attachInternetGateway(
             input: ElasticComputeCloudModel.AttachInternetGatewayRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46844,7 +46844,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func attachNetworkInterface(
             input: ElasticComputeCloudModel.AttachNetworkInterfaceRequest) async throws -> ElasticComputeCloudModel.AttachNetworkInterfaceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46883,7 +46883,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func attachVerifiedAccessTrustProvider(
             input: ElasticComputeCloudModel.AttachVerifiedAccessTrustProviderRequest) async throws -> ElasticComputeCloudModel.AttachVerifiedAccessTrustProviderResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46922,7 +46922,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func attachVolume(
             input: ElasticComputeCloudModel.AttachVolumeRequest) async throws -> ElasticComputeCloudModel.VolumeAttachment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -46961,7 +46961,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func attachVpnGateway(
             input: ElasticComputeCloudModel.AttachVpnGatewayRequest) async throws -> ElasticComputeCloudModel.AttachVpnGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47000,7 +47000,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func authorizeClientVpnIngress(
             input: ElasticComputeCloudModel.AuthorizeClientVpnIngressRequest) async throws -> ElasticComputeCloudModel.AuthorizeClientVpnIngressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47039,7 +47039,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func authorizeSecurityGroupEgress(
             input: ElasticComputeCloudModel.AuthorizeSecurityGroupEgressRequest) async throws -> ElasticComputeCloudModel.AuthorizeSecurityGroupEgressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47078,7 +47078,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func authorizeSecurityGroupIngress(
             input: ElasticComputeCloudModel.AuthorizeSecurityGroupIngressRequest) async throws -> ElasticComputeCloudModel.AuthorizeSecurityGroupIngressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47117,7 +47117,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func bundleInstance(
             input: ElasticComputeCloudModel.BundleInstanceRequest) async throws -> ElasticComputeCloudModel.BundleInstanceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47156,7 +47156,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func cancelBundleTask(
             input: ElasticComputeCloudModel.CancelBundleTaskRequest) async throws -> ElasticComputeCloudModel.CancelBundleTaskResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47195,7 +47195,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func cancelCapacityReservation(
             input: ElasticComputeCloudModel.CancelCapacityReservationRequest) async throws -> ElasticComputeCloudModel.CancelCapacityReservationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47234,7 +47234,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func cancelCapacityReservationFleets(
             input: ElasticComputeCloudModel.CancelCapacityReservationFleetsRequest) async throws -> ElasticComputeCloudModel.CancelCapacityReservationFleetsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47271,7 +47271,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func cancelConversionTask(
             input: ElasticComputeCloudModel.CancelConversionRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47308,7 +47308,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func cancelExportTask(
             input: ElasticComputeCloudModel.CancelExportTaskRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47347,7 +47347,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func cancelImageLaunchPermission(
             input: ElasticComputeCloudModel.CancelImageLaunchPermissionRequest) async throws -> ElasticComputeCloudModel.CancelImageLaunchPermissionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47386,7 +47386,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func cancelImportTask(
             input: ElasticComputeCloudModel.CancelImportTaskRequest) async throws -> ElasticComputeCloudModel.CancelImportTaskResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47425,7 +47425,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func cancelReservedInstancesListing(
             input: ElasticComputeCloudModel.CancelReservedInstancesListingRequest) async throws -> ElasticComputeCloudModel.CancelReservedInstancesListingResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47464,7 +47464,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func cancelSpotFleetRequests(
             input: ElasticComputeCloudModel.CancelSpotFleetRequestsRequest) async throws -> ElasticComputeCloudModel.CancelSpotFleetRequestsResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47503,7 +47503,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func cancelSpotInstanceRequests(
             input: ElasticComputeCloudModel.CancelSpotInstanceRequestsRequest) async throws -> ElasticComputeCloudModel.CancelSpotInstanceRequestsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47542,7 +47542,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func confirmProductInstance(
             input: ElasticComputeCloudModel.ConfirmProductInstanceRequest) async throws -> ElasticComputeCloudModel.ConfirmProductInstanceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47581,7 +47581,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func copyFpgaImage(
             input: ElasticComputeCloudModel.CopyFpgaImageRequest) async throws -> ElasticComputeCloudModel.CopyFpgaImageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47620,7 +47620,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func copyImage(
             input: ElasticComputeCloudModel.CopyImageRequest) async throws -> ElasticComputeCloudModel.CopyImageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47659,7 +47659,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func copySnapshot(
             input: ElasticComputeCloudModel.CopySnapshotRequest) async throws -> ElasticComputeCloudModel.CopySnapshotResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47698,7 +47698,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createCapacityReservation(
             input: ElasticComputeCloudModel.CreateCapacityReservationRequest) async throws -> ElasticComputeCloudModel.CreateCapacityReservationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47737,7 +47737,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createCapacityReservationFleet(
             input: ElasticComputeCloudModel.CreateCapacityReservationFleetRequest) async throws -> ElasticComputeCloudModel.CreateCapacityReservationFleetResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47776,7 +47776,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createCarrierGateway(
             input: ElasticComputeCloudModel.CreateCarrierGatewayRequest) async throws -> ElasticComputeCloudModel.CreateCarrierGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47815,7 +47815,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createClientVpnEndpoint(
             input: ElasticComputeCloudModel.CreateClientVpnEndpointRequest) async throws -> ElasticComputeCloudModel.CreateClientVpnEndpointResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47854,7 +47854,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createClientVpnRoute(
             input: ElasticComputeCloudModel.CreateClientVpnRouteRequest) async throws -> ElasticComputeCloudModel.CreateClientVpnRouteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47893,7 +47893,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createCoipCidr(
             input: ElasticComputeCloudModel.CreateCoipCidrRequest) async throws -> ElasticComputeCloudModel.CreateCoipCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47932,7 +47932,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createCoipPool(
             input: ElasticComputeCloudModel.CreateCoipPoolRequest) async throws -> ElasticComputeCloudModel.CreateCoipPoolResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -47971,7 +47971,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createCustomerGateway(
             input: ElasticComputeCloudModel.CreateCustomerGatewayRequest) async throws -> ElasticComputeCloudModel.CreateCustomerGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48010,7 +48010,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createDefaultSubnet(
             input: ElasticComputeCloudModel.CreateDefaultSubnetRequest) async throws -> ElasticComputeCloudModel.CreateDefaultSubnetResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48049,7 +48049,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createDefaultVpc(
             input: ElasticComputeCloudModel.CreateDefaultVpcRequest) async throws -> ElasticComputeCloudModel.CreateDefaultVpcResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48088,7 +48088,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createDhcpOptions(
             input: ElasticComputeCloudModel.CreateDhcpOptionsRequest) async throws -> ElasticComputeCloudModel.CreateDhcpOptionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48127,7 +48127,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createEgressOnlyInternetGateway(
             input: ElasticComputeCloudModel.CreateEgressOnlyInternetGatewayRequest) async throws -> ElasticComputeCloudModel.CreateEgressOnlyInternetGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48166,7 +48166,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createFleet(
             input: ElasticComputeCloudModel.CreateFleetRequest) async throws -> ElasticComputeCloudModel.CreateFleetResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48205,7 +48205,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createFlowLogs(
             input: ElasticComputeCloudModel.CreateFlowLogsRequest) async throws -> ElasticComputeCloudModel.CreateFlowLogsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48244,7 +48244,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createFpgaImage(
             input: ElasticComputeCloudModel.CreateFpgaImageRequest) async throws -> ElasticComputeCloudModel.CreateFpgaImageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48283,7 +48283,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createImage(
             input: ElasticComputeCloudModel.CreateImageRequest) async throws -> ElasticComputeCloudModel.CreateImageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48322,7 +48322,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createInstanceConnectEndpoint(
             input: ElasticComputeCloudModel.CreateInstanceConnectEndpointRequest) async throws -> ElasticComputeCloudModel.CreateInstanceConnectEndpointResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48361,7 +48361,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createInstanceEventWindow(
             input: ElasticComputeCloudModel.CreateInstanceEventWindowRequest) async throws -> ElasticComputeCloudModel.CreateInstanceEventWindowResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48400,7 +48400,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createInstanceExportTask(
             input: ElasticComputeCloudModel.CreateInstanceExportTaskRequest) async throws -> ElasticComputeCloudModel.CreateInstanceExportTaskResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48439,7 +48439,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createInternetGateway(
             input: ElasticComputeCloudModel.CreateInternetGatewayRequest) async throws -> ElasticComputeCloudModel.CreateInternetGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48478,7 +48478,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createIpam(
             input: ElasticComputeCloudModel.CreateIpamRequest) async throws -> ElasticComputeCloudModel.CreateIpamResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48517,7 +48517,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createIpamPool(
             input: ElasticComputeCloudModel.CreateIpamPoolRequest) async throws -> ElasticComputeCloudModel.CreateIpamPoolResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48556,7 +48556,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createIpamResourceDiscovery(
             input: ElasticComputeCloudModel.CreateIpamResourceDiscoveryRequest) async throws -> ElasticComputeCloudModel.CreateIpamResourceDiscoveryResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48595,7 +48595,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createIpamScope(
             input: ElasticComputeCloudModel.CreateIpamScopeRequest) async throws -> ElasticComputeCloudModel.CreateIpamScopeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48634,7 +48634,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createKeyPair(
             input: ElasticComputeCloudModel.CreateKeyPairRequest) async throws -> ElasticComputeCloudModel.KeyPair {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48673,7 +48673,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createLaunchTemplate(
             input: ElasticComputeCloudModel.CreateLaunchTemplateRequest) async throws -> ElasticComputeCloudModel.CreateLaunchTemplateResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48712,7 +48712,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createLaunchTemplateVersion(
             input: ElasticComputeCloudModel.CreateLaunchTemplateVersionRequest) async throws -> ElasticComputeCloudModel.CreateLaunchTemplateVersionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48751,7 +48751,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createLocalGatewayRoute(
             input: ElasticComputeCloudModel.CreateLocalGatewayRouteRequest) async throws -> ElasticComputeCloudModel.CreateLocalGatewayRouteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48790,7 +48790,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createLocalGatewayRouteTable(
             input: ElasticComputeCloudModel.CreateLocalGatewayRouteTableRequest) async throws -> ElasticComputeCloudModel.CreateLocalGatewayRouteTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48829,7 +48829,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createLocalGatewayRouteTableVirtualInterfaceGroupAssociation(
             input: ElasticComputeCloudModel.CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest) async throws -> ElasticComputeCloudModel.CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48868,7 +48868,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createLocalGatewayRouteTableVpcAssociation(
             input: ElasticComputeCloudModel.CreateLocalGatewayRouteTableVpcAssociationRequest) async throws -> ElasticComputeCloudModel.CreateLocalGatewayRouteTableVpcAssociationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48907,7 +48907,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createManagedPrefixList(
             input: ElasticComputeCloudModel.CreateManagedPrefixListRequest) async throws -> ElasticComputeCloudModel.CreateManagedPrefixListResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48946,7 +48946,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createNatGateway(
             input: ElasticComputeCloudModel.CreateNatGatewayRequest) async throws -> ElasticComputeCloudModel.CreateNatGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -48985,7 +48985,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createNetworkAcl(
             input: ElasticComputeCloudModel.CreateNetworkAclRequest) async throws -> ElasticComputeCloudModel.CreateNetworkAclResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49022,7 +49022,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createNetworkAclEntry(
             input: ElasticComputeCloudModel.CreateNetworkAclEntryRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49061,7 +49061,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createNetworkInsightsAccessScope(
             input: ElasticComputeCloudModel.CreateNetworkInsightsAccessScopeRequest) async throws -> ElasticComputeCloudModel.CreateNetworkInsightsAccessScopeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49100,7 +49100,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createNetworkInsightsPath(
             input: ElasticComputeCloudModel.CreateNetworkInsightsPathRequest) async throws -> ElasticComputeCloudModel.CreateNetworkInsightsPathResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49139,7 +49139,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createNetworkInterface(
             input: ElasticComputeCloudModel.CreateNetworkInterfaceRequest) async throws -> ElasticComputeCloudModel.CreateNetworkInterfaceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49178,7 +49178,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createNetworkInterfacePermission(
             input: ElasticComputeCloudModel.CreateNetworkInterfacePermissionRequest) async throws -> ElasticComputeCloudModel.CreateNetworkInterfacePermissionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49217,7 +49217,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createPlacementGroup(
             input: ElasticComputeCloudModel.CreatePlacementGroupRequest) async throws -> ElasticComputeCloudModel.CreatePlacementGroupResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49256,7 +49256,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createPublicIpv4Pool(
             input: ElasticComputeCloudModel.CreatePublicIpv4PoolRequest) async throws -> ElasticComputeCloudModel.CreatePublicIpv4PoolResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49295,7 +49295,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createReplaceRootVolumeTask(
             input: ElasticComputeCloudModel.CreateReplaceRootVolumeTaskRequest) async throws -> ElasticComputeCloudModel.CreateReplaceRootVolumeTaskResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49334,7 +49334,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createReservedInstancesListing(
             input: ElasticComputeCloudModel.CreateReservedInstancesListingRequest) async throws -> ElasticComputeCloudModel.CreateReservedInstancesListingResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49373,7 +49373,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createRestoreImageTask(
             input: ElasticComputeCloudModel.CreateRestoreImageTaskRequest) async throws -> ElasticComputeCloudModel.CreateRestoreImageTaskResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49412,7 +49412,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createRoute(
             input: ElasticComputeCloudModel.CreateRouteRequest) async throws -> ElasticComputeCloudModel.CreateRouteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49451,7 +49451,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createRouteTable(
             input: ElasticComputeCloudModel.CreateRouteTableRequest) async throws -> ElasticComputeCloudModel.CreateRouteTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49490,7 +49490,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createSecurityGroup(
             input: ElasticComputeCloudModel.CreateSecurityGroupRequest) async throws -> ElasticComputeCloudModel.CreateSecurityGroupResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49529,7 +49529,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createSnapshot(
             input: ElasticComputeCloudModel.CreateSnapshotRequest) async throws -> ElasticComputeCloudModel.Snapshot {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49568,7 +49568,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createSnapshots(
             input: ElasticComputeCloudModel.CreateSnapshotsRequest) async throws -> ElasticComputeCloudModel.CreateSnapshotsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49607,7 +49607,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createSpotDatafeedSubscription(
             input: ElasticComputeCloudModel.CreateSpotDatafeedSubscriptionRequest) async throws -> ElasticComputeCloudModel.CreateSpotDatafeedSubscriptionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49646,7 +49646,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createStoreImageTask(
             input: ElasticComputeCloudModel.CreateStoreImageTaskRequest) async throws -> ElasticComputeCloudModel.CreateStoreImageTaskResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49685,7 +49685,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createSubnet(
             input: ElasticComputeCloudModel.CreateSubnetRequest) async throws -> ElasticComputeCloudModel.CreateSubnetResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49724,7 +49724,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createSubnetCidrReservation(
             input: ElasticComputeCloudModel.CreateSubnetCidrReservationRequest) async throws -> ElasticComputeCloudModel.CreateSubnetCidrReservationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49761,7 +49761,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTags(
             input: ElasticComputeCloudModel.CreateTagsRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49800,7 +49800,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTrafficMirrorFilter(
             input: ElasticComputeCloudModel.CreateTrafficMirrorFilterRequest) async throws -> ElasticComputeCloudModel.CreateTrafficMirrorFilterResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49839,7 +49839,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTrafficMirrorFilterRule(
             input: ElasticComputeCloudModel.CreateTrafficMirrorFilterRuleRequest) async throws -> ElasticComputeCloudModel.CreateTrafficMirrorFilterRuleResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49878,7 +49878,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTrafficMirrorSession(
             input: ElasticComputeCloudModel.CreateTrafficMirrorSessionRequest) async throws -> ElasticComputeCloudModel.CreateTrafficMirrorSessionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49917,7 +49917,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTrafficMirrorTarget(
             input: ElasticComputeCloudModel.CreateTrafficMirrorTargetRequest) async throws -> ElasticComputeCloudModel.CreateTrafficMirrorTargetResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49956,7 +49956,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGateway(
             input: ElasticComputeCloudModel.CreateTransitGatewayRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -49995,7 +49995,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGatewayConnect(
             input: ElasticComputeCloudModel.CreateTransitGatewayConnectRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayConnectResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50034,7 +50034,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGatewayConnectPeer(
             input: ElasticComputeCloudModel.CreateTransitGatewayConnectPeerRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayConnectPeerResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50073,7 +50073,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGatewayMulticastDomain(
             input: ElasticComputeCloudModel.CreateTransitGatewayMulticastDomainRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayMulticastDomainResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50112,7 +50112,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGatewayPeeringAttachment(
             input: ElasticComputeCloudModel.CreateTransitGatewayPeeringAttachmentRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayPeeringAttachmentResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50151,7 +50151,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGatewayPolicyTable(
             input: ElasticComputeCloudModel.CreateTransitGatewayPolicyTableRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayPolicyTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50190,7 +50190,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGatewayPrefixListReference(
             input: ElasticComputeCloudModel.CreateTransitGatewayPrefixListReferenceRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayPrefixListReferenceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50229,7 +50229,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGatewayRoute(
             input: ElasticComputeCloudModel.CreateTransitGatewayRouteRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayRouteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50268,7 +50268,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGatewayRouteTable(
             input: ElasticComputeCloudModel.CreateTransitGatewayRouteTableRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayRouteTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50307,7 +50307,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGatewayRouteTableAnnouncement(
             input: ElasticComputeCloudModel.CreateTransitGatewayRouteTableAnnouncementRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayRouteTableAnnouncementResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50346,7 +50346,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createTransitGatewayVpcAttachment(
             input: ElasticComputeCloudModel.CreateTransitGatewayVpcAttachmentRequest) async throws -> ElasticComputeCloudModel.CreateTransitGatewayVpcAttachmentResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50385,7 +50385,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVerifiedAccessEndpoint(
             input: ElasticComputeCloudModel.CreateVerifiedAccessEndpointRequest) async throws -> ElasticComputeCloudModel.CreateVerifiedAccessEndpointResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50424,7 +50424,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVerifiedAccessGroup(
             input: ElasticComputeCloudModel.CreateVerifiedAccessGroupRequest) async throws -> ElasticComputeCloudModel.CreateVerifiedAccessGroupResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50463,7 +50463,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVerifiedAccessInstance(
             input: ElasticComputeCloudModel.CreateVerifiedAccessInstanceRequest) async throws -> ElasticComputeCloudModel.CreateVerifiedAccessInstanceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50502,7 +50502,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVerifiedAccessTrustProvider(
             input: ElasticComputeCloudModel.CreateVerifiedAccessTrustProviderRequest) async throws -> ElasticComputeCloudModel.CreateVerifiedAccessTrustProviderResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50541,7 +50541,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVolume(
             input: ElasticComputeCloudModel.CreateVolumeRequest) async throws -> ElasticComputeCloudModel.Volume {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50580,7 +50580,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVpc(
             input: ElasticComputeCloudModel.CreateVpcRequest) async throws -> ElasticComputeCloudModel.CreateVpcResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50619,7 +50619,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVpcEndpoint(
             input: ElasticComputeCloudModel.CreateVpcEndpointRequest) async throws -> ElasticComputeCloudModel.CreateVpcEndpointResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50658,7 +50658,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVpcEndpointConnectionNotification(
             input: ElasticComputeCloudModel.CreateVpcEndpointConnectionNotificationRequest) async throws -> ElasticComputeCloudModel.CreateVpcEndpointConnectionNotificationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50697,7 +50697,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVpcEndpointServiceConfiguration(
             input: ElasticComputeCloudModel.CreateVpcEndpointServiceConfigurationRequest) async throws -> ElasticComputeCloudModel.CreateVpcEndpointServiceConfigurationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50736,7 +50736,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVpcPeeringConnection(
             input: ElasticComputeCloudModel.CreateVpcPeeringConnectionRequest) async throws -> ElasticComputeCloudModel.CreateVpcPeeringConnectionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50775,7 +50775,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVpnConnection(
             input: ElasticComputeCloudModel.CreateVpnConnectionRequest) async throws -> ElasticComputeCloudModel.CreateVpnConnectionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50812,7 +50812,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVpnConnectionRoute(
             input: ElasticComputeCloudModel.CreateVpnConnectionRouteRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50851,7 +50851,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func createVpnGateway(
             input: ElasticComputeCloudModel.CreateVpnGatewayRequest) async throws -> ElasticComputeCloudModel.CreateVpnGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50890,7 +50890,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteCarrierGateway(
             input: ElasticComputeCloudModel.DeleteCarrierGatewayRequest) async throws -> ElasticComputeCloudModel.DeleteCarrierGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50929,7 +50929,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteClientVpnEndpoint(
             input: ElasticComputeCloudModel.DeleteClientVpnEndpointRequest) async throws -> ElasticComputeCloudModel.DeleteClientVpnEndpointResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -50968,7 +50968,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteClientVpnRoute(
             input: ElasticComputeCloudModel.DeleteClientVpnRouteRequest) async throws -> ElasticComputeCloudModel.DeleteClientVpnRouteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51007,7 +51007,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteCoipCidr(
             input: ElasticComputeCloudModel.DeleteCoipCidrRequest) async throws -> ElasticComputeCloudModel.DeleteCoipCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51046,7 +51046,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteCoipPool(
             input: ElasticComputeCloudModel.DeleteCoipPoolRequest) async throws -> ElasticComputeCloudModel.DeleteCoipPoolResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51083,7 +51083,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteCustomerGateway(
             input: ElasticComputeCloudModel.DeleteCustomerGatewayRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51120,7 +51120,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteDhcpOptions(
             input: ElasticComputeCloudModel.DeleteDhcpOptionsRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51159,7 +51159,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteEgressOnlyInternetGateway(
             input: ElasticComputeCloudModel.DeleteEgressOnlyInternetGatewayRequest) async throws -> ElasticComputeCloudModel.DeleteEgressOnlyInternetGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51198,7 +51198,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteFleets(
             input: ElasticComputeCloudModel.DeleteFleetsRequest) async throws -> ElasticComputeCloudModel.DeleteFleetsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51237,7 +51237,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteFlowLogs(
             input: ElasticComputeCloudModel.DeleteFlowLogsRequest) async throws -> ElasticComputeCloudModel.DeleteFlowLogsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51276,7 +51276,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteFpgaImage(
             input: ElasticComputeCloudModel.DeleteFpgaImageRequest) async throws -> ElasticComputeCloudModel.DeleteFpgaImageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51315,7 +51315,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteInstanceConnectEndpoint(
             input: ElasticComputeCloudModel.DeleteInstanceConnectEndpointRequest) async throws -> ElasticComputeCloudModel.DeleteInstanceConnectEndpointResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51354,7 +51354,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteInstanceEventWindow(
             input: ElasticComputeCloudModel.DeleteInstanceEventWindowRequest) async throws -> ElasticComputeCloudModel.DeleteInstanceEventWindowResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51391,7 +51391,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteInternetGateway(
             input: ElasticComputeCloudModel.DeleteInternetGatewayRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51430,7 +51430,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteIpam(
             input: ElasticComputeCloudModel.DeleteIpamRequest) async throws -> ElasticComputeCloudModel.DeleteIpamResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51469,7 +51469,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteIpamPool(
             input: ElasticComputeCloudModel.DeleteIpamPoolRequest) async throws -> ElasticComputeCloudModel.DeleteIpamPoolResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51508,7 +51508,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteIpamResourceDiscovery(
             input: ElasticComputeCloudModel.DeleteIpamResourceDiscoveryRequest) async throws -> ElasticComputeCloudModel.DeleteIpamResourceDiscoveryResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51547,7 +51547,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteIpamScope(
             input: ElasticComputeCloudModel.DeleteIpamScopeRequest) async throws -> ElasticComputeCloudModel.DeleteIpamScopeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51586,7 +51586,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteKeyPair(
             input: ElasticComputeCloudModel.DeleteKeyPairRequest) async throws -> ElasticComputeCloudModel.DeleteKeyPairResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51625,7 +51625,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteLaunchTemplate(
             input: ElasticComputeCloudModel.DeleteLaunchTemplateRequest) async throws -> ElasticComputeCloudModel.DeleteLaunchTemplateResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51664,7 +51664,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteLaunchTemplateVersions(
             input: ElasticComputeCloudModel.DeleteLaunchTemplateVersionsRequest) async throws -> ElasticComputeCloudModel.DeleteLaunchTemplateVersionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51703,7 +51703,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteLocalGatewayRoute(
             input: ElasticComputeCloudModel.DeleteLocalGatewayRouteRequest) async throws -> ElasticComputeCloudModel.DeleteLocalGatewayRouteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51742,7 +51742,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteLocalGatewayRouteTable(
             input: ElasticComputeCloudModel.DeleteLocalGatewayRouteTableRequest) async throws -> ElasticComputeCloudModel.DeleteLocalGatewayRouteTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51781,7 +51781,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteLocalGatewayRouteTableVirtualInterfaceGroupAssociation(
             input: ElasticComputeCloudModel.DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest) async throws -> ElasticComputeCloudModel.DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51820,7 +51820,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteLocalGatewayRouteTableVpcAssociation(
             input: ElasticComputeCloudModel.DeleteLocalGatewayRouteTableVpcAssociationRequest) async throws -> ElasticComputeCloudModel.DeleteLocalGatewayRouteTableVpcAssociationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51859,7 +51859,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteManagedPrefixList(
             input: ElasticComputeCloudModel.DeleteManagedPrefixListRequest) async throws -> ElasticComputeCloudModel.DeleteManagedPrefixListResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51898,7 +51898,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteNatGateway(
             input: ElasticComputeCloudModel.DeleteNatGatewayRequest) async throws -> ElasticComputeCloudModel.DeleteNatGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51935,7 +51935,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteNetworkAcl(
             input: ElasticComputeCloudModel.DeleteNetworkAclRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -51972,7 +51972,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteNetworkAclEntry(
             input: ElasticComputeCloudModel.DeleteNetworkAclEntryRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52011,7 +52011,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteNetworkInsightsAccessScope(
             input: ElasticComputeCloudModel.DeleteNetworkInsightsAccessScopeRequest) async throws -> ElasticComputeCloudModel.DeleteNetworkInsightsAccessScopeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52050,7 +52050,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteNetworkInsightsAccessScopeAnalysis(
             input: ElasticComputeCloudModel.DeleteNetworkInsightsAccessScopeAnalysisRequest) async throws -> ElasticComputeCloudModel.DeleteNetworkInsightsAccessScopeAnalysisResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52089,7 +52089,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteNetworkInsightsAnalysis(
             input: ElasticComputeCloudModel.DeleteNetworkInsightsAnalysisRequest) async throws -> ElasticComputeCloudModel.DeleteNetworkInsightsAnalysisResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52128,7 +52128,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteNetworkInsightsPath(
             input: ElasticComputeCloudModel.DeleteNetworkInsightsPathRequest) async throws -> ElasticComputeCloudModel.DeleteNetworkInsightsPathResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52165,7 +52165,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteNetworkInterface(
             input: ElasticComputeCloudModel.DeleteNetworkInterfaceRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52204,7 +52204,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteNetworkInterfacePermission(
             input: ElasticComputeCloudModel.DeleteNetworkInterfacePermissionRequest) async throws -> ElasticComputeCloudModel.DeleteNetworkInterfacePermissionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52241,7 +52241,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deletePlacementGroup(
             input: ElasticComputeCloudModel.DeletePlacementGroupRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52280,7 +52280,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deletePublicIpv4Pool(
             input: ElasticComputeCloudModel.DeletePublicIpv4PoolRequest) async throws -> ElasticComputeCloudModel.DeletePublicIpv4PoolResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52319,7 +52319,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteQueuedReservedInstances(
             input: ElasticComputeCloudModel.DeleteQueuedReservedInstancesRequest) async throws -> ElasticComputeCloudModel.DeleteQueuedReservedInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52356,7 +52356,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteRoute(
             input: ElasticComputeCloudModel.DeleteRouteRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52393,7 +52393,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteRouteTable(
             input: ElasticComputeCloudModel.DeleteRouteTableRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52430,7 +52430,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteSecurityGroup(
             input: ElasticComputeCloudModel.DeleteSecurityGroupRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52467,7 +52467,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteSnapshot(
             input: ElasticComputeCloudModel.DeleteSnapshotRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52504,7 +52504,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteSpotDatafeedSubscription(
             input: ElasticComputeCloudModel.DeleteSpotDatafeedSubscriptionRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52541,7 +52541,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteSubnet(
             input: ElasticComputeCloudModel.DeleteSubnetRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52580,7 +52580,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteSubnetCidrReservation(
             input: ElasticComputeCloudModel.DeleteSubnetCidrReservationRequest) async throws -> ElasticComputeCloudModel.DeleteSubnetCidrReservationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52617,7 +52617,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTags(
             input: ElasticComputeCloudModel.DeleteTagsRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52656,7 +52656,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTrafficMirrorFilter(
             input: ElasticComputeCloudModel.DeleteTrafficMirrorFilterRequest) async throws -> ElasticComputeCloudModel.DeleteTrafficMirrorFilterResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52695,7 +52695,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTrafficMirrorFilterRule(
             input: ElasticComputeCloudModel.DeleteTrafficMirrorFilterRuleRequest) async throws -> ElasticComputeCloudModel.DeleteTrafficMirrorFilterRuleResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52734,7 +52734,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTrafficMirrorSession(
             input: ElasticComputeCloudModel.DeleteTrafficMirrorSessionRequest) async throws -> ElasticComputeCloudModel.DeleteTrafficMirrorSessionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52773,7 +52773,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTrafficMirrorTarget(
             input: ElasticComputeCloudModel.DeleteTrafficMirrorTargetRequest) async throws -> ElasticComputeCloudModel.DeleteTrafficMirrorTargetResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52812,7 +52812,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGateway(
             input: ElasticComputeCloudModel.DeleteTransitGatewayRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52851,7 +52851,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGatewayConnect(
             input: ElasticComputeCloudModel.DeleteTransitGatewayConnectRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayConnectResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52890,7 +52890,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGatewayConnectPeer(
             input: ElasticComputeCloudModel.DeleteTransitGatewayConnectPeerRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayConnectPeerResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52929,7 +52929,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGatewayMulticastDomain(
             input: ElasticComputeCloudModel.DeleteTransitGatewayMulticastDomainRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayMulticastDomainResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -52968,7 +52968,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGatewayPeeringAttachment(
             input: ElasticComputeCloudModel.DeleteTransitGatewayPeeringAttachmentRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayPeeringAttachmentResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53007,7 +53007,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGatewayPolicyTable(
             input: ElasticComputeCloudModel.DeleteTransitGatewayPolicyTableRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayPolicyTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53046,7 +53046,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGatewayPrefixListReference(
             input: ElasticComputeCloudModel.DeleteTransitGatewayPrefixListReferenceRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayPrefixListReferenceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53085,7 +53085,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGatewayRoute(
             input: ElasticComputeCloudModel.DeleteTransitGatewayRouteRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayRouteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53124,7 +53124,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGatewayRouteTable(
             input: ElasticComputeCloudModel.DeleteTransitGatewayRouteTableRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayRouteTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53163,7 +53163,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGatewayRouteTableAnnouncement(
             input: ElasticComputeCloudModel.DeleteTransitGatewayRouteTableAnnouncementRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayRouteTableAnnouncementResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53202,7 +53202,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteTransitGatewayVpcAttachment(
             input: ElasticComputeCloudModel.DeleteTransitGatewayVpcAttachmentRequest) async throws -> ElasticComputeCloudModel.DeleteTransitGatewayVpcAttachmentResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53241,7 +53241,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVerifiedAccessEndpoint(
             input: ElasticComputeCloudModel.DeleteVerifiedAccessEndpointRequest) async throws -> ElasticComputeCloudModel.DeleteVerifiedAccessEndpointResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53280,7 +53280,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVerifiedAccessGroup(
             input: ElasticComputeCloudModel.DeleteVerifiedAccessGroupRequest) async throws -> ElasticComputeCloudModel.DeleteVerifiedAccessGroupResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53319,7 +53319,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVerifiedAccessInstance(
             input: ElasticComputeCloudModel.DeleteVerifiedAccessInstanceRequest) async throws -> ElasticComputeCloudModel.DeleteVerifiedAccessInstanceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53358,7 +53358,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVerifiedAccessTrustProvider(
             input: ElasticComputeCloudModel.DeleteVerifiedAccessTrustProviderRequest) async throws -> ElasticComputeCloudModel.DeleteVerifiedAccessTrustProviderResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53395,7 +53395,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVolume(
             input: ElasticComputeCloudModel.DeleteVolumeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53432,7 +53432,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVpc(
             input: ElasticComputeCloudModel.DeleteVpcRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53471,7 +53471,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVpcEndpointConnectionNotifications(
             input: ElasticComputeCloudModel.DeleteVpcEndpointConnectionNotificationsRequest) async throws -> ElasticComputeCloudModel.DeleteVpcEndpointConnectionNotificationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53510,7 +53510,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVpcEndpointServiceConfigurations(
             input: ElasticComputeCloudModel.DeleteVpcEndpointServiceConfigurationsRequest) async throws -> ElasticComputeCloudModel.DeleteVpcEndpointServiceConfigurationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53549,7 +53549,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVpcEndpoints(
             input: ElasticComputeCloudModel.DeleteVpcEndpointsRequest) async throws -> ElasticComputeCloudModel.DeleteVpcEndpointsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53588,7 +53588,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVpcPeeringConnection(
             input: ElasticComputeCloudModel.DeleteVpcPeeringConnectionRequest) async throws -> ElasticComputeCloudModel.DeleteVpcPeeringConnectionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53625,7 +53625,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVpnConnection(
             input: ElasticComputeCloudModel.DeleteVpnConnectionRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53662,7 +53662,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVpnConnectionRoute(
             input: ElasticComputeCloudModel.DeleteVpnConnectionRouteRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53699,7 +53699,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deleteVpnGateway(
             input: ElasticComputeCloudModel.DeleteVpnGatewayRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53738,7 +53738,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deprovisionByoipCidr(
             input: ElasticComputeCloudModel.DeprovisionByoipCidrRequest) async throws -> ElasticComputeCloudModel.DeprovisionByoipCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53777,7 +53777,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deprovisionIpamPoolCidr(
             input: ElasticComputeCloudModel.DeprovisionIpamPoolCidrRequest) async throws -> ElasticComputeCloudModel.DeprovisionIpamPoolCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53816,7 +53816,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deprovisionPublicIpv4PoolCidr(
             input: ElasticComputeCloudModel.DeprovisionPublicIpv4PoolCidrRequest) async throws -> ElasticComputeCloudModel.DeprovisionPublicIpv4PoolCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53853,7 +53853,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deregisterImage(
             input: ElasticComputeCloudModel.DeregisterImageRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53892,7 +53892,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deregisterInstanceEventNotificationAttributes(
             input: ElasticComputeCloudModel.DeregisterInstanceEventNotificationAttributesRequest) async throws -> ElasticComputeCloudModel.DeregisterInstanceEventNotificationAttributesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53931,7 +53931,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deregisterTransitGatewayMulticastGroupMembers(
             input: ElasticComputeCloudModel.DeregisterTransitGatewayMulticastGroupMembersRequest) async throws -> ElasticComputeCloudModel.DeregisterTransitGatewayMulticastGroupMembersResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -53970,7 +53970,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func deregisterTransitGatewayMulticastGroupSources(
             input: ElasticComputeCloudModel.DeregisterTransitGatewayMulticastGroupSourcesRequest) async throws -> ElasticComputeCloudModel.DeregisterTransitGatewayMulticastGroupSourcesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54009,7 +54009,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeAccountAttributes(
             input: ElasticComputeCloudModel.DescribeAccountAttributesRequest) async throws -> ElasticComputeCloudModel.DescribeAccountAttributesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54048,7 +54048,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeAddressTransfers(
             input: ElasticComputeCloudModel.DescribeAddressTransfersRequest) async throws -> ElasticComputeCloudModel.DescribeAddressTransfersResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54087,7 +54087,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeAddresses(
             input: ElasticComputeCloudModel.DescribeAddressesRequest) async throws -> ElasticComputeCloudModel.DescribeAddressesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54126,7 +54126,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeAddressesAttribute(
             input: ElasticComputeCloudModel.DescribeAddressesAttributeRequest) async throws -> ElasticComputeCloudModel.DescribeAddressesAttributeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54165,7 +54165,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeAggregateIdFormat(
             input: ElasticComputeCloudModel.DescribeAggregateIdFormatRequest) async throws -> ElasticComputeCloudModel.DescribeAggregateIdFormatResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54204,7 +54204,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeAvailabilityZones(
             input: ElasticComputeCloudModel.DescribeAvailabilityZonesRequest) async throws -> ElasticComputeCloudModel.DescribeAvailabilityZonesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54243,7 +54243,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeAwsNetworkPerformanceMetricSubscriptions(
             input: ElasticComputeCloudModel.DescribeAwsNetworkPerformanceMetricSubscriptionsRequest) async throws -> ElasticComputeCloudModel.DescribeAwsNetworkPerformanceMetricSubscriptionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54282,7 +54282,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeBundleTasks(
             input: ElasticComputeCloudModel.DescribeBundleTasksRequest) async throws -> ElasticComputeCloudModel.DescribeBundleTasksResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54321,7 +54321,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeByoipCidrs(
             input: ElasticComputeCloudModel.DescribeByoipCidrsRequest) async throws -> ElasticComputeCloudModel.DescribeByoipCidrsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54360,7 +54360,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeCapacityReservationFleets(
             input: ElasticComputeCloudModel.DescribeCapacityReservationFleetsRequest) async throws -> ElasticComputeCloudModel.DescribeCapacityReservationFleetsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54399,7 +54399,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeCapacityReservations(
             input: ElasticComputeCloudModel.DescribeCapacityReservationsRequest) async throws -> ElasticComputeCloudModel.DescribeCapacityReservationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54438,7 +54438,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeCarrierGateways(
             input: ElasticComputeCloudModel.DescribeCarrierGatewaysRequest) async throws -> ElasticComputeCloudModel.DescribeCarrierGatewaysResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54477,7 +54477,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeClassicLinkInstances(
             input: ElasticComputeCloudModel.DescribeClassicLinkInstancesRequest) async throws -> ElasticComputeCloudModel.DescribeClassicLinkInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54516,7 +54516,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeClientVpnAuthorizationRules(
             input: ElasticComputeCloudModel.DescribeClientVpnAuthorizationRulesRequest) async throws -> ElasticComputeCloudModel.DescribeClientVpnAuthorizationRulesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54555,7 +54555,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeClientVpnConnections(
             input: ElasticComputeCloudModel.DescribeClientVpnConnectionsRequest) async throws -> ElasticComputeCloudModel.DescribeClientVpnConnectionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54594,7 +54594,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeClientVpnEndpoints(
             input: ElasticComputeCloudModel.DescribeClientVpnEndpointsRequest) async throws -> ElasticComputeCloudModel.DescribeClientVpnEndpointsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54633,7 +54633,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeClientVpnRoutes(
             input: ElasticComputeCloudModel.DescribeClientVpnRoutesRequest) async throws -> ElasticComputeCloudModel.DescribeClientVpnRoutesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54672,7 +54672,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeClientVpnTargetNetworks(
             input: ElasticComputeCloudModel.DescribeClientVpnTargetNetworksRequest) async throws -> ElasticComputeCloudModel.DescribeClientVpnTargetNetworksResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54711,7 +54711,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeCoipPools(
             input: ElasticComputeCloudModel.DescribeCoipPoolsRequest) async throws -> ElasticComputeCloudModel.DescribeCoipPoolsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54750,7 +54750,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeConversionTasks(
             input: ElasticComputeCloudModel.DescribeConversionTasksRequest) async throws -> ElasticComputeCloudModel.DescribeConversionTasksResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54789,7 +54789,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeCustomerGateways(
             input: ElasticComputeCloudModel.DescribeCustomerGatewaysRequest) async throws -> ElasticComputeCloudModel.DescribeCustomerGatewaysResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54828,7 +54828,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeDhcpOptions(
             input: ElasticComputeCloudModel.DescribeDhcpOptionsRequest) async throws -> ElasticComputeCloudModel.DescribeDhcpOptionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54867,7 +54867,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeEgressOnlyInternetGateways(
             input: ElasticComputeCloudModel.DescribeEgressOnlyInternetGatewaysRequest) async throws -> ElasticComputeCloudModel.DescribeEgressOnlyInternetGatewaysResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54906,7 +54906,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeElasticGpus(
             input: ElasticComputeCloudModel.DescribeElasticGpusRequest) async throws -> ElasticComputeCloudModel.DescribeElasticGpusResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54945,7 +54945,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeExportImageTasks(
             input: ElasticComputeCloudModel.DescribeExportImageTasksRequest) async throws -> ElasticComputeCloudModel.DescribeExportImageTasksResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -54984,7 +54984,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeExportTasks(
             input: ElasticComputeCloudModel.DescribeExportTasksRequest) async throws -> ElasticComputeCloudModel.DescribeExportTasksResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55023,7 +55023,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeFastLaunchImages(
             input: ElasticComputeCloudModel.DescribeFastLaunchImagesRequest) async throws -> ElasticComputeCloudModel.DescribeFastLaunchImagesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55062,7 +55062,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeFastSnapshotRestores(
             input: ElasticComputeCloudModel.DescribeFastSnapshotRestoresRequest) async throws -> ElasticComputeCloudModel.DescribeFastSnapshotRestoresResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55101,7 +55101,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeFleetHistory(
             input: ElasticComputeCloudModel.DescribeFleetHistoryRequest) async throws -> ElasticComputeCloudModel.DescribeFleetHistoryResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55140,7 +55140,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeFleetInstances(
             input: ElasticComputeCloudModel.DescribeFleetInstancesRequest) async throws -> ElasticComputeCloudModel.DescribeFleetInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55179,7 +55179,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeFleets(
             input: ElasticComputeCloudModel.DescribeFleetsRequest) async throws -> ElasticComputeCloudModel.DescribeFleetsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55218,7 +55218,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeFlowLogs(
             input: ElasticComputeCloudModel.DescribeFlowLogsRequest) async throws -> ElasticComputeCloudModel.DescribeFlowLogsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55257,7 +55257,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeFpgaImageAttribute(
             input: ElasticComputeCloudModel.DescribeFpgaImageAttributeRequest) async throws -> ElasticComputeCloudModel.DescribeFpgaImageAttributeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55296,7 +55296,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeFpgaImages(
             input: ElasticComputeCloudModel.DescribeFpgaImagesRequest) async throws -> ElasticComputeCloudModel.DescribeFpgaImagesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55335,7 +55335,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeHostReservationOfferings(
             input: ElasticComputeCloudModel.DescribeHostReservationOfferingsRequest) async throws -> ElasticComputeCloudModel.DescribeHostReservationOfferingsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55374,7 +55374,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeHostReservations(
             input: ElasticComputeCloudModel.DescribeHostReservationsRequest) async throws -> ElasticComputeCloudModel.DescribeHostReservationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55413,7 +55413,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeHosts(
             input: ElasticComputeCloudModel.DescribeHostsRequest) async throws -> ElasticComputeCloudModel.DescribeHostsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55452,7 +55452,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeIamInstanceProfileAssociations(
             input: ElasticComputeCloudModel.DescribeIamInstanceProfileAssociationsRequest) async throws -> ElasticComputeCloudModel.DescribeIamInstanceProfileAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55491,7 +55491,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeIdFormat(
             input: ElasticComputeCloudModel.DescribeIdFormatRequest) async throws -> ElasticComputeCloudModel.DescribeIdFormatResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55530,7 +55530,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeIdentityIdFormat(
             input: ElasticComputeCloudModel.DescribeIdentityIdFormatRequest) async throws -> ElasticComputeCloudModel.DescribeIdentityIdFormatResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55569,7 +55569,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeImageAttribute(
             input: ElasticComputeCloudModel.DescribeImageAttributeRequest) async throws -> ElasticComputeCloudModel.ImageAttribute {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55608,7 +55608,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeImages(
             input: ElasticComputeCloudModel.DescribeImagesRequest) async throws -> ElasticComputeCloudModel.DescribeImagesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55647,7 +55647,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeImportImageTasks(
             input: ElasticComputeCloudModel.DescribeImportImageTasksRequest) async throws -> ElasticComputeCloudModel.DescribeImportImageTasksResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55686,7 +55686,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeImportSnapshotTasks(
             input: ElasticComputeCloudModel.DescribeImportSnapshotTasksRequest) async throws -> ElasticComputeCloudModel.DescribeImportSnapshotTasksResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55725,7 +55725,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeInstanceAttribute(
             input: ElasticComputeCloudModel.DescribeInstanceAttributeRequest) async throws -> ElasticComputeCloudModel.InstanceAttribute {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55764,7 +55764,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeInstanceConnectEndpoints(
             input: ElasticComputeCloudModel.DescribeInstanceConnectEndpointsRequest) async throws -> ElasticComputeCloudModel.DescribeInstanceConnectEndpointsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55803,7 +55803,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeInstanceCreditSpecifications(
             input: ElasticComputeCloudModel.DescribeInstanceCreditSpecificationsRequest) async throws -> ElasticComputeCloudModel.DescribeInstanceCreditSpecificationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55842,7 +55842,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeInstanceEventNotificationAttributes(
             input: ElasticComputeCloudModel.DescribeInstanceEventNotificationAttributesRequest) async throws -> ElasticComputeCloudModel.DescribeInstanceEventNotificationAttributesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55881,7 +55881,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeInstanceEventWindows(
             input: ElasticComputeCloudModel.DescribeInstanceEventWindowsRequest) async throws -> ElasticComputeCloudModel.DescribeInstanceEventWindowsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55920,7 +55920,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeInstanceStatus(
             input: ElasticComputeCloudModel.DescribeInstanceStatusRequest) async throws -> ElasticComputeCloudModel.DescribeInstanceStatusResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55959,7 +55959,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeInstanceTypeOfferings(
             input: ElasticComputeCloudModel.DescribeInstanceTypeOfferingsRequest) async throws -> ElasticComputeCloudModel.DescribeInstanceTypeOfferingsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -55998,7 +55998,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeInstanceTypes(
             input: ElasticComputeCloudModel.DescribeInstanceTypesRequest) async throws -> ElasticComputeCloudModel.DescribeInstanceTypesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56037,7 +56037,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeInstances(
             input: ElasticComputeCloudModel.DescribeInstancesRequest) async throws -> ElasticComputeCloudModel.DescribeInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56076,7 +56076,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeInternetGateways(
             input: ElasticComputeCloudModel.DescribeInternetGatewaysRequest) async throws -> ElasticComputeCloudModel.DescribeInternetGatewaysResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56115,7 +56115,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeIpamPools(
             input: ElasticComputeCloudModel.DescribeIpamPoolsRequest) async throws -> ElasticComputeCloudModel.DescribeIpamPoolsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56154,7 +56154,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeIpamResourceDiscoveries(
             input: ElasticComputeCloudModel.DescribeIpamResourceDiscoveriesRequest) async throws -> ElasticComputeCloudModel.DescribeIpamResourceDiscoveriesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56193,7 +56193,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeIpamResourceDiscoveryAssociations(
             input: ElasticComputeCloudModel.DescribeIpamResourceDiscoveryAssociationsRequest) async throws -> ElasticComputeCloudModel.DescribeIpamResourceDiscoveryAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56232,7 +56232,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeIpamScopes(
             input: ElasticComputeCloudModel.DescribeIpamScopesRequest) async throws -> ElasticComputeCloudModel.DescribeIpamScopesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56271,7 +56271,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeIpams(
             input: ElasticComputeCloudModel.DescribeIpamsRequest) async throws -> ElasticComputeCloudModel.DescribeIpamsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56310,7 +56310,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeIpv6Pools(
             input: ElasticComputeCloudModel.DescribeIpv6PoolsRequest) async throws -> ElasticComputeCloudModel.DescribeIpv6PoolsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56349,7 +56349,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeKeyPairs(
             input: ElasticComputeCloudModel.DescribeKeyPairsRequest) async throws -> ElasticComputeCloudModel.DescribeKeyPairsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56388,7 +56388,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeLaunchTemplateVersions(
             input: ElasticComputeCloudModel.DescribeLaunchTemplateVersionsRequest) async throws -> ElasticComputeCloudModel.DescribeLaunchTemplateVersionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56427,7 +56427,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeLaunchTemplates(
             input: ElasticComputeCloudModel.DescribeLaunchTemplatesRequest) async throws -> ElasticComputeCloudModel.DescribeLaunchTemplatesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56466,7 +56466,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeLocalGatewayRouteTableVirtualInterfaceGroupAssociations(
             input: ElasticComputeCloudModel.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest) async throws -> ElasticComputeCloudModel.DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56505,7 +56505,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeLocalGatewayRouteTableVpcAssociations(
             input: ElasticComputeCloudModel.DescribeLocalGatewayRouteTableVpcAssociationsRequest) async throws -> ElasticComputeCloudModel.DescribeLocalGatewayRouteTableVpcAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56544,7 +56544,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeLocalGatewayRouteTables(
             input: ElasticComputeCloudModel.DescribeLocalGatewayRouteTablesRequest) async throws -> ElasticComputeCloudModel.DescribeLocalGatewayRouteTablesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56583,7 +56583,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeLocalGatewayVirtualInterfaceGroups(
             input: ElasticComputeCloudModel.DescribeLocalGatewayVirtualInterfaceGroupsRequest) async throws -> ElasticComputeCloudModel.DescribeLocalGatewayVirtualInterfaceGroupsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56622,7 +56622,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeLocalGatewayVirtualInterfaces(
             input: ElasticComputeCloudModel.DescribeLocalGatewayVirtualInterfacesRequest) async throws -> ElasticComputeCloudModel.DescribeLocalGatewayVirtualInterfacesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56661,7 +56661,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeLocalGateways(
             input: ElasticComputeCloudModel.DescribeLocalGatewaysRequest) async throws -> ElasticComputeCloudModel.DescribeLocalGatewaysResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56700,7 +56700,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeManagedPrefixLists(
             input: ElasticComputeCloudModel.DescribeManagedPrefixListsRequest) async throws -> ElasticComputeCloudModel.DescribeManagedPrefixListsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56739,7 +56739,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeMovingAddresses(
             input: ElasticComputeCloudModel.DescribeMovingAddressesRequest) async throws -> ElasticComputeCloudModel.DescribeMovingAddressesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56778,7 +56778,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeNatGateways(
             input: ElasticComputeCloudModel.DescribeNatGatewaysRequest) async throws -> ElasticComputeCloudModel.DescribeNatGatewaysResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56817,7 +56817,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeNetworkAcls(
             input: ElasticComputeCloudModel.DescribeNetworkAclsRequest) async throws -> ElasticComputeCloudModel.DescribeNetworkAclsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56856,7 +56856,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeNetworkInsightsAccessScopeAnalyses(
             input: ElasticComputeCloudModel.DescribeNetworkInsightsAccessScopeAnalysesRequest) async throws -> ElasticComputeCloudModel.DescribeNetworkInsightsAccessScopeAnalysesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56895,7 +56895,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeNetworkInsightsAccessScopes(
             input: ElasticComputeCloudModel.DescribeNetworkInsightsAccessScopesRequest) async throws -> ElasticComputeCloudModel.DescribeNetworkInsightsAccessScopesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56934,7 +56934,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeNetworkInsightsAnalyses(
             input: ElasticComputeCloudModel.DescribeNetworkInsightsAnalysesRequest) async throws -> ElasticComputeCloudModel.DescribeNetworkInsightsAnalysesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -56973,7 +56973,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeNetworkInsightsPaths(
             input: ElasticComputeCloudModel.DescribeNetworkInsightsPathsRequest) async throws -> ElasticComputeCloudModel.DescribeNetworkInsightsPathsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57012,7 +57012,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeNetworkInterfaceAttribute(
             input: ElasticComputeCloudModel.DescribeNetworkInterfaceAttributeRequest) async throws -> ElasticComputeCloudModel.DescribeNetworkInterfaceAttributeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57051,7 +57051,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeNetworkInterfacePermissions(
             input: ElasticComputeCloudModel.DescribeNetworkInterfacePermissionsRequest) async throws -> ElasticComputeCloudModel.DescribeNetworkInterfacePermissionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57090,7 +57090,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeNetworkInterfaces(
             input: ElasticComputeCloudModel.DescribeNetworkInterfacesRequest) async throws -> ElasticComputeCloudModel.DescribeNetworkInterfacesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57129,7 +57129,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describePlacementGroups(
             input: ElasticComputeCloudModel.DescribePlacementGroupsRequest) async throws -> ElasticComputeCloudModel.DescribePlacementGroupsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57168,7 +57168,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describePrefixLists(
             input: ElasticComputeCloudModel.DescribePrefixListsRequest) async throws -> ElasticComputeCloudModel.DescribePrefixListsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57207,7 +57207,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describePrincipalIdFormat(
             input: ElasticComputeCloudModel.DescribePrincipalIdFormatRequest) async throws -> ElasticComputeCloudModel.DescribePrincipalIdFormatResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57246,7 +57246,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describePublicIpv4Pools(
             input: ElasticComputeCloudModel.DescribePublicIpv4PoolsRequest) async throws -> ElasticComputeCloudModel.DescribePublicIpv4PoolsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57285,7 +57285,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeRegions(
             input: ElasticComputeCloudModel.DescribeRegionsRequest) async throws -> ElasticComputeCloudModel.DescribeRegionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57324,7 +57324,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeReplaceRootVolumeTasks(
             input: ElasticComputeCloudModel.DescribeReplaceRootVolumeTasksRequest) async throws -> ElasticComputeCloudModel.DescribeReplaceRootVolumeTasksResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57363,7 +57363,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeReservedInstances(
             input: ElasticComputeCloudModel.DescribeReservedInstancesRequest) async throws -> ElasticComputeCloudModel.DescribeReservedInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57402,7 +57402,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeReservedInstancesListings(
             input: ElasticComputeCloudModel.DescribeReservedInstancesListingsRequest) async throws -> ElasticComputeCloudModel.DescribeReservedInstancesListingsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57441,7 +57441,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeReservedInstancesModifications(
             input: ElasticComputeCloudModel.DescribeReservedInstancesModificationsRequest) async throws -> ElasticComputeCloudModel.DescribeReservedInstancesModificationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57480,7 +57480,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeReservedInstancesOfferings(
             input: ElasticComputeCloudModel.DescribeReservedInstancesOfferingsRequest) async throws -> ElasticComputeCloudModel.DescribeReservedInstancesOfferingsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57519,7 +57519,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeRouteTables(
             input: ElasticComputeCloudModel.DescribeRouteTablesRequest) async throws -> ElasticComputeCloudModel.DescribeRouteTablesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57558,7 +57558,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeScheduledInstanceAvailability(
             input: ElasticComputeCloudModel.DescribeScheduledInstanceAvailabilityRequest) async throws -> ElasticComputeCloudModel.DescribeScheduledInstanceAvailabilityResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57597,7 +57597,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeScheduledInstances(
             input: ElasticComputeCloudModel.DescribeScheduledInstancesRequest) async throws -> ElasticComputeCloudModel.DescribeScheduledInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57636,7 +57636,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSecurityGroupReferences(
             input: ElasticComputeCloudModel.DescribeSecurityGroupReferencesRequest) async throws -> ElasticComputeCloudModel.DescribeSecurityGroupReferencesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57675,7 +57675,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSecurityGroupRules(
             input: ElasticComputeCloudModel.DescribeSecurityGroupRulesRequest) async throws -> ElasticComputeCloudModel.DescribeSecurityGroupRulesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57714,7 +57714,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSecurityGroups(
             input: ElasticComputeCloudModel.DescribeSecurityGroupsRequest) async throws -> ElasticComputeCloudModel.DescribeSecurityGroupsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57753,7 +57753,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSnapshotAttribute(
             input: ElasticComputeCloudModel.DescribeSnapshotAttributeRequest) async throws -> ElasticComputeCloudModel.DescribeSnapshotAttributeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57792,7 +57792,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSnapshotTierStatus(
             input: ElasticComputeCloudModel.DescribeSnapshotTierStatusRequest) async throws -> ElasticComputeCloudModel.DescribeSnapshotTierStatusResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57831,7 +57831,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSnapshots(
             input: ElasticComputeCloudModel.DescribeSnapshotsRequest) async throws -> ElasticComputeCloudModel.DescribeSnapshotsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57870,7 +57870,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSpotDatafeedSubscription(
             input: ElasticComputeCloudModel.DescribeSpotDatafeedSubscriptionRequest) async throws -> ElasticComputeCloudModel.DescribeSpotDatafeedSubscriptionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57909,7 +57909,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSpotFleetInstances(
             input: ElasticComputeCloudModel.DescribeSpotFleetInstancesRequest) async throws -> ElasticComputeCloudModel.DescribeSpotFleetInstancesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57948,7 +57948,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSpotFleetRequestHistory(
             input: ElasticComputeCloudModel.DescribeSpotFleetRequestHistoryRequest) async throws -> ElasticComputeCloudModel.DescribeSpotFleetRequestHistoryResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -57987,7 +57987,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSpotFleetRequests(
             input: ElasticComputeCloudModel.DescribeSpotFleetRequestsRequest) async throws -> ElasticComputeCloudModel.DescribeSpotFleetRequestsResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58026,7 +58026,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSpotInstanceRequests(
             input: ElasticComputeCloudModel.DescribeSpotInstanceRequestsRequest) async throws -> ElasticComputeCloudModel.DescribeSpotInstanceRequestsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58065,7 +58065,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSpotPriceHistory(
             input: ElasticComputeCloudModel.DescribeSpotPriceHistoryRequest) async throws -> ElasticComputeCloudModel.DescribeSpotPriceHistoryResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58104,7 +58104,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeStaleSecurityGroups(
             input: ElasticComputeCloudModel.DescribeStaleSecurityGroupsRequest) async throws -> ElasticComputeCloudModel.DescribeStaleSecurityGroupsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58143,7 +58143,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeStoreImageTasks(
             input: ElasticComputeCloudModel.DescribeStoreImageTasksRequest) async throws -> ElasticComputeCloudModel.DescribeStoreImageTasksResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58182,7 +58182,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeSubnets(
             input: ElasticComputeCloudModel.DescribeSubnetsRequest) async throws -> ElasticComputeCloudModel.DescribeSubnetsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58221,7 +58221,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTags(
             input: ElasticComputeCloudModel.DescribeTagsRequest) async throws -> ElasticComputeCloudModel.DescribeTagsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58260,7 +58260,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTrafficMirrorFilters(
             input: ElasticComputeCloudModel.DescribeTrafficMirrorFiltersRequest) async throws -> ElasticComputeCloudModel.DescribeTrafficMirrorFiltersResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58299,7 +58299,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTrafficMirrorSessions(
             input: ElasticComputeCloudModel.DescribeTrafficMirrorSessionsRequest) async throws -> ElasticComputeCloudModel.DescribeTrafficMirrorSessionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58338,7 +58338,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTrafficMirrorTargets(
             input: ElasticComputeCloudModel.DescribeTrafficMirrorTargetsRequest) async throws -> ElasticComputeCloudModel.DescribeTrafficMirrorTargetsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58377,7 +58377,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTransitGatewayAttachments(
             input: ElasticComputeCloudModel.DescribeTransitGatewayAttachmentsRequest) async throws -> ElasticComputeCloudModel.DescribeTransitGatewayAttachmentsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58416,7 +58416,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTransitGatewayConnectPeers(
             input: ElasticComputeCloudModel.DescribeTransitGatewayConnectPeersRequest) async throws -> ElasticComputeCloudModel.DescribeTransitGatewayConnectPeersResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58455,7 +58455,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTransitGatewayConnects(
             input: ElasticComputeCloudModel.DescribeTransitGatewayConnectsRequest) async throws -> ElasticComputeCloudModel.DescribeTransitGatewayConnectsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58494,7 +58494,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTransitGatewayMulticastDomains(
             input: ElasticComputeCloudModel.DescribeTransitGatewayMulticastDomainsRequest) async throws -> ElasticComputeCloudModel.DescribeTransitGatewayMulticastDomainsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58533,7 +58533,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTransitGatewayPeeringAttachments(
             input: ElasticComputeCloudModel.DescribeTransitGatewayPeeringAttachmentsRequest) async throws -> ElasticComputeCloudModel.DescribeTransitGatewayPeeringAttachmentsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58572,7 +58572,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTransitGatewayPolicyTables(
             input: ElasticComputeCloudModel.DescribeTransitGatewayPolicyTablesRequest) async throws -> ElasticComputeCloudModel.DescribeTransitGatewayPolicyTablesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58611,7 +58611,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTransitGatewayRouteTableAnnouncements(
             input: ElasticComputeCloudModel.DescribeTransitGatewayRouteTableAnnouncementsRequest) async throws -> ElasticComputeCloudModel.DescribeTransitGatewayRouteTableAnnouncementsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58650,7 +58650,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTransitGatewayRouteTables(
             input: ElasticComputeCloudModel.DescribeTransitGatewayRouteTablesRequest) async throws -> ElasticComputeCloudModel.DescribeTransitGatewayRouteTablesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58689,7 +58689,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTransitGatewayVpcAttachments(
             input: ElasticComputeCloudModel.DescribeTransitGatewayVpcAttachmentsRequest) async throws -> ElasticComputeCloudModel.DescribeTransitGatewayVpcAttachmentsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58728,7 +58728,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTransitGateways(
             input: ElasticComputeCloudModel.DescribeTransitGatewaysRequest) async throws -> ElasticComputeCloudModel.DescribeTransitGatewaysResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58767,7 +58767,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeTrunkInterfaceAssociations(
             input: ElasticComputeCloudModel.DescribeTrunkInterfaceAssociationsRequest) async throws -> ElasticComputeCloudModel.DescribeTrunkInterfaceAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58806,7 +58806,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVerifiedAccessEndpoints(
             input: ElasticComputeCloudModel.DescribeVerifiedAccessEndpointsRequest) async throws -> ElasticComputeCloudModel.DescribeVerifiedAccessEndpointsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58845,7 +58845,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVerifiedAccessGroups(
             input: ElasticComputeCloudModel.DescribeVerifiedAccessGroupsRequest) async throws -> ElasticComputeCloudModel.DescribeVerifiedAccessGroupsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58884,7 +58884,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVerifiedAccessInstanceLoggingConfigurations(
             input: ElasticComputeCloudModel.DescribeVerifiedAccessInstanceLoggingConfigurationsRequest) async throws -> ElasticComputeCloudModel.DescribeVerifiedAccessInstanceLoggingConfigurationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58923,7 +58923,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVerifiedAccessInstances(
             input: ElasticComputeCloudModel.DescribeVerifiedAccessInstancesRequest) async throws -> ElasticComputeCloudModel.DescribeVerifiedAccessInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -58962,7 +58962,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVerifiedAccessTrustProviders(
             input: ElasticComputeCloudModel.DescribeVerifiedAccessTrustProvidersRequest) async throws -> ElasticComputeCloudModel.DescribeVerifiedAccessTrustProvidersResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59001,7 +59001,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVolumeAttribute(
             input: ElasticComputeCloudModel.DescribeVolumeAttributeRequest) async throws -> ElasticComputeCloudModel.DescribeVolumeAttributeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59040,7 +59040,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVolumeStatus(
             input: ElasticComputeCloudModel.DescribeVolumeStatusRequest) async throws -> ElasticComputeCloudModel.DescribeVolumeStatusResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59079,7 +59079,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVolumes(
             input: ElasticComputeCloudModel.DescribeVolumesRequest) async throws -> ElasticComputeCloudModel.DescribeVolumesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59118,7 +59118,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVolumesModifications(
             input: ElasticComputeCloudModel.DescribeVolumesModificationsRequest) async throws -> ElasticComputeCloudModel.DescribeVolumesModificationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59157,7 +59157,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcAttribute(
             input: ElasticComputeCloudModel.DescribeVpcAttributeRequest) async throws -> ElasticComputeCloudModel.DescribeVpcAttributeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59196,7 +59196,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcClassicLink(
             input: ElasticComputeCloudModel.DescribeVpcClassicLinkRequest) async throws -> ElasticComputeCloudModel.DescribeVpcClassicLinkResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59235,7 +59235,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcClassicLinkDnsSupport(
             input: ElasticComputeCloudModel.DescribeVpcClassicLinkDnsSupportRequest) async throws -> ElasticComputeCloudModel.DescribeVpcClassicLinkDnsSupportResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59274,7 +59274,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcEndpointConnectionNotifications(
             input: ElasticComputeCloudModel.DescribeVpcEndpointConnectionNotificationsRequest) async throws -> ElasticComputeCloudModel.DescribeVpcEndpointConnectionNotificationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59313,7 +59313,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcEndpointConnections(
             input: ElasticComputeCloudModel.DescribeVpcEndpointConnectionsRequest) async throws -> ElasticComputeCloudModel.DescribeVpcEndpointConnectionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59352,7 +59352,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcEndpointServiceConfigurations(
             input: ElasticComputeCloudModel.DescribeVpcEndpointServiceConfigurationsRequest) async throws -> ElasticComputeCloudModel.DescribeVpcEndpointServiceConfigurationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59391,7 +59391,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcEndpointServicePermissions(
             input: ElasticComputeCloudModel.DescribeVpcEndpointServicePermissionsRequest) async throws -> ElasticComputeCloudModel.DescribeVpcEndpointServicePermissionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59430,7 +59430,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcEndpointServices(
             input: ElasticComputeCloudModel.DescribeVpcEndpointServicesRequest) async throws -> ElasticComputeCloudModel.DescribeVpcEndpointServicesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59469,7 +59469,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcEndpoints(
             input: ElasticComputeCloudModel.DescribeVpcEndpointsRequest) async throws -> ElasticComputeCloudModel.DescribeVpcEndpointsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59508,7 +59508,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcPeeringConnections(
             input: ElasticComputeCloudModel.DescribeVpcPeeringConnectionsRequest) async throws -> ElasticComputeCloudModel.DescribeVpcPeeringConnectionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59547,7 +59547,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpcs(
             input: ElasticComputeCloudModel.DescribeVpcsRequest) async throws -> ElasticComputeCloudModel.DescribeVpcsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59586,7 +59586,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpnConnections(
             input: ElasticComputeCloudModel.DescribeVpnConnectionsRequest) async throws -> ElasticComputeCloudModel.DescribeVpnConnectionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59625,7 +59625,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func describeVpnGateways(
             input: ElasticComputeCloudModel.DescribeVpnGatewaysRequest) async throws -> ElasticComputeCloudModel.DescribeVpnGatewaysResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59664,7 +59664,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func detachClassicLinkVpc(
             input: ElasticComputeCloudModel.DetachClassicLinkVpcRequest) async throws -> ElasticComputeCloudModel.DetachClassicLinkVpcResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59701,7 +59701,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func detachInternetGateway(
             input: ElasticComputeCloudModel.DetachInternetGatewayRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59738,7 +59738,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func detachNetworkInterface(
             input: ElasticComputeCloudModel.DetachNetworkInterfaceRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59777,7 +59777,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func detachVerifiedAccessTrustProvider(
             input: ElasticComputeCloudModel.DetachVerifiedAccessTrustProviderRequest) async throws -> ElasticComputeCloudModel.DetachVerifiedAccessTrustProviderResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59816,7 +59816,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func detachVolume(
             input: ElasticComputeCloudModel.DetachVolumeRequest) async throws -> ElasticComputeCloudModel.VolumeAttachment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59853,7 +59853,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func detachVpnGateway(
             input: ElasticComputeCloudModel.DetachVpnGatewayRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59892,7 +59892,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableAddressTransfer(
             input: ElasticComputeCloudModel.DisableAddressTransferRequest) async throws -> ElasticComputeCloudModel.DisableAddressTransferResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59931,7 +59931,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableAwsNetworkPerformanceMetricSubscription(
             input: ElasticComputeCloudModel.DisableAwsNetworkPerformanceMetricSubscriptionRequest) async throws -> ElasticComputeCloudModel.DisableAwsNetworkPerformanceMetricSubscriptionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -59970,7 +59970,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableEbsEncryptionByDefault(
             input: ElasticComputeCloudModel.DisableEbsEncryptionByDefaultRequest) async throws -> ElasticComputeCloudModel.DisableEbsEncryptionByDefaultResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60009,7 +60009,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableFastLaunch(
             input: ElasticComputeCloudModel.DisableFastLaunchRequest) async throws -> ElasticComputeCloudModel.DisableFastLaunchResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60048,7 +60048,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableFastSnapshotRestores(
             input: ElasticComputeCloudModel.DisableFastSnapshotRestoresRequest) async throws -> ElasticComputeCloudModel.DisableFastSnapshotRestoresResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60087,7 +60087,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableImage(
             input: ElasticComputeCloudModel.DisableImageRequest) async throws -> ElasticComputeCloudModel.DisableImageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60126,7 +60126,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableImageBlockPublicAccess(
             input: ElasticComputeCloudModel.DisableImageBlockPublicAccessRequest) async throws -> ElasticComputeCloudModel.DisableImageBlockPublicAccessResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60165,7 +60165,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableImageDeprecation(
             input: ElasticComputeCloudModel.DisableImageDeprecationRequest) async throws -> ElasticComputeCloudModel.DisableImageDeprecationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60204,7 +60204,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableIpamOrganizationAdminAccount(
             input: ElasticComputeCloudModel.DisableIpamOrganizationAdminAccountRequest) async throws -> ElasticComputeCloudModel.DisableIpamOrganizationAdminAccountResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60243,7 +60243,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableSerialConsoleAccess(
             input: ElasticComputeCloudModel.DisableSerialConsoleAccessRequest) async throws -> ElasticComputeCloudModel.DisableSerialConsoleAccessResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60282,7 +60282,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableTransitGatewayRouteTablePropagation(
             input: ElasticComputeCloudModel.DisableTransitGatewayRouteTablePropagationRequest) async throws -> ElasticComputeCloudModel.DisableTransitGatewayRouteTablePropagationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60319,7 +60319,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableVgwRoutePropagation(
             input: ElasticComputeCloudModel.DisableVgwRoutePropagationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60358,7 +60358,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableVpcClassicLink(
             input: ElasticComputeCloudModel.DisableVpcClassicLinkRequest) async throws -> ElasticComputeCloudModel.DisableVpcClassicLinkResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60397,7 +60397,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disableVpcClassicLinkDnsSupport(
             input: ElasticComputeCloudModel.DisableVpcClassicLinkDnsSupportRequest) async throws -> ElasticComputeCloudModel.DisableVpcClassicLinkDnsSupportResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60434,7 +60434,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateAddress(
             input: ElasticComputeCloudModel.DisassociateAddressRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60473,7 +60473,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateClientVpnTargetNetwork(
             input: ElasticComputeCloudModel.DisassociateClientVpnTargetNetworkRequest) async throws -> ElasticComputeCloudModel.DisassociateClientVpnTargetNetworkResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60512,7 +60512,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateEnclaveCertificateIamRole(
             input: ElasticComputeCloudModel.DisassociateEnclaveCertificateIamRoleRequest) async throws -> ElasticComputeCloudModel.DisassociateEnclaveCertificateIamRoleResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60551,7 +60551,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateIamInstanceProfile(
             input: ElasticComputeCloudModel.DisassociateIamInstanceProfileRequest) async throws -> ElasticComputeCloudModel.DisassociateIamInstanceProfileResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60590,7 +60590,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateInstanceEventWindow(
             input: ElasticComputeCloudModel.DisassociateInstanceEventWindowRequest) async throws -> ElasticComputeCloudModel.DisassociateInstanceEventWindowResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60629,7 +60629,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateIpamResourceDiscovery(
             input: ElasticComputeCloudModel.DisassociateIpamResourceDiscoveryRequest) async throws -> ElasticComputeCloudModel.DisassociateIpamResourceDiscoveryResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60668,7 +60668,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateNatGatewayAddress(
             input: ElasticComputeCloudModel.DisassociateNatGatewayAddressRequest) async throws -> ElasticComputeCloudModel.DisassociateNatGatewayAddressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60705,7 +60705,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateRouteTable(
             input: ElasticComputeCloudModel.DisassociateRouteTableRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60744,7 +60744,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateSubnetCidrBlock(
             input: ElasticComputeCloudModel.DisassociateSubnetCidrBlockRequest) async throws -> ElasticComputeCloudModel.DisassociateSubnetCidrBlockResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60783,7 +60783,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateTransitGatewayMulticastDomain(
             input: ElasticComputeCloudModel.DisassociateTransitGatewayMulticastDomainRequest) async throws -> ElasticComputeCloudModel.DisassociateTransitGatewayMulticastDomainResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60822,7 +60822,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateTransitGatewayPolicyTable(
             input: ElasticComputeCloudModel.DisassociateTransitGatewayPolicyTableRequest) async throws -> ElasticComputeCloudModel.DisassociateTransitGatewayPolicyTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60861,7 +60861,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateTransitGatewayRouteTable(
             input: ElasticComputeCloudModel.DisassociateTransitGatewayRouteTableRequest) async throws -> ElasticComputeCloudModel.DisassociateTransitGatewayRouteTableResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60900,7 +60900,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateTrunkInterface(
             input: ElasticComputeCloudModel.DisassociateTrunkInterfaceRequest) async throws -> ElasticComputeCloudModel.DisassociateTrunkInterfaceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60939,7 +60939,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func disassociateVpcCidrBlock(
             input: ElasticComputeCloudModel.DisassociateVpcCidrBlockRequest) async throws -> ElasticComputeCloudModel.DisassociateVpcCidrBlockResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -60978,7 +60978,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableAddressTransfer(
             input: ElasticComputeCloudModel.EnableAddressTransferRequest) async throws -> ElasticComputeCloudModel.EnableAddressTransferResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61017,7 +61017,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableAwsNetworkPerformanceMetricSubscription(
             input: ElasticComputeCloudModel.EnableAwsNetworkPerformanceMetricSubscriptionRequest) async throws -> ElasticComputeCloudModel.EnableAwsNetworkPerformanceMetricSubscriptionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61056,7 +61056,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableEbsEncryptionByDefault(
             input: ElasticComputeCloudModel.EnableEbsEncryptionByDefaultRequest) async throws -> ElasticComputeCloudModel.EnableEbsEncryptionByDefaultResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61095,7 +61095,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableFastLaunch(
             input: ElasticComputeCloudModel.EnableFastLaunchRequest) async throws -> ElasticComputeCloudModel.EnableFastLaunchResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61134,7 +61134,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableFastSnapshotRestores(
             input: ElasticComputeCloudModel.EnableFastSnapshotRestoresRequest) async throws -> ElasticComputeCloudModel.EnableFastSnapshotRestoresResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61173,7 +61173,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableImage(
             input: ElasticComputeCloudModel.EnableImageRequest) async throws -> ElasticComputeCloudModel.EnableImageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61212,7 +61212,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableImageBlockPublicAccess(
             input: ElasticComputeCloudModel.EnableImageBlockPublicAccessRequest) async throws -> ElasticComputeCloudModel.EnableImageBlockPublicAccessResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61251,7 +61251,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableImageDeprecation(
             input: ElasticComputeCloudModel.EnableImageDeprecationRequest) async throws -> ElasticComputeCloudModel.EnableImageDeprecationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61290,7 +61290,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableIpamOrganizationAdminAccount(
             input: ElasticComputeCloudModel.EnableIpamOrganizationAdminAccountRequest) async throws -> ElasticComputeCloudModel.EnableIpamOrganizationAdminAccountResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61329,7 +61329,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableReachabilityAnalyzerOrganizationSharing(
             input: ElasticComputeCloudModel.EnableReachabilityAnalyzerOrganizationSharingRequest) async throws -> ElasticComputeCloudModel.EnableReachabilityAnalyzerOrganizationSharingResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61368,7 +61368,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableSerialConsoleAccess(
             input: ElasticComputeCloudModel.EnableSerialConsoleAccessRequest) async throws -> ElasticComputeCloudModel.EnableSerialConsoleAccessResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61407,7 +61407,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableTransitGatewayRouteTablePropagation(
             input: ElasticComputeCloudModel.EnableTransitGatewayRouteTablePropagationRequest) async throws -> ElasticComputeCloudModel.EnableTransitGatewayRouteTablePropagationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61444,7 +61444,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableVgwRoutePropagation(
             input: ElasticComputeCloudModel.EnableVgwRoutePropagationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61481,7 +61481,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableVolumeIO(
             input: ElasticComputeCloudModel.EnableVolumeIORequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61520,7 +61520,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableVpcClassicLink(
             input: ElasticComputeCloudModel.EnableVpcClassicLinkRequest) async throws -> ElasticComputeCloudModel.EnableVpcClassicLinkResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61559,7 +61559,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func enableVpcClassicLinkDnsSupport(
             input: ElasticComputeCloudModel.EnableVpcClassicLinkDnsSupportRequest) async throws -> ElasticComputeCloudModel.EnableVpcClassicLinkDnsSupportResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61598,7 +61598,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func exportClientVpnClientCertificateRevocationList(
             input: ElasticComputeCloudModel.ExportClientVpnClientCertificateRevocationListRequest) async throws -> ElasticComputeCloudModel.ExportClientVpnClientCertificateRevocationListResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61637,7 +61637,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func exportClientVpnClientConfiguration(
             input: ElasticComputeCloudModel.ExportClientVpnClientConfigurationRequest) async throws -> ElasticComputeCloudModel.ExportClientVpnClientConfigurationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61676,7 +61676,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func exportImage(
             input: ElasticComputeCloudModel.ExportImageRequest) async throws -> ElasticComputeCloudModel.ExportImageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61715,7 +61715,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func exportTransitGatewayRoutes(
             input: ElasticComputeCloudModel.ExportTransitGatewayRoutesRequest) async throws -> ElasticComputeCloudModel.ExportTransitGatewayRoutesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61754,7 +61754,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getAssociatedEnclaveCertificateIamRoles(
             input: ElasticComputeCloudModel.GetAssociatedEnclaveCertificateIamRolesRequest) async throws -> ElasticComputeCloudModel.GetAssociatedEnclaveCertificateIamRolesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61793,7 +61793,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getAssociatedIpv6PoolCidrs(
             input: ElasticComputeCloudModel.GetAssociatedIpv6PoolCidrsRequest) async throws -> ElasticComputeCloudModel.GetAssociatedIpv6PoolCidrsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61832,7 +61832,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getAwsNetworkPerformanceData(
             input: ElasticComputeCloudModel.GetAwsNetworkPerformanceDataRequest) async throws -> ElasticComputeCloudModel.GetAwsNetworkPerformanceDataResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61871,7 +61871,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getCapacityReservationUsage(
             input: ElasticComputeCloudModel.GetCapacityReservationUsageRequest) async throws -> ElasticComputeCloudModel.GetCapacityReservationUsageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61910,7 +61910,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getCoipPoolUsage(
             input: ElasticComputeCloudModel.GetCoipPoolUsageRequest) async throws -> ElasticComputeCloudModel.GetCoipPoolUsageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61949,7 +61949,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getConsoleOutput(
             input: ElasticComputeCloudModel.GetConsoleOutputRequest) async throws -> ElasticComputeCloudModel.GetConsoleOutputResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -61988,7 +61988,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getConsoleScreenshot(
             input: ElasticComputeCloudModel.GetConsoleScreenshotRequest) async throws -> ElasticComputeCloudModel.GetConsoleScreenshotResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62027,7 +62027,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getDefaultCreditSpecification(
             input: ElasticComputeCloudModel.GetDefaultCreditSpecificationRequest) async throws -> ElasticComputeCloudModel.GetDefaultCreditSpecificationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62066,7 +62066,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getEbsDefaultKmsKeyId(
             input: ElasticComputeCloudModel.GetEbsDefaultKmsKeyIdRequest) async throws -> ElasticComputeCloudModel.GetEbsDefaultKmsKeyIdResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62105,7 +62105,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getEbsEncryptionByDefault(
             input: ElasticComputeCloudModel.GetEbsEncryptionByDefaultRequest) async throws -> ElasticComputeCloudModel.GetEbsEncryptionByDefaultResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62144,7 +62144,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getFlowLogsIntegrationTemplate(
             input: ElasticComputeCloudModel.GetFlowLogsIntegrationTemplateRequest) async throws -> ElasticComputeCloudModel.GetFlowLogsIntegrationTemplateResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62183,7 +62183,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getGroupsForCapacityReservation(
             input: ElasticComputeCloudModel.GetGroupsForCapacityReservationRequest) async throws -> ElasticComputeCloudModel.GetGroupsForCapacityReservationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62222,7 +62222,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getHostReservationPurchasePreview(
             input: ElasticComputeCloudModel.GetHostReservationPurchasePreviewRequest) async throws -> ElasticComputeCloudModel.GetHostReservationPurchasePreviewResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62261,7 +62261,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getImageBlockPublicAccessState(
             input: ElasticComputeCloudModel.GetImageBlockPublicAccessStateRequest) async throws -> ElasticComputeCloudModel.GetImageBlockPublicAccessStateResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62300,7 +62300,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getInstanceTypesFromInstanceRequirements(
             input: ElasticComputeCloudModel.GetInstanceTypesFromInstanceRequirementsRequest) async throws -> ElasticComputeCloudModel.GetInstanceTypesFromInstanceRequirementsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62339,7 +62339,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getInstanceUefiData(
             input: ElasticComputeCloudModel.GetInstanceUefiDataRequest) async throws -> ElasticComputeCloudModel.GetInstanceUefiDataResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62378,7 +62378,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getIpamAddressHistory(
             input: ElasticComputeCloudModel.GetIpamAddressHistoryRequest) async throws -> ElasticComputeCloudModel.GetIpamAddressHistoryResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62417,7 +62417,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getIpamDiscoveredAccounts(
             input: ElasticComputeCloudModel.GetIpamDiscoveredAccountsRequest) async throws -> ElasticComputeCloudModel.GetIpamDiscoveredAccountsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62456,7 +62456,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getIpamDiscoveredResourceCidrs(
             input: ElasticComputeCloudModel.GetIpamDiscoveredResourceCidrsRequest) async throws -> ElasticComputeCloudModel.GetIpamDiscoveredResourceCidrsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62495,7 +62495,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getIpamPoolAllocations(
             input: ElasticComputeCloudModel.GetIpamPoolAllocationsRequest) async throws -> ElasticComputeCloudModel.GetIpamPoolAllocationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62534,7 +62534,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getIpamPoolCidrs(
             input: ElasticComputeCloudModel.GetIpamPoolCidrsRequest) async throws -> ElasticComputeCloudModel.GetIpamPoolCidrsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62573,7 +62573,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getIpamResourceCidrs(
             input: ElasticComputeCloudModel.GetIpamResourceCidrsRequest) async throws -> ElasticComputeCloudModel.GetIpamResourceCidrsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62612,7 +62612,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getLaunchTemplateData(
             input: ElasticComputeCloudModel.GetLaunchTemplateDataRequest) async throws -> ElasticComputeCloudModel.GetLaunchTemplateDataResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62651,7 +62651,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getManagedPrefixListAssociations(
             input: ElasticComputeCloudModel.GetManagedPrefixListAssociationsRequest) async throws -> ElasticComputeCloudModel.GetManagedPrefixListAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62690,7 +62690,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getManagedPrefixListEntries(
             input: ElasticComputeCloudModel.GetManagedPrefixListEntriesRequest) async throws -> ElasticComputeCloudModel.GetManagedPrefixListEntriesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62729,7 +62729,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getNetworkInsightsAccessScopeAnalysisFindings(
             input: ElasticComputeCloudModel.GetNetworkInsightsAccessScopeAnalysisFindingsRequest) async throws -> ElasticComputeCloudModel.GetNetworkInsightsAccessScopeAnalysisFindingsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62768,7 +62768,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getNetworkInsightsAccessScopeContent(
             input: ElasticComputeCloudModel.GetNetworkInsightsAccessScopeContentRequest) async throws -> ElasticComputeCloudModel.GetNetworkInsightsAccessScopeContentResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62807,7 +62807,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getPasswordData(
             input: ElasticComputeCloudModel.GetPasswordDataRequest) async throws -> ElasticComputeCloudModel.GetPasswordDataResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62846,7 +62846,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getReservedInstancesExchangeQuote(
             input: ElasticComputeCloudModel.GetReservedInstancesExchangeQuoteRequest) async throws -> ElasticComputeCloudModel.GetReservedInstancesExchangeQuoteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62885,7 +62885,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getSecurityGroupsForVpc(
             input: ElasticComputeCloudModel.GetSecurityGroupsForVpcRequest) async throws -> ElasticComputeCloudModel.GetSecurityGroupsForVpcResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62924,7 +62924,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getSerialConsoleAccessStatus(
             input: ElasticComputeCloudModel.GetSerialConsoleAccessStatusRequest) async throws -> ElasticComputeCloudModel.GetSerialConsoleAccessStatusResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -62963,7 +62963,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getSpotPlacementScores(
             input: ElasticComputeCloudModel.GetSpotPlacementScoresRequest) async throws -> ElasticComputeCloudModel.GetSpotPlacementScoresResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63002,7 +63002,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getSubnetCidrReservations(
             input: ElasticComputeCloudModel.GetSubnetCidrReservationsRequest) async throws -> ElasticComputeCloudModel.GetSubnetCidrReservationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63041,7 +63041,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getTransitGatewayAttachmentPropagations(
             input: ElasticComputeCloudModel.GetTransitGatewayAttachmentPropagationsRequest) async throws -> ElasticComputeCloudModel.GetTransitGatewayAttachmentPropagationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63080,7 +63080,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getTransitGatewayMulticastDomainAssociations(
             input: ElasticComputeCloudModel.GetTransitGatewayMulticastDomainAssociationsRequest) async throws -> ElasticComputeCloudModel.GetTransitGatewayMulticastDomainAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63119,7 +63119,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getTransitGatewayPolicyTableAssociations(
             input: ElasticComputeCloudModel.GetTransitGatewayPolicyTableAssociationsRequest) async throws -> ElasticComputeCloudModel.GetTransitGatewayPolicyTableAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63158,7 +63158,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getTransitGatewayPolicyTableEntries(
             input: ElasticComputeCloudModel.GetTransitGatewayPolicyTableEntriesRequest) async throws -> ElasticComputeCloudModel.GetTransitGatewayPolicyTableEntriesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63197,7 +63197,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getTransitGatewayPrefixListReferences(
             input: ElasticComputeCloudModel.GetTransitGatewayPrefixListReferencesRequest) async throws -> ElasticComputeCloudModel.GetTransitGatewayPrefixListReferencesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63236,7 +63236,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getTransitGatewayRouteTableAssociations(
             input: ElasticComputeCloudModel.GetTransitGatewayRouteTableAssociationsRequest) async throws -> ElasticComputeCloudModel.GetTransitGatewayRouteTableAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63275,7 +63275,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getTransitGatewayRouteTablePropagations(
             input: ElasticComputeCloudModel.GetTransitGatewayRouteTablePropagationsRequest) async throws -> ElasticComputeCloudModel.GetTransitGatewayRouteTablePropagationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63314,7 +63314,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getVerifiedAccessEndpointPolicy(
             input: ElasticComputeCloudModel.GetVerifiedAccessEndpointPolicyRequest) async throws -> ElasticComputeCloudModel.GetVerifiedAccessEndpointPolicyResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63353,7 +63353,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getVerifiedAccessGroupPolicy(
             input: ElasticComputeCloudModel.GetVerifiedAccessGroupPolicyRequest) async throws -> ElasticComputeCloudModel.GetVerifiedAccessGroupPolicyResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63392,7 +63392,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getVpnConnectionDeviceSampleConfiguration(
             input: ElasticComputeCloudModel.GetVpnConnectionDeviceSampleConfigurationRequest) async throws -> ElasticComputeCloudModel.GetVpnConnectionDeviceSampleConfigurationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63431,7 +63431,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getVpnConnectionDeviceTypes(
             input: ElasticComputeCloudModel.GetVpnConnectionDeviceTypesRequest) async throws -> ElasticComputeCloudModel.GetVpnConnectionDeviceTypesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63470,7 +63470,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func getVpnTunnelReplacementStatus(
             input: ElasticComputeCloudModel.GetVpnTunnelReplacementStatusRequest) async throws -> ElasticComputeCloudModel.GetVpnTunnelReplacementStatusResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63509,7 +63509,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func importClientVpnClientCertificateRevocationList(
             input: ElasticComputeCloudModel.ImportClientVpnClientCertificateRevocationListRequest) async throws -> ElasticComputeCloudModel.ImportClientVpnClientCertificateRevocationListResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63548,7 +63548,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func importImage(
             input: ElasticComputeCloudModel.ImportImageRequest) async throws -> ElasticComputeCloudModel.ImportImageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63587,7 +63587,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func importInstance(
             input: ElasticComputeCloudModel.ImportInstanceRequest) async throws -> ElasticComputeCloudModel.ImportInstanceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63626,7 +63626,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func importKeyPair(
             input: ElasticComputeCloudModel.ImportKeyPairRequest) async throws -> ElasticComputeCloudModel.ImportKeyPairResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63665,7 +63665,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func importSnapshot(
             input: ElasticComputeCloudModel.ImportSnapshotRequest) async throws -> ElasticComputeCloudModel.ImportSnapshotResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63704,7 +63704,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func importVolume(
             input: ElasticComputeCloudModel.ImportVolumeRequest) async throws -> ElasticComputeCloudModel.ImportVolumeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63743,7 +63743,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func listImagesInRecycleBin(
             input: ElasticComputeCloudModel.ListImagesInRecycleBinRequest) async throws -> ElasticComputeCloudModel.ListImagesInRecycleBinResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63782,7 +63782,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func listSnapshotsInRecycleBin(
             input: ElasticComputeCloudModel.ListSnapshotsInRecycleBinRequest) async throws -> ElasticComputeCloudModel.ListSnapshotsInRecycleBinResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63821,7 +63821,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyAddressAttribute(
             input: ElasticComputeCloudModel.ModifyAddressAttributeRequest) async throws -> ElasticComputeCloudModel.ModifyAddressAttributeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63860,7 +63860,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyAvailabilityZoneGroup(
             input: ElasticComputeCloudModel.ModifyAvailabilityZoneGroupRequest) async throws -> ElasticComputeCloudModel.ModifyAvailabilityZoneGroupResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63899,7 +63899,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyCapacityReservation(
             input: ElasticComputeCloudModel.ModifyCapacityReservationRequest) async throws -> ElasticComputeCloudModel.ModifyCapacityReservationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63938,7 +63938,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyCapacityReservationFleet(
             input: ElasticComputeCloudModel.ModifyCapacityReservationFleetRequest) async throws -> ElasticComputeCloudModel.ModifyCapacityReservationFleetResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -63977,7 +63977,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyClientVpnEndpoint(
             input: ElasticComputeCloudModel.ModifyClientVpnEndpointRequest) async throws -> ElasticComputeCloudModel.ModifyClientVpnEndpointResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64016,7 +64016,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyDefaultCreditSpecification(
             input: ElasticComputeCloudModel.ModifyDefaultCreditSpecificationRequest) async throws -> ElasticComputeCloudModel.ModifyDefaultCreditSpecificationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64055,7 +64055,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyEbsDefaultKmsKeyId(
             input: ElasticComputeCloudModel.ModifyEbsDefaultKmsKeyIdRequest) async throws -> ElasticComputeCloudModel.ModifyEbsDefaultKmsKeyIdResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64094,7 +64094,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyFleet(
             input: ElasticComputeCloudModel.ModifyFleetRequest) async throws -> ElasticComputeCloudModel.ModifyFleetResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64133,7 +64133,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyFpgaImageAttribute(
             input: ElasticComputeCloudModel.ModifyFpgaImageAttributeRequest) async throws -> ElasticComputeCloudModel.ModifyFpgaImageAttributeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64172,7 +64172,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyHosts(
             input: ElasticComputeCloudModel.ModifyHostsRequest) async throws -> ElasticComputeCloudModel.ModifyHostsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64209,7 +64209,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyIdFormat(
             input: ElasticComputeCloudModel.ModifyIdFormatRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64246,7 +64246,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyIdentityIdFormat(
             input: ElasticComputeCloudModel.ModifyIdentityIdFormatRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64283,7 +64283,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyImageAttribute(
             input: ElasticComputeCloudModel.ModifyImageAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64320,7 +64320,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyInstanceAttribute(
             input: ElasticComputeCloudModel.ModifyInstanceAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64359,7 +64359,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyInstanceCapacityReservationAttributes(
             input: ElasticComputeCloudModel.ModifyInstanceCapacityReservationAttributesRequest) async throws -> ElasticComputeCloudModel.ModifyInstanceCapacityReservationAttributesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64398,7 +64398,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyInstanceCreditSpecification(
             input: ElasticComputeCloudModel.ModifyInstanceCreditSpecificationRequest) async throws -> ElasticComputeCloudModel.ModifyInstanceCreditSpecificationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64437,7 +64437,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyInstanceEventStartTime(
             input: ElasticComputeCloudModel.ModifyInstanceEventStartTimeRequest) async throws -> ElasticComputeCloudModel.ModifyInstanceEventStartTimeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64476,7 +64476,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyInstanceEventWindow(
             input: ElasticComputeCloudModel.ModifyInstanceEventWindowRequest) async throws -> ElasticComputeCloudModel.ModifyInstanceEventWindowResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64515,7 +64515,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyInstanceMaintenanceOptions(
             input: ElasticComputeCloudModel.ModifyInstanceMaintenanceOptionsRequest) async throws -> ElasticComputeCloudModel.ModifyInstanceMaintenanceOptionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64554,7 +64554,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyInstanceMetadataOptions(
             input: ElasticComputeCloudModel.ModifyInstanceMetadataOptionsRequest) async throws -> ElasticComputeCloudModel.ModifyInstanceMetadataOptionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64593,7 +64593,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyInstancePlacement(
             input: ElasticComputeCloudModel.ModifyInstancePlacementRequest) async throws -> ElasticComputeCloudModel.ModifyInstancePlacementResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64632,7 +64632,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyIpam(
             input: ElasticComputeCloudModel.ModifyIpamRequest) async throws -> ElasticComputeCloudModel.ModifyIpamResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64671,7 +64671,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyIpamPool(
             input: ElasticComputeCloudModel.ModifyIpamPoolRequest) async throws -> ElasticComputeCloudModel.ModifyIpamPoolResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64710,7 +64710,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyIpamResourceCidr(
             input: ElasticComputeCloudModel.ModifyIpamResourceCidrRequest) async throws -> ElasticComputeCloudModel.ModifyIpamResourceCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64749,7 +64749,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyIpamResourceDiscovery(
             input: ElasticComputeCloudModel.ModifyIpamResourceDiscoveryRequest) async throws -> ElasticComputeCloudModel.ModifyIpamResourceDiscoveryResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64788,7 +64788,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyIpamScope(
             input: ElasticComputeCloudModel.ModifyIpamScopeRequest) async throws -> ElasticComputeCloudModel.ModifyIpamScopeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64827,7 +64827,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyLaunchTemplate(
             input: ElasticComputeCloudModel.ModifyLaunchTemplateRequest) async throws -> ElasticComputeCloudModel.ModifyLaunchTemplateResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64866,7 +64866,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyLocalGatewayRoute(
             input: ElasticComputeCloudModel.ModifyLocalGatewayRouteRequest) async throws -> ElasticComputeCloudModel.ModifyLocalGatewayRouteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64905,7 +64905,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyManagedPrefixList(
             input: ElasticComputeCloudModel.ModifyManagedPrefixListRequest) async throws -> ElasticComputeCloudModel.ModifyManagedPrefixListResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64942,7 +64942,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyNetworkInterfaceAttribute(
             input: ElasticComputeCloudModel.ModifyNetworkInterfaceAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -64981,7 +64981,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyPrivateDnsNameOptions(
             input: ElasticComputeCloudModel.ModifyPrivateDnsNameOptionsRequest) async throws -> ElasticComputeCloudModel.ModifyPrivateDnsNameOptionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65020,7 +65020,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyReservedInstances(
             input: ElasticComputeCloudModel.ModifyReservedInstancesRequest) async throws -> ElasticComputeCloudModel.ModifyReservedInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65059,7 +65059,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifySecurityGroupRules(
             input: ElasticComputeCloudModel.ModifySecurityGroupRulesRequest) async throws -> ElasticComputeCloudModel.ModifySecurityGroupRulesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65096,7 +65096,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifySnapshotAttribute(
             input: ElasticComputeCloudModel.ModifySnapshotAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65135,7 +65135,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifySnapshotTier(
             input: ElasticComputeCloudModel.ModifySnapshotTierRequest) async throws -> ElasticComputeCloudModel.ModifySnapshotTierResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65174,7 +65174,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifySpotFleetRequest(
             input: ElasticComputeCloudModel.ModifySpotFleetRequestRequest) async throws -> ElasticComputeCloudModel.ModifySpotFleetRequestResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65211,7 +65211,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifySubnetAttribute(
             input: ElasticComputeCloudModel.ModifySubnetAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65250,7 +65250,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyTrafficMirrorFilterNetworkServices(
             input: ElasticComputeCloudModel.ModifyTrafficMirrorFilterNetworkServicesRequest) async throws -> ElasticComputeCloudModel.ModifyTrafficMirrorFilterNetworkServicesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65289,7 +65289,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyTrafficMirrorFilterRule(
             input: ElasticComputeCloudModel.ModifyTrafficMirrorFilterRuleRequest) async throws -> ElasticComputeCloudModel.ModifyTrafficMirrorFilterRuleResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65328,7 +65328,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyTrafficMirrorSession(
             input: ElasticComputeCloudModel.ModifyTrafficMirrorSessionRequest) async throws -> ElasticComputeCloudModel.ModifyTrafficMirrorSessionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65367,7 +65367,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyTransitGateway(
             input: ElasticComputeCloudModel.ModifyTransitGatewayRequest) async throws -> ElasticComputeCloudModel.ModifyTransitGatewayResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65406,7 +65406,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyTransitGatewayPrefixListReference(
             input: ElasticComputeCloudModel.ModifyTransitGatewayPrefixListReferenceRequest) async throws -> ElasticComputeCloudModel.ModifyTransitGatewayPrefixListReferenceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65445,7 +65445,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyTransitGatewayVpcAttachment(
             input: ElasticComputeCloudModel.ModifyTransitGatewayVpcAttachmentRequest) async throws -> ElasticComputeCloudModel.ModifyTransitGatewayVpcAttachmentResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65484,7 +65484,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVerifiedAccessEndpoint(
             input: ElasticComputeCloudModel.ModifyVerifiedAccessEndpointRequest) async throws -> ElasticComputeCloudModel.ModifyVerifiedAccessEndpointResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65523,7 +65523,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVerifiedAccessEndpointPolicy(
             input: ElasticComputeCloudModel.ModifyVerifiedAccessEndpointPolicyRequest) async throws -> ElasticComputeCloudModel.ModifyVerifiedAccessEndpointPolicyResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65562,7 +65562,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVerifiedAccessGroup(
             input: ElasticComputeCloudModel.ModifyVerifiedAccessGroupRequest) async throws -> ElasticComputeCloudModel.ModifyVerifiedAccessGroupResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65601,7 +65601,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVerifiedAccessGroupPolicy(
             input: ElasticComputeCloudModel.ModifyVerifiedAccessGroupPolicyRequest) async throws -> ElasticComputeCloudModel.ModifyVerifiedAccessGroupPolicyResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65640,7 +65640,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVerifiedAccessInstance(
             input: ElasticComputeCloudModel.ModifyVerifiedAccessInstanceRequest) async throws -> ElasticComputeCloudModel.ModifyVerifiedAccessInstanceResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65679,7 +65679,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVerifiedAccessInstanceLoggingConfiguration(
             input: ElasticComputeCloudModel.ModifyVerifiedAccessInstanceLoggingConfigurationRequest) async throws -> ElasticComputeCloudModel.ModifyVerifiedAccessInstanceLoggingConfigurationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65718,7 +65718,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVerifiedAccessTrustProvider(
             input: ElasticComputeCloudModel.ModifyVerifiedAccessTrustProviderRequest) async throws -> ElasticComputeCloudModel.ModifyVerifiedAccessTrustProviderResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65757,7 +65757,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVolume(
             input: ElasticComputeCloudModel.ModifyVolumeRequest) async throws -> ElasticComputeCloudModel.ModifyVolumeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65794,7 +65794,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVolumeAttribute(
             input: ElasticComputeCloudModel.ModifyVolumeAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65831,7 +65831,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpcAttribute(
             input: ElasticComputeCloudModel.ModifyVpcAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65870,7 +65870,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpcEndpoint(
             input: ElasticComputeCloudModel.ModifyVpcEndpointRequest) async throws -> ElasticComputeCloudModel.ModifyVpcEndpointResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65909,7 +65909,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpcEndpointConnectionNotification(
             input: ElasticComputeCloudModel.ModifyVpcEndpointConnectionNotificationRequest) async throws -> ElasticComputeCloudModel.ModifyVpcEndpointConnectionNotificationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65948,7 +65948,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpcEndpointServiceConfiguration(
             input: ElasticComputeCloudModel.ModifyVpcEndpointServiceConfigurationRequest) async throws -> ElasticComputeCloudModel.ModifyVpcEndpointServiceConfigurationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -65987,7 +65987,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpcEndpointServicePayerResponsibility(
             input: ElasticComputeCloudModel.ModifyVpcEndpointServicePayerResponsibilityRequest) async throws -> ElasticComputeCloudModel.ModifyVpcEndpointServicePayerResponsibilityResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66026,7 +66026,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpcEndpointServicePermissions(
             input: ElasticComputeCloudModel.ModifyVpcEndpointServicePermissionsRequest) async throws -> ElasticComputeCloudModel.ModifyVpcEndpointServicePermissionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66065,7 +66065,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpcPeeringConnectionOptions(
             input: ElasticComputeCloudModel.ModifyVpcPeeringConnectionOptionsRequest) async throws -> ElasticComputeCloudModel.ModifyVpcPeeringConnectionOptionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66104,7 +66104,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpcTenancy(
             input: ElasticComputeCloudModel.ModifyVpcTenancyRequest) async throws -> ElasticComputeCloudModel.ModifyVpcTenancyResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66143,7 +66143,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpnConnection(
             input: ElasticComputeCloudModel.ModifyVpnConnectionRequest) async throws -> ElasticComputeCloudModel.ModifyVpnConnectionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66182,7 +66182,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpnConnectionOptions(
             input: ElasticComputeCloudModel.ModifyVpnConnectionOptionsRequest) async throws -> ElasticComputeCloudModel.ModifyVpnConnectionOptionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66221,7 +66221,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpnTunnelCertificate(
             input: ElasticComputeCloudModel.ModifyVpnTunnelCertificateRequest) async throws -> ElasticComputeCloudModel.ModifyVpnTunnelCertificateResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66260,7 +66260,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func modifyVpnTunnelOptions(
             input: ElasticComputeCloudModel.ModifyVpnTunnelOptionsRequest) async throws -> ElasticComputeCloudModel.ModifyVpnTunnelOptionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66299,7 +66299,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func monitorInstances(
             input: ElasticComputeCloudModel.MonitorInstancesRequest) async throws -> ElasticComputeCloudModel.MonitorInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66338,7 +66338,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func moveAddressToVpc(
             input: ElasticComputeCloudModel.MoveAddressToVpcRequest) async throws -> ElasticComputeCloudModel.MoveAddressToVpcResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66377,7 +66377,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func moveByoipCidrToIpam(
             input: ElasticComputeCloudModel.MoveByoipCidrToIpamRequest) async throws -> ElasticComputeCloudModel.MoveByoipCidrToIpamResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66416,7 +66416,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func provisionByoipCidr(
             input: ElasticComputeCloudModel.ProvisionByoipCidrRequest) async throws -> ElasticComputeCloudModel.ProvisionByoipCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66455,7 +66455,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func provisionIpamPoolCidr(
             input: ElasticComputeCloudModel.ProvisionIpamPoolCidrRequest) async throws -> ElasticComputeCloudModel.ProvisionIpamPoolCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66494,7 +66494,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func provisionPublicIpv4PoolCidr(
             input: ElasticComputeCloudModel.ProvisionPublicIpv4PoolCidrRequest) async throws -> ElasticComputeCloudModel.ProvisionPublicIpv4PoolCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66533,7 +66533,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func purchaseHostReservation(
             input: ElasticComputeCloudModel.PurchaseHostReservationRequest) async throws -> ElasticComputeCloudModel.PurchaseHostReservationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66572,7 +66572,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func purchaseReservedInstancesOffering(
             input: ElasticComputeCloudModel.PurchaseReservedInstancesOfferingRequest) async throws -> ElasticComputeCloudModel.PurchaseReservedInstancesOfferingResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66611,7 +66611,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func purchaseScheduledInstances(
             input: ElasticComputeCloudModel.PurchaseScheduledInstancesRequest) async throws -> ElasticComputeCloudModel.PurchaseScheduledInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66648,7 +66648,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func rebootInstances(
             input: ElasticComputeCloudModel.RebootInstancesRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66687,7 +66687,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func registerImage(
             input: ElasticComputeCloudModel.RegisterImageRequest) async throws -> ElasticComputeCloudModel.RegisterImageResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66726,7 +66726,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func registerInstanceEventNotificationAttributes(
             input: ElasticComputeCloudModel.RegisterInstanceEventNotificationAttributesRequest) async throws -> ElasticComputeCloudModel.RegisterInstanceEventNotificationAttributesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66765,7 +66765,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func registerTransitGatewayMulticastGroupMembers(
             input: ElasticComputeCloudModel.RegisterTransitGatewayMulticastGroupMembersRequest) async throws -> ElasticComputeCloudModel.RegisterTransitGatewayMulticastGroupMembersResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66804,7 +66804,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func registerTransitGatewayMulticastGroupSources(
             input: ElasticComputeCloudModel.RegisterTransitGatewayMulticastGroupSourcesRequest) async throws -> ElasticComputeCloudModel.RegisterTransitGatewayMulticastGroupSourcesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66843,7 +66843,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func rejectTransitGatewayMulticastDomainAssociations(
             input: ElasticComputeCloudModel.RejectTransitGatewayMulticastDomainAssociationsRequest) async throws -> ElasticComputeCloudModel.RejectTransitGatewayMulticastDomainAssociationsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66882,7 +66882,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func rejectTransitGatewayPeeringAttachment(
             input: ElasticComputeCloudModel.RejectTransitGatewayPeeringAttachmentRequest) async throws -> ElasticComputeCloudModel.RejectTransitGatewayPeeringAttachmentResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66921,7 +66921,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func rejectTransitGatewayVpcAttachment(
             input: ElasticComputeCloudModel.RejectTransitGatewayVpcAttachmentRequest) async throws -> ElasticComputeCloudModel.RejectTransitGatewayVpcAttachmentResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66960,7 +66960,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func rejectVpcEndpointConnections(
             input: ElasticComputeCloudModel.RejectVpcEndpointConnectionsRequest) async throws -> ElasticComputeCloudModel.RejectVpcEndpointConnectionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -66999,7 +66999,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func rejectVpcPeeringConnection(
             input: ElasticComputeCloudModel.RejectVpcPeeringConnectionRequest) async throws -> ElasticComputeCloudModel.RejectVpcPeeringConnectionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67036,7 +67036,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func releaseAddress(
             input: ElasticComputeCloudModel.ReleaseAddressRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67075,7 +67075,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func releaseHosts(
             input: ElasticComputeCloudModel.ReleaseHostsRequest) async throws -> ElasticComputeCloudModel.ReleaseHostsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67114,7 +67114,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func releaseIpamPoolAllocation(
             input: ElasticComputeCloudModel.ReleaseIpamPoolAllocationRequest) async throws -> ElasticComputeCloudModel.ReleaseIpamPoolAllocationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67153,7 +67153,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func replaceIamInstanceProfileAssociation(
             input: ElasticComputeCloudModel.ReplaceIamInstanceProfileAssociationRequest) async throws -> ElasticComputeCloudModel.ReplaceIamInstanceProfileAssociationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67192,7 +67192,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func replaceNetworkAclAssociation(
             input: ElasticComputeCloudModel.ReplaceNetworkAclAssociationRequest) async throws -> ElasticComputeCloudModel.ReplaceNetworkAclAssociationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67229,7 +67229,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func replaceNetworkAclEntry(
             input: ElasticComputeCloudModel.ReplaceNetworkAclEntryRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67266,7 +67266,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func replaceRoute(
             input: ElasticComputeCloudModel.ReplaceRouteRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67305,7 +67305,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func replaceRouteTableAssociation(
             input: ElasticComputeCloudModel.ReplaceRouteTableAssociationRequest) async throws -> ElasticComputeCloudModel.ReplaceRouteTableAssociationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67344,7 +67344,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func replaceTransitGatewayRoute(
             input: ElasticComputeCloudModel.ReplaceTransitGatewayRouteRequest) async throws -> ElasticComputeCloudModel.ReplaceTransitGatewayRouteResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67383,7 +67383,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func replaceVpnTunnel(
             input: ElasticComputeCloudModel.ReplaceVpnTunnelRequest) async throws -> ElasticComputeCloudModel.ReplaceVpnTunnelResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67420,7 +67420,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func reportInstanceStatus(
             input: ElasticComputeCloudModel.ReportInstanceStatusRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67459,7 +67459,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func requestSpotFleet(
             input: ElasticComputeCloudModel.RequestSpotFleetRequest) async throws -> ElasticComputeCloudModel.RequestSpotFleetResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67498,7 +67498,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func requestSpotInstances(
             input: ElasticComputeCloudModel.RequestSpotInstancesRequest) async throws -> ElasticComputeCloudModel.RequestSpotInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67537,7 +67537,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func resetAddressAttribute(
             input: ElasticComputeCloudModel.ResetAddressAttributeRequest) async throws -> ElasticComputeCloudModel.ResetAddressAttributeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67576,7 +67576,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func resetEbsDefaultKmsKeyId(
             input: ElasticComputeCloudModel.ResetEbsDefaultKmsKeyIdRequest) async throws -> ElasticComputeCloudModel.ResetEbsDefaultKmsKeyIdResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67615,7 +67615,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func resetFpgaImageAttribute(
             input: ElasticComputeCloudModel.ResetFpgaImageAttributeRequest) async throws -> ElasticComputeCloudModel.ResetFpgaImageAttributeResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67652,7 +67652,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func resetImageAttribute(
             input: ElasticComputeCloudModel.ResetImageAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67689,7 +67689,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func resetInstanceAttribute(
             input: ElasticComputeCloudModel.ResetInstanceAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67726,7 +67726,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func resetNetworkInterfaceAttribute(
             input: ElasticComputeCloudModel.ResetNetworkInterfaceAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67763,7 +67763,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func resetSnapshotAttribute(
             input: ElasticComputeCloudModel.ResetSnapshotAttributeRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67802,7 +67802,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func restoreAddressToClassic(
             input: ElasticComputeCloudModel.RestoreAddressToClassicRequest) async throws -> ElasticComputeCloudModel.RestoreAddressToClassicResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67841,7 +67841,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func restoreImageFromRecycleBin(
             input: ElasticComputeCloudModel.RestoreImageFromRecycleBinRequest) async throws -> ElasticComputeCloudModel.RestoreImageFromRecycleBinResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67880,7 +67880,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func restoreManagedPrefixListVersion(
             input: ElasticComputeCloudModel.RestoreManagedPrefixListVersionRequest) async throws -> ElasticComputeCloudModel.RestoreManagedPrefixListVersionResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67919,7 +67919,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func restoreSnapshotFromRecycleBin(
             input: ElasticComputeCloudModel.RestoreSnapshotFromRecycleBinRequest) async throws -> ElasticComputeCloudModel.RestoreSnapshotFromRecycleBinResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67958,7 +67958,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func restoreSnapshotTier(
             input: ElasticComputeCloudModel.RestoreSnapshotTierRequest) async throws -> ElasticComputeCloudModel.RestoreSnapshotTierResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -67997,7 +67997,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func revokeClientVpnIngress(
             input: ElasticComputeCloudModel.RevokeClientVpnIngressRequest) async throws -> ElasticComputeCloudModel.RevokeClientVpnIngressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68036,7 +68036,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func revokeSecurityGroupEgress(
             input: ElasticComputeCloudModel.RevokeSecurityGroupEgressRequest) async throws -> ElasticComputeCloudModel.RevokeSecurityGroupEgressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68075,7 +68075,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func revokeSecurityGroupIngress(
             input: ElasticComputeCloudModel.RevokeSecurityGroupIngressRequest) async throws -> ElasticComputeCloudModel.RevokeSecurityGroupIngressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68114,7 +68114,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func runInstances(
             input: ElasticComputeCloudModel.RunInstancesRequest) async throws -> ElasticComputeCloudModel.Reservation {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68153,7 +68153,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func runScheduledInstances(
             input: ElasticComputeCloudModel.RunScheduledInstancesRequest) async throws -> ElasticComputeCloudModel.RunScheduledInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68192,7 +68192,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func searchLocalGatewayRoutes(
             input: ElasticComputeCloudModel.SearchLocalGatewayRoutesRequest) async throws -> ElasticComputeCloudModel.SearchLocalGatewayRoutesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68231,7 +68231,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func searchTransitGatewayMulticastGroups(
             input: ElasticComputeCloudModel.SearchTransitGatewayMulticastGroupsRequest) async throws -> ElasticComputeCloudModel.SearchTransitGatewayMulticastGroupsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68270,7 +68270,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func searchTransitGatewayRoutes(
             input: ElasticComputeCloudModel.SearchTransitGatewayRoutesRequest) async throws -> ElasticComputeCloudModel.SearchTransitGatewayRoutesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68307,7 +68307,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func sendDiagnosticInterrupt(
             input: ElasticComputeCloudModel.SendDiagnosticInterruptRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68346,7 +68346,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func startInstances(
             input: ElasticComputeCloudModel.StartInstancesRequest) async throws -> ElasticComputeCloudModel.StartInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68385,7 +68385,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func startNetworkInsightsAccessScopeAnalysis(
             input: ElasticComputeCloudModel.StartNetworkInsightsAccessScopeAnalysisRequest) async throws -> ElasticComputeCloudModel.StartNetworkInsightsAccessScopeAnalysisResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68424,7 +68424,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func startNetworkInsightsAnalysis(
             input: ElasticComputeCloudModel.StartNetworkInsightsAnalysisRequest) async throws -> ElasticComputeCloudModel.StartNetworkInsightsAnalysisResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68463,7 +68463,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func startVpcEndpointServicePrivateDnsVerification(
             input: ElasticComputeCloudModel.StartVpcEndpointServicePrivateDnsVerificationRequest) async throws -> ElasticComputeCloudModel.StartVpcEndpointServicePrivateDnsVerificationResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68502,7 +68502,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func stopInstances(
             input: ElasticComputeCloudModel.StopInstancesRequest) async throws -> ElasticComputeCloudModel.StopInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68541,7 +68541,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func terminateClientVpnConnections(
             input: ElasticComputeCloudModel.TerminateClientVpnConnectionsRequest) async throws -> ElasticComputeCloudModel.TerminateClientVpnConnectionsResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68580,7 +68580,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func terminateInstances(
             input: ElasticComputeCloudModel.TerminateInstancesRequest) async throws -> ElasticComputeCloudModel.TerminateInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68619,7 +68619,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func unassignIpv6Addresses(
             input: ElasticComputeCloudModel.UnassignIpv6AddressesRequest) async throws -> ElasticComputeCloudModel.UnassignIpv6AddressesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68656,7 +68656,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func unassignPrivateIpAddresses(
             input: ElasticComputeCloudModel.UnassignPrivateIpAddressesRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68695,7 +68695,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func unassignPrivateNatGatewayAddress(
             input: ElasticComputeCloudModel.UnassignPrivateNatGatewayAddressRequest) async throws -> ElasticComputeCloudModel.UnassignPrivateNatGatewayAddressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68734,7 +68734,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func unmonitorInstances(
             input: ElasticComputeCloudModel.UnmonitorInstancesRequest) async throws -> ElasticComputeCloudModel.UnmonitorInstancesResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68773,7 +68773,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func updateSecurityGroupRuleDescriptionsEgress(
             input: ElasticComputeCloudModel.UpdateSecurityGroupRuleDescriptionsEgressRequest) async throws -> ElasticComputeCloudModel.UpdateSecurityGroupRuleDescriptionsEgressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68812,7 +68812,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func updateSecurityGroupRuleDescriptionsIngress(
             input: ElasticComputeCloudModel.UpdateSecurityGroupRuleDescriptionsIngressRequest) async throws -> ElasticComputeCloudModel.UpdateSecurityGroupRuleDescriptionsIngressResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -68851,7 +68851,7 @@ public struct AWSElasticComputeCloudClient<InvocationReportingType: HTTPClientCo
      */
     public func withdrawByoipCidr(
             input: ElasticComputeCloudModel.WithdrawByoipCidrRequest) async throws -> ElasticComputeCloudModel.WithdrawByoipCidrResult {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
+++ b/Sources/ElasticContainerClient/AWSElasticContainerClient.swift
@@ -4100,7 +4100,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func createCapacityProvider(
             input: ElasticContainerModel.CreateCapacityProviderRequest) async throws -> ElasticContainerModel.CreateCapacityProviderResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4136,7 +4136,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func createCluster(
             input: ElasticContainerModel.CreateClusterRequest) async throws -> ElasticContainerModel.CreateClusterResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4172,7 +4172,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func createService(
             input: ElasticContainerModel.CreateServiceRequest) async throws -> ElasticContainerModel.CreateServiceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4208,7 +4208,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func createTaskSet(
             input: ElasticContainerModel.CreateTaskSetRequest) async throws -> ElasticContainerModel.CreateTaskSetResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4244,7 +4244,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func deleteAccountSetting(
             input: ElasticContainerModel.DeleteAccountSettingRequest) async throws -> ElasticContainerModel.DeleteAccountSettingResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4280,7 +4280,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func deleteAttributes(
             input: ElasticContainerModel.DeleteAttributesRequest) async throws -> ElasticContainerModel.DeleteAttributesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4316,7 +4316,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func deleteCapacityProvider(
             input: ElasticContainerModel.DeleteCapacityProviderRequest) async throws -> ElasticContainerModel.DeleteCapacityProviderResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4352,7 +4352,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func deleteCluster(
             input: ElasticContainerModel.DeleteClusterRequest) async throws -> ElasticContainerModel.DeleteClusterResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4388,7 +4388,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func deleteService(
             input: ElasticContainerModel.DeleteServiceRequest) async throws -> ElasticContainerModel.DeleteServiceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4424,7 +4424,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func deleteTaskDefinitions(
             input: ElasticContainerModel.DeleteTaskDefinitionsRequest) async throws -> ElasticContainerModel.DeleteTaskDefinitionsResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4460,7 +4460,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func deleteTaskSet(
             input: ElasticContainerModel.DeleteTaskSetRequest) async throws -> ElasticContainerModel.DeleteTaskSetResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4496,7 +4496,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func deregisterContainerInstance(
             input: ElasticContainerModel.DeregisterContainerInstanceRequest) async throws -> ElasticContainerModel.DeregisterContainerInstanceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4532,7 +4532,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func deregisterTaskDefinition(
             input: ElasticContainerModel.DeregisterTaskDefinitionRequest) async throws -> ElasticContainerModel.DeregisterTaskDefinitionResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4568,7 +4568,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func describeCapacityProviders(
             input: ElasticContainerModel.DescribeCapacityProvidersRequest) async throws -> ElasticContainerModel.DescribeCapacityProvidersResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4604,7 +4604,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func describeClusters(
             input: ElasticContainerModel.DescribeClustersRequest) async throws -> ElasticContainerModel.DescribeClustersResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4640,7 +4640,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func describeContainerInstances(
             input: ElasticContainerModel.DescribeContainerInstancesRequest) async throws -> ElasticContainerModel.DescribeContainerInstancesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4676,7 +4676,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func describeServices(
             input: ElasticContainerModel.DescribeServicesRequest) async throws -> ElasticContainerModel.DescribeServicesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4712,7 +4712,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func describeTaskDefinition(
             input: ElasticContainerModel.DescribeTaskDefinitionRequest) async throws -> ElasticContainerModel.DescribeTaskDefinitionResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4748,7 +4748,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func describeTaskSets(
             input: ElasticContainerModel.DescribeTaskSetsRequest) async throws -> ElasticContainerModel.DescribeTaskSetsResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4784,7 +4784,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func describeTasks(
             input: ElasticContainerModel.DescribeTasksRequest) async throws -> ElasticContainerModel.DescribeTasksResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4820,7 +4820,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func discoverPollEndpoint(
             input: ElasticContainerModel.DiscoverPollEndpointRequest) async throws -> ElasticContainerModel.DiscoverPollEndpointResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4856,7 +4856,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func executeCommand(
             input: ElasticContainerModel.ExecuteCommandRequest) async throws -> ElasticContainerModel.ExecuteCommandResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4892,7 +4892,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func getTaskProtection(
             input: ElasticContainerModel.GetTaskProtectionRequest) async throws -> ElasticContainerModel.GetTaskProtectionResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4928,7 +4928,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func listAccountSettings(
             input: ElasticContainerModel.ListAccountSettingsRequest) async throws -> ElasticContainerModel.ListAccountSettingsResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4964,7 +4964,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func listAttributes(
             input: ElasticContainerModel.ListAttributesRequest) async throws -> ElasticContainerModel.ListAttributesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5000,7 +5000,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func listClusters(
             input: ElasticContainerModel.ListClustersRequest) async throws -> ElasticContainerModel.ListClustersResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5036,7 +5036,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func listContainerInstances(
             input: ElasticContainerModel.ListContainerInstancesRequest) async throws -> ElasticContainerModel.ListContainerInstancesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5072,7 +5072,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func listServices(
             input: ElasticContainerModel.ListServicesRequest) async throws -> ElasticContainerModel.ListServicesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5108,7 +5108,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func listServicesByNamespace(
             input: ElasticContainerModel.ListServicesByNamespaceRequest) async throws -> ElasticContainerModel.ListServicesByNamespaceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5144,7 +5144,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func listTagsForResource(
             input: ElasticContainerModel.ListTagsForResourceRequest) async throws -> ElasticContainerModel.ListTagsForResourceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5180,7 +5180,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func listTaskDefinitionFamilies(
             input: ElasticContainerModel.ListTaskDefinitionFamiliesRequest) async throws -> ElasticContainerModel.ListTaskDefinitionFamiliesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5216,7 +5216,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func listTaskDefinitions(
             input: ElasticContainerModel.ListTaskDefinitionsRequest) async throws -> ElasticContainerModel.ListTaskDefinitionsResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5252,7 +5252,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func listTasks(
             input: ElasticContainerModel.ListTasksRequest) async throws -> ElasticContainerModel.ListTasksResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5288,7 +5288,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func putAccountSetting(
             input: ElasticContainerModel.PutAccountSettingRequest) async throws -> ElasticContainerModel.PutAccountSettingResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5324,7 +5324,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func putAccountSettingDefault(
             input: ElasticContainerModel.PutAccountSettingDefaultRequest) async throws -> ElasticContainerModel.PutAccountSettingDefaultResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5360,7 +5360,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func putAttributes(
             input: ElasticContainerModel.PutAttributesRequest) async throws -> ElasticContainerModel.PutAttributesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5396,7 +5396,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func putClusterCapacityProviders(
             input: ElasticContainerModel.PutClusterCapacityProvidersRequest) async throws -> ElasticContainerModel.PutClusterCapacityProvidersResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5432,7 +5432,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func registerContainerInstance(
             input: ElasticContainerModel.RegisterContainerInstanceRequest) async throws -> ElasticContainerModel.RegisterContainerInstanceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5468,7 +5468,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func registerTaskDefinition(
             input: ElasticContainerModel.RegisterTaskDefinitionRequest) async throws -> ElasticContainerModel.RegisterTaskDefinitionResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5504,7 +5504,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func runTask(
             input: ElasticContainerModel.RunTaskRequest) async throws -> ElasticContainerModel.RunTaskResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5540,7 +5540,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func startTask(
             input: ElasticContainerModel.StartTaskRequest) async throws -> ElasticContainerModel.StartTaskResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5576,7 +5576,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func stopTask(
             input: ElasticContainerModel.StopTaskRequest) async throws -> ElasticContainerModel.StopTaskResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5612,7 +5612,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func submitAttachmentStateChanges(
             input: ElasticContainerModel.SubmitAttachmentStateChangesRequest) async throws -> ElasticContainerModel.SubmitAttachmentStateChangesResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5648,7 +5648,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func submitContainerStateChange(
             input: ElasticContainerModel.SubmitContainerStateChangeRequest) async throws -> ElasticContainerModel.SubmitContainerStateChangeResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5684,7 +5684,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func submitTaskStateChange(
             input: ElasticContainerModel.SubmitTaskStateChangeRequest) async throws -> ElasticContainerModel.SubmitTaskStateChangeResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5720,7 +5720,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func tagResource(
             input: ElasticContainerModel.TagResourceRequest) async throws -> ElasticContainerModel.TagResourceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5756,7 +5756,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func untagResource(
             input: ElasticContainerModel.UntagResourceRequest) async throws -> ElasticContainerModel.UntagResourceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5792,7 +5792,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func updateCapacityProvider(
             input: ElasticContainerModel.UpdateCapacityProviderRequest) async throws -> ElasticContainerModel.UpdateCapacityProviderResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5828,7 +5828,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func updateCluster(
             input: ElasticContainerModel.UpdateClusterRequest) async throws -> ElasticContainerModel.UpdateClusterResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5864,7 +5864,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func updateClusterSettings(
             input: ElasticContainerModel.UpdateClusterSettingsRequest) async throws -> ElasticContainerModel.UpdateClusterSettingsResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5900,7 +5900,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func updateContainerAgent(
             input: ElasticContainerModel.UpdateContainerAgentRequest) async throws -> ElasticContainerModel.UpdateContainerAgentResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5936,7 +5936,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func updateContainerInstancesState(
             input: ElasticContainerModel.UpdateContainerInstancesStateRequest) async throws -> ElasticContainerModel.UpdateContainerInstancesStateResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5972,7 +5972,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func updateService(
             input: ElasticContainerModel.UpdateServiceRequest) async throws -> ElasticContainerModel.UpdateServiceResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6008,7 +6008,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func updateServicePrimaryTaskSet(
             input: ElasticContainerModel.UpdateServicePrimaryTaskSetRequest) async throws -> ElasticContainerModel.UpdateServicePrimaryTaskSetResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6044,7 +6044,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func updateTaskProtection(
             input: ElasticContainerModel.UpdateTaskProtectionRequest) async throws -> ElasticContainerModel.UpdateTaskProtectionResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6080,7 +6080,7 @@ public struct AWSElasticContainerClient<InvocationReportingType: HTTPClientCoreI
      */
     public func updateTaskSet(
             input: ElasticContainerModel.UpdateTaskSetRequest) async throws -> ElasticContainerModel.UpdateTaskSetResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/RDSClient/AWSRDSClient.swift
+++ b/Sources/RDSClient/AWSRDSClient.swift
@@ -11343,7 +11343,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func addRoleToDBCluster(
             input: RDSModel.AddRoleToDBClusterMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11381,7 +11381,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func addRoleToDBInstance(
             input: RDSModel.AddRoleToDBInstanceMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11421,7 +11421,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func addSourceIdentifierToSubscription(
             input: RDSModel.AddSourceIdentifierToSubscriptionMessage) async throws -> RDSModel.AddSourceIdentifierToSubscriptionResultForAddSourceIdentifierToSubscription {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11459,7 +11459,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func addTagsToResource(
             input: RDSModel.AddTagsToResourceMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11499,7 +11499,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func applyPendingMaintenanceAction(
             input: RDSModel.ApplyPendingMaintenanceActionMessage) async throws -> RDSModel.ApplyPendingMaintenanceActionResultForApplyPendingMaintenanceAction {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11539,7 +11539,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func authorizeDBSecurityGroupIngress(
             input: RDSModel.AuthorizeDBSecurityGroupIngressMessage) async throws -> RDSModel.AuthorizeDBSecurityGroupIngressResultForAuthorizeDBSecurityGroupIngress {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11579,7 +11579,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func backtrackDBCluster(
             input: RDSModel.BacktrackDBClusterMessage) async throws -> RDSModel.DBClusterBacktrackForBacktrackDBCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11619,7 +11619,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func cancelExportTask(
             input: RDSModel.CancelExportTaskMessage) async throws -> RDSModel.ExportTaskForCancelExportTask {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11659,7 +11659,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func copyDBClusterParameterGroup(
             input: RDSModel.CopyDBClusterParameterGroupMessage) async throws -> RDSModel.CopyDBClusterParameterGroupResultForCopyDBClusterParameterGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11699,7 +11699,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func copyDBClusterSnapshot(
             input: RDSModel.CopyDBClusterSnapshotMessage) async throws -> RDSModel.CopyDBClusterSnapshotResultForCopyDBClusterSnapshot {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11739,7 +11739,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func copyDBParameterGroup(
             input: RDSModel.CopyDBParameterGroupMessage) async throws -> RDSModel.CopyDBParameterGroupResultForCopyDBParameterGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11779,7 +11779,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func copyDBSnapshot(
             input: RDSModel.CopyDBSnapshotMessage) async throws -> RDSModel.CopyDBSnapshotResultForCopyDBSnapshot {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11819,7 +11819,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func copyOptionGroup(
             input: RDSModel.CopyOptionGroupMessage) async throws -> RDSModel.CopyOptionGroupResultForCopyOptionGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11859,7 +11859,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createBlueGreenDeployment(
             input: RDSModel.CreateBlueGreenDeploymentRequest) async throws -> RDSModel.CreateBlueGreenDeploymentResponseForCreateBlueGreenDeployment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11899,7 +11899,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createCustomDBEngineVersion(
             input: RDSModel.CreateCustomDBEngineVersionMessage) async throws -> RDSModel.DBEngineVersionForCreateCustomDBEngineVersion {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11939,7 +11939,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBCluster(
             input: RDSModel.CreateDBClusterMessage) async throws -> RDSModel.CreateDBClusterResultForCreateDBCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -11979,7 +11979,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBClusterEndpoint(
             input: RDSModel.CreateDBClusterEndpointMessage) async throws -> RDSModel.DBClusterEndpointForCreateDBClusterEndpoint {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12019,7 +12019,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBClusterParameterGroup(
             input: RDSModel.CreateDBClusterParameterGroupMessage) async throws -> RDSModel.CreateDBClusterParameterGroupResultForCreateDBClusterParameterGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12059,7 +12059,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBClusterSnapshot(
             input: RDSModel.CreateDBClusterSnapshotMessage) async throws -> RDSModel.CreateDBClusterSnapshotResultForCreateDBClusterSnapshot {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12099,7 +12099,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBInstance(
             input: RDSModel.CreateDBInstanceMessage) async throws -> RDSModel.CreateDBInstanceResultForCreateDBInstance {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12139,7 +12139,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBInstanceReadReplica(
             input: RDSModel.CreateDBInstanceReadReplicaMessage) async throws -> RDSModel.CreateDBInstanceReadReplicaResultForCreateDBInstanceReadReplica {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12179,7 +12179,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBParameterGroup(
             input: RDSModel.CreateDBParameterGroupMessage) async throws -> RDSModel.CreateDBParameterGroupResultForCreateDBParameterGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12219,7 +12219,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBProxy(
             input: RDSModel.CreateDBProxyRequest) async throws -> RDSModel.CreateDBProxyResponseForCreateDBProxy {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12259,7 +12259,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBProxyEndpoint(
             input: RDSModel.CreateDBProxyEndpointRequest) async throws -> RDSModel.CreateDBProxyEndpointResponseForCreateDBProxyEndpoint {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12299,7 +12299,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBSecurityGroup(
             input: RDSModel.CreateDBSecurityGroupMessage) async throws -> RDSModel.CreateDBSecurityGroupResultForCreateDBSecurityGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12339,7 +12339,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBSnapshot(
             input: RDSModel.CreateDBSnapshotMessage) async throws -> RDSModel.CreateDBSnapshotResultForCreateDBSnapshot {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12379,7 +12379,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createDBSubnetGroup(
             input: RDSModel.CreateDBSubnetGroupMessage) async throws -> RDSModel.CreateDBSubnetGroupResultForCreateDBSubnetGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12419,7 +12419,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createEventSubscription(
             input: RDSModel.CreateEventSubscriptionMessage) async throws -> RDSModel.CreateEventSubscriptionResultForCreateEventSubscription {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12459,7 +12459,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createGlobalCluster(
             input: RDSModel.CreateGlobalClusterMessage) async throws -> RDSModel.CreateGlobalClusterResultForCreateGlobalCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12499,7 +12499,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func createOptionGroup(
             input: RDSModel.CreateOptionGroupMessage) async throws -> RDSModel.CreateOptionGroupResultForCreateOptionGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12539,7 +12539,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteBlueGreenDeployment(
             input: RDSModel.DeleteBlueGreenDeploymentRequest) async throws -> RDSModel.DeleteBlueGreenDeploymentResponseForDeleteBlueGreenDeployment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12579,7 +12579,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteCustomDBEngineVersion(
             input: RDSModel.DeleteCustomDBEngineVersionMessage) async throws -> RDSModel.DBEngineVersionForDeleteCustomDBEngineVersion {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12619,7 +12619,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBCluster(
             input: RDSModel.DeleteDBClusterMessage) async throws -> RDSModel.DeleteDBClusterResultForDeleteDBCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12659,7 +12659,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBClusterAutomatedBackup(
             input: RDSModel.DeleteDBClusterAutomatedBackupMessage) async throws -> RDSModel.DeleteDBClusterAutomatedBackupResultForDeleteDBClusterAutomatedBackup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12699,7 +12699,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBClusterEndpoint(
             input: RDSModel.DeleteDBClusterEndpointMessage) async throws -> RDSModel.DBClusterEndpointForDeleteDBClusterEndpoint {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12737,7 +12737,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBClusterParameterGroup(
             input: RDSModel.DeleteDBClusterParameterGroupMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12777,7 +12777,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBClusterSnapshot(
             input: RDSModel.DeleteDBClusterSnapshotMessage) async throws -> RDSModel.DeleteDBClusterSnapshotResultForDeleteDBClusterSnapshot {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12817,7 +12817,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBInstance(
             input: RDSModel.DeleteDBInstanceMessage) async throws -> RDSModel.DeleteDBInstanceResultForDeleteDBInstance {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12857,7 +12857,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBInstanceAutomatedBackup(
             input: RDSModel.DeleteDBInstanceAutomatedBackupMessage) async throws -> RDSModel.DeleteDBInstanceAutomatedBackupResultForDeleteDBInstanceAutomatedBackup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12895,7 +12895,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBParameterGroup(
             input: RDSModel.DeleteDBParameterGroupMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12935,7 +12935,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBProxy(
             input: RDSModel.DeleteDBProxyRequest) async throws -> RDSModel.DeleteDBProxyResponseForDeleteDBProxy {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -12975,7 +12975,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBProxyEndpoint(
             input: RDSModel.DeleteDBProxyEndpointRequest) async throws -> RDSModel.DeleteDBProxyEndpointResponseForDeleteDBProxyEndpoint {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13013,7 +13013,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBSecurityGroup(
             input: RDSModel.DeleteDBSecurityGroupMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13053,7 +13053,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBSnapshot(
             input: RDSModel.DeleteDBSnapshotMessage) async throws -> RDSModel.DeleteDBSnapshotResultForDeleteDBSnapshot {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13091,7 +13091,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteDBSubnetGroup(
             input: RDSModel.DeleteDBSubnetGroupMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13131,7 +13131,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteEventSubscription(
             input: RDSModel.DeleteEventSubscriptionMessage) async throws -> RDSModel.DeleteEventSubscriptionResultForDeleteEventSubscription {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13171,7 +13171,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteGlobalCluster(
             input: RDSModel.DeleteGlobalClusterMessage) async throws -> RDSModel.DeleteGlobalClusterResultForDeleteGlobalCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13209,7 +13209,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deleteOptionGroup(
             input: RDSModel.DeleteOptionGroupMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13249,7 +13249,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func deregisterDBProxyTargets(
             input: RDSModel.DeregisterDBProxyTargetsRequest) async throws -> RDSModel.DeregisterDBProxyTargetsResponseForDeregisterDBProxyTargets {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13288,7 +13288,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeAccountAttributes(
             input: RDSModel.DescribeAccountAttributesMessage) async throws -> RDSModel.AccountAttributesMessageForDescribeAccountAttributes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13328,7 +13328,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeBlueGreenDeployments(
             input: RDSModel.DescribeBlueGreenDeploymentsRequest) async throws -> RDSModel.DescribeBlueGreenDeploymentsResponseForDescribeBlueGreenDeployments {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13368,7 +13368,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeCertificates(
             input: RDSModel.DescribeCertificatesMessage) async throws -> RDSModel.CertificateMessageForDescribeCertificates {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13408,7 +13408,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBClusterAutomatedBackups(
             input: RDSModel.DescribeDBClusterAutomatedBackupsMessage) async throws -> RDSModel.DBClusterAutomatedBackupMessageForDescribeDBClusterAutomatedBackups {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13448,7 +13448,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBClusterBacktracks(
             input: RDSModel.DescribeDBClusterBacktracksMessage) async throws -> RDSModel.DBClusterBacktrackMessageForDescribeDBClusterBacktracks {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13488,7 +13488,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBClusterEndpoints(
             input: RDSModel.DescribeDBClusterEndpointsMessage) async throws -> RDSModel.DBClusterEndpointMessageForDescribeDBClusterEndpoints {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13528,7 +13528,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBClusterParameterGroups(
             input: RDSModel.DescribeDBClusterParameterGroupsMessage) async throws -> RDSModel.DBClusterParameterGroupsMessageForDescribeDBClusterParameterGroups {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13568,7 +13568,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBClusterParameters(
             input: RDSModel.DescribeDBClusterParametersMessage) async throws -> RDSModel.DBClusterParameterGroupDetailsForDescribeDBClusterParameters {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13608,7 +13608,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBClusterSnapshotAttributes(
             input: RDSModel.DescribeDBClusterSnapshotAttributesMessage) async throws -> RDSModel.DescribeDBClusterSnapshotAttributesResultForDescribeDBClusterSnapshotAttributes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13648,7 +13648,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBClusterSnapshots(
             input: RDSModel.DescribeDBClusterSnapshotsMessage) async throws -> RDSModel.DBClusterSnapshotMessageForDescribeDBClusterSnapshots {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13688,7 +13688,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBClusters(
             input: RDSModel.DescribeDBClustersMessage) async throws -> RDSModel.DBClusterMessageForDescribeDBClusters {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13727,7 +13727,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBEngineVersions(
             input: RDSModel.DescribeDBEngineVersionsMessage) async throws -> RDSModel.DBEngineVersionMessageForDescribeDBEngineVersions {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13767,7 +13767,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBInstanceAutomatedBackups(
             input: RDSModel.DescribeDBInstanceAutomatedBackupsMessage) async throws -> RDSModel.DBInstanceAutomatedBackupMessageForDescribeDBInstanceAutomatedBackups {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13807,7 +13807,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBInstances(
             input: RDSModel.DescribeDBInstancesMessage) async throws -> RDSModel.DBInstanceMessageForDescribeDBInstances {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13847,7 +13847,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBLogFiles(
             input: RDSModel.DescribeDBLogFilesMessage) async throws -> RDSModel.DescribeDBLogFilesResponseForDescribeDBLogFiles {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13887,7 +13887,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBParameterGroups(
             input: RDSModel.DescribeDBParameterGroupsMessage) async throws -> RDSModel.DBParameterGroupsMessageForDescribeDBParameterGroups {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13927,7 +13927,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBParameters(
             input: RDSModel.DescribeDBParametersMessage) async throws -> RDSModel.DBParameterGroupDetailsForDescribeDBParameters {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -13967,7 +13967,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBProxies(
             input: RDSModel.DescribeDBProxiesRequest) async throws -> RDSModel.DescribeDBProxiesResponseForDescribeDBProxies {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14007,7 +14007,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBProxyEndpoints(
             input: RDSModel.DescribeDBProxyEndpointsRequest) async throws -> RDSModel.DescribeDBProxyEndpointsResponseForDescribeDBProxyEndpoints {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14047,7 +14047,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBProxyTargetGroups(
             input: RDSModel.DescribeDBProxyTargetGroupsRequest) async throws -> RDSModel.DescribeDBProxyTargetGroupsResponseForDescribeDBProxyTargetGroups {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14087,7 +14087,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBProxyTargets(
             input: RDSModel.DescribeDBProxyTargetsRequest) async throws -> RDSModel.DescribeDBProxyTargetsResponseForDescribeDBProxyTargets {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14127,7 +14127,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBSecurityGroups(
             input: RDSModel.DescribeDBSecurityGroupsMessage) async throws -> RDSModel.DBSecurityGroupMessageForDescribeDBSecurityGroups {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14167,7 +14167,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBSnapshotAttributes(
             input: RDSModel.DescribeDBSnapshotAttributesMessage) async throws -> RDSModel.DescribeDBSnapshotAttributesResultForDescribeDBSnapshotAttributes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14207,7 +14207,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBSnapshots(
             input: RDSModel.DescribeDBSnapshotsMessage) async throws -> RDSModel.DBSnapshotMessageForDescribeDBSnapshots {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14247,7 +14247,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeDBSubnetGroups(
             input: RDSModel.DescribeDBSubnetGroupsMessage) async throws -> RDSModel.DBSubnetGroupMessageForDescribeDBSubnetGroups {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14286,7 +14286,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeEngineDefaultClusterParameters(
             input: RDSModel.DescribeEngineDefaultClusterParametersMessage) async throws -> RDSModel.DescribeEngineDefaultClusterParametersResultForDescribeEngineDefaultClusterParameters {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14325,7 +14325,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeEngineDefaultParameters(
             input: RDSModel.DescribeEngineDefaultParametersMessage) async throws -> RDSModel.DescribeEngineDefaultParametersResultForDescribeEngineDefaultParameters {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14364,7 +14364,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeEventCategories(
             input: RDSModel.DescribeEventCategoriesMessage) async throws -> RDSModel.EventCategoriesMessageForDescribeEventCategories {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14404,7 +14404,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeEventSubscriptions(
             input: RDSModel.DescribeEventSubscriptionsMessage) async throws -> RDSModel.EventSubscriptionsMessageForDescribeEventSubscriptions {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14443,7 +14443,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeEvents(
             input: RDSModel.DescribeEventsMessage) async throws -> RDSModel.EventsMessageForDescribeEvents {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14483,7 +14483,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeExportTasks(
             input: RDSModel.DescribeExportTasksMessage) async throws -> RDSModel.ExportTasksMessageForDescribeExportTasks {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14523,7 +14523,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeGlobalClusters(
             input: RDSModel.DescribeGlobalClustersMessage) async throws -> RDSModel.GlobalClustersMessageForDescribeGlobalClusters {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14562,7 +14562,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeOptionGroupOptions(
             input: RDSModel.DescribeOptionGroupOptionsMessage) async throws -> RDSModel.OptionGroupOptionsMessageForDescribeOptionGroupOptions {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14602,7 +14602,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeOptionGroups(
             input: RDSModel.DescribeOptionGroupsMessage) async throws -> RDSModel.OptionGroupsForDescribeOptionGroups {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14641,7 +14641,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeOrderableDBInstanceOptions(
             input: RDSModel.DescribeOrderableDBInstanceOptionsMessage) async throws -> RDSModel.OrderableDBInstanceOptionsMessageForDescribeOrderableDBInstanceOptions {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14681,7 +14681,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describePendingMaintenanceActions(
             input: RDSModel.DescribePendingMaintenanceActionsMessage) async throws -> RDSModel.PendingMaintenanceActionsMessageForDescribePendingMaintenanceActions {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14721,7 +14721,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeReservedDBInstances(
             input: RDSModel.DescribeReservedDBInstancesMessage) async throws -> RDSModel.ReservedDBInstanceMessageForDescribeReservedDBInstances {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14761,7 +14761,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeReservedDBInstancesOfferings(
             input: RDSModel.DescribeReservedDBInstancesOfferingsMessage) async throws -> RDSModel.ReservedDBInstancesOfferingMessageForDescribeReservedDBInstancesOfferings {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14800,7 +14800,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeSourceRegions(
             input: RDSModel.DescribeSourceRegionsMessage) async throws -> RDSModel.SourceRegionMessageForDescribeSourceRegions {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14840,7 +14840,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func describeValidDBInstanceModifications(
             input: RDSModel.DescribeValidDBInstanceModificationsMessage) async throws -> RDSModel.DescribeValidDBInstanceModificationsResultForDescribeValidDBInstanceModifications {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14880,7 +14880,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func downloadDBLogFilePortion(
             input: RDSModel.DownloadDBLogFilePortionMessage) async throws -> RDSModel.DownloadDBLogFilePortionDetailsForDownloadDBLogFilePortion {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14920,7 +14920,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func failoverDBCluster(
             input: RDSModel.FailoverDBClusterMessage) async throws -> RDSModel.FailoverDBClusterResultForFailoverDBCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -14960,7 +14960,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func failoverGlobalCluster(
             input: RDSModel.FailoverGlobalClusterMessage) async throws -> RDSModel.FailoverGlobalClusterResultForFailoverGlobalCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15000,7 +15000,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func listTagsForResource(
             input: RDSModel.ListTagsForResourceMessage) async throws -> RDSModel.TagListMessageForListTagsForResource {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15040,7 +15040,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyActivityStream(
             input: RDSModel.ModifyActivityStreamRequest) async throws -> RDSModel.ModifyActivityStreamResponseForModifyActivityStream {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15080,7 +15080,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyCertificates(
             input: RDSModel.ModifyCertificatesMessage) async throws -> RDSModel.ModifyCertificatesResultForModifyCertificates {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15120,7 +15120,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyCurrentDBClusterCapacity(
             input: RDSModel.ModifyCurrentDBClusterCapacityMessage) async throws -> RDSModel.DBClusterCapacityInfoForModifyCurrentDBClusterCapacity {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15160,7 +15160,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyCustomDBEngineVersion(
             input: RDSModel.ModifyCustomDBEngineVersionMessage) async throws -> RDSModel.DBEngineVersionForModifyCustomDBEngineVersion {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15200,7 +15200,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBCluster(
             input: RDSModel.ModifyDBClusterMessage) async throws -> RDSModel.ModifyDBClusterResultForModifyDBCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15240,7 +15240,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBClusterEndpoint(
             input: RDSModel.ModifyDBClusterEndpointMessage) async throws -> RDSModel.DBClusterEndpointForModifyDBClusterEndpoint {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15280,7 +15280,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBClusterParameterGroup(
             input: RDSModel.ModifyDBClusterParameterGroupMessage) async throws -> RDSModel.DBClusterParameterGroupNameMessageForModifyDBClusterParameterGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15320,7 +15320,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBClusterSnapshotAttribute(
             input: RDSModel.ModifyDBClusterSnapshotAttributeMessage) async throws -> RDSModel.ModifyDBClusterSnapshotAttributeResultForModifyDBClusterSnapshotAttribute {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15360,7 +15360,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBInstance(
             input: RDSModel.ModifyDBInstanceMessage) async throws -> RDSModel.ModifyDBInstanceResultForModifyDBInstance {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15400,7 +15400,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBParameterGroup(
             input: RDSModel.ModifyDBParameterGroupMessage) async throws -> RDSModel.DBParameterGroupNameMessageForModifyDBParameterGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15440,7 +15440,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBProxy(
             input: RDSModel.ModifyDBProxyRequest) async throws -> RDSModel.ModifyDBProxyResponseForModifyDBProxy {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15480,7 +15480,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBProxyEndpoint(
             input: RDSModel.ModifyDBProxyEndpointRequest) async throws -> RDSModel.ModifyDBProxyEndpointResponseForModifyDBProxyEndpoint {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15520,7 +15520,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBProxyTargetGroup(
             input: RDSModel.ModifyDBProxyTargetGroupRequest) async throws -> RDSModel.ModifyDBProxyTargetGroupResponseForModifyDBProxyTargetGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15560,7 +15560,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBSnapshot(
             input: RDSModel.ModifyDBSnapshotMessage) async throws -> RDSModel.ModifyDBSnapshotResultForModifyDBSnapshot {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15600,7 +15600,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBSnapshotAttribute(
             input: RDSModel.ModifyDBSnapshotAttributeMessage) async throws -> RDSModel.ModifyDBSnapshotAttributeResultForModifyDBSnapshotAttribute {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15640,7 +15640,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyDBSubnetGroup(
             input: RDSModel.ModifyDBSubnetGroupMessage) async throws -> RDSModel.ModifyDBSubnetGroupResultForModifyDBSubnetGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15680,7 +15680,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyEventSubscription(
             input: RDSModel.ModifyEventSubscriptionMessage) async throws -> RDSModel.ModifyEventSubscriptionResultForModifyEventSubscription {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15720,7 +15720,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyGlobalCluster(
             input: RDSModel.ModifyGlobalClusterMessage) async throws -> RDSModel.ModifyGlobalClusterResultForModifyGlobalCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15760,7 +15760,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func modifyOptionGroup(
             input: RDSModel.ModifyOptionGroupMessage) async throws -> RDSModel.ModifyOptionGroupResultForModifyOptionGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15800,7 +15800,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func promoteReadReplica(
             input: RDSModel.PromoteReadReplicaMessage) async throws -> RDSModel.PromoteReadReplicaResultForPromoteReadReplica {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15840,7 +15840,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func promoteReadReplicaDBCluster(
             input: RDSModel.PromoteReadReplicaDBClusterMessage) async throws -> RDSModel.PromoteReadReplicaDBClusterResultForPromoteReadReplicaDBCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15880,7 +15880,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func purchaseReservedDBInstancesOffering(
             input: RDSModel.PurchaseReservedDBInstancesOfferingMessage) async throws -> RDSModel.PurchaseReservedDBInstancesOfferingResultForPurchaseReservedDBInstancesOffering {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15920,7 +15920,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func rebootDBCluster(
             input: RDSModel.RebootDBClusterMessage) async throws -> RDSModel.RebootDBClusterResultForRebootDBCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -15960,7 +15960,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func rebootDBInstance(
             input: RDSModel.RebootDBInstanceMessage) async throws -> RDSModel.RebootDBInstanceResultForRebootDBInstance {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16000,7 +16000,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func registerDBProxyTargets(
             input: RDSModel.RegisterDBProxyTargetsRequest) async throws -> RDSModel.RegisterDBProxyTargetsResponseForRegisterDBProxyTargets {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16040,7 +16040,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func removeFromGlobalCluster(
             input: RDSModel.RemoveFromGlobalClusterMessage) async throws -> RDSModel.RemoveFromGlobalClusterResultForRemoveFromGlobalCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16078,7 +16078,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func removeRoleFromDBCluster(
             input: RDSModel.RemoveRoleFromDBClusterMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16116,7 +16116,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func removeRoleFromDBInstance(
             input: RDSModel.RemoveRoleFromDBInstanceMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16156,7 +16156,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func removeSourceIdentifierFromSubscription(
             input: RDSModel.RemoveSourceIdentifierFromSubscriptionMessage) async throws -> RDSModel.RemoveSourceIdentifierFromSubscriptionResultForRemoveSourceIdentifierFromSubscription {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16194,7 +16194,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func removeTagsFromResource(
             input: RDSModel.RemoveTagsFromResourceMessage) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16234,7 +16234,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func resetDBClusterParameterGroup(
             input: RDSModel.ResetDBClusterParameterGroupMessage) async throws -> RDSModel.DBClusterParameterGroupNameMessageForResetDBClusterParameterGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16274,7 +16274,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func resetDBParameterGroup(
             input: RDSModel.ResetDBParameterGroupMessage) async throws -> RDSModel.DBParameterGroupNameMessageForResetDBParameterGroup {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16314,7 +16314,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func restoreDBClusterFromS3(
             input: RDSModel.RestoreDBClusterFromS3Message) async throws -> RDSModel.RestoreDBClusterFromS3ResultForRestoreDBClusterFromS3 {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16354,7 +16354,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func restoreDBClusterFromSnapshot(
             input: RDSModel.RestoreDBClusterFromSnapshotMessage) async throws -> RDSModel.RestoreDBClusterFromSnapshotResultForRestoreDBClusterFromSnapshot {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16394,7 +16394,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func restoreDBClusterToPointInTime(
             input: RDSModel.RestoreDBClusterToPointInTimeMessage) async throws -> RDSModel.RestoreDBClusterToPointInTimeResultForRestoreDBClusterToPointInTime {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16434,7 +16434,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func restoreDBInstanceFromDBSnapshot(
             input: RDSModel.RestoreDBInstanceFromDBSnapshotMessage) async throws -> RDSModel.RestoreDBInstanceFromDBSnapshotResultForRestoreDBInstanceFromDBSnapshot {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16474,7 +16474,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func restoreDBInstanceFromS3(
             input: RDSModel.RestoreDBInstanceFromS3Message) async throws -> RDSModel.RestoreDBInstanceFromS3ResultForRestoreDBInstanceFromS3 {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16514,7 +16514,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func restoreDBInstanceToPointInTime(
             input: RDSModel.RestoreDBInstanceToPointInTimeMessage) async throws -> RDSModel.RestoreDBInstanceToPointInTimeResultForRestoreDBInstanceToPointInTime {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16554,7 +16554,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func revokeDBSecurityGroupIngress(
             input: RDSModel.RevokeDBSecurityGroupIngressMessage) async throws -> RDSModel.RevokeDBSecurityGroupIngressResultForRevokeDBSecurityGroupIngress {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16594,7 +16594,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func startActivityStream(
             input: RDSModel.StartActivityStreamRequest) async throws -> RDSModel.StartActivityStreamResponseForStartActivityStream {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16634,7 +16634,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func startDBCluster(
             input: RDSModel.StartDBClusterMessage) async throws -> RDSModel.StartDBClusterResultForStartDBCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16674,7 +16674,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func startDBInstance(
             input: RDSModel.StartDBInstanceMessage) async throws -> RDSModel.StartDBInstanceResultForStartDBInstance {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16714,7 +16714,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func startDBInstanceAutomatedBackupsReplication(
             input: RDSModel.StartDBInstanceAutomatedBackupsReplicationMessage) async throws -> RDSModel.StartDBInstanceAutomatedBackupsReplicationResultForStartDBInstanceAutomatedBackupsReplication {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16754,7 +16754,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func startExportTask(
             input: RDSModel.StartExportTaskMessage) async throws -> RDSModel.ExportTaskForStartExportTask {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16794,7 +16794,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func stopActivityStream(
             input: RDSModel.StopActivityStreamRequest) async throws -> RDSModel.StopActivityStreamResponseForStopActivityStream {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16834,7 +16834,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func stopDBCluster(
             input: RDSModel.StopDBClusterMessage) async throws -> RDSModel.StopDBClusterResultForStopDBCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16874,7 +16874,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func stopDBInstance(
             input: RDSModel.StopDBInstanceMessage) async throws -> RDSModel.StopDBInstanceResultForStopDBInstance {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16914,7 +16914,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func stopDBInstanceAutomatedBackupsReplication(
             input: RDSModel.StopDBInstanceAutomatedBackupsReplicationMessage) async throws -> RDSModel.StopDBInstanceAutomatedBackupsReplicationResultForStopDBInstanceAutomatedBackupsReplication {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16954,7 +16954,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func switchoverBlueGreenDeployment(
             input: RDSModel.SwitchoverBlueGreenDeploymentRequest) async throws -> RDSModel.SwitchoverBlueGreenDeploymentResponseForSwitchoverBlueGreenDeployment {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -16994,7 +16994,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func switchoverGlobalCluster(
             input: RDSModel.SwitchoverGlobalClusterMessage) async throws -> RDSModel.SwitchoverGlobalClusterResultForSwitchoverGlobalCluster {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -17034,7 +17034,7 @@ public struct AWSRDSClient<InvocationReportingType: HTTPClientCoreInvocationRepo
      */
     public func switchoverReadReplica(
             input: RDSModel.SwitchoverReadReplicaMessage) async throws -> RDSModel.SwitchoverReadReplicaResultForSwitchoverReadReplica {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/RDSDataClient/AWSRDSDataClient.swift
+++ b/Sources/RDSDataClient/AWSRDSDataClient.swift
@@ -581,7 +581,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
      */
     public func batchExecuteStatement(
             input: RDSDataModel.BatchExecuteStatementRequest) async throws -> RDSDataModel.BatchExecuteStatementResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -617,7 +617,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
      */
     public func beginTransaction(
             input: RDSDataModel.BeginTransactionRequest) async throws -> RDSDataModel.BeginTransactionResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -653,7 +653,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
      */
     public func commitTransaction(
             input: RDSDataModel.CommitTransactionRequest) async throws -> RDSDataModel.CommitTransactionResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -689,7 +689,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
      */
     public func executeSql(
             input: RDSDataModel.ExecuteSqlRequest) async throws -> RDSDataModel.ExecuteSqlResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -725,7 +725,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
      */
     public func executeStatement(
             input: RDSDataModel.ExecuteStatementRequest) async throws -> RDSDataModel.ExecuteStatementResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -761,7 +761,7 @@ public struct AWSRDSDataClient<InvocationReportingType: HTTPClientCoreInvocation
      */
     public func rollbackTransaction(
             input: RDSDataModel.RollbackTransactionRequest) async throws -> RDSDataModel.RollbackTransactionResponse {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/S3Client/AWSS3Client.swift
+++ b/Sources/S3Client/AWSS3Client.swift
@@ -6871,7 +6871,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func abortMultipartUpload(
             input: S3Model.AbortMultipartUploadRequest) async throws -> S3Model.AbortMultipartUploadOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6907,7 +6907,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func completeMultipartUpload(
             input: S3Model.CompleteMultipartUploadRequest) async throws -> S3Model.CompleteMultipartUploadOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6944,7 +6944,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func copyObject(
             input: S3Model.CopyObjectRequest) async throws -> S3Model.CopyObjectOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -6981,7 +6981,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func createBucket(
             input: S3Model.CreateBucketRequest) async throws -> S3Model.CreateBucketOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7017,7 +7017,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func createMultipartUpload(
             input: S3Model.CreateMultipartUploadRequest) async throws -> S3Model.CreateMultipartUploadOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7051,7 +7051,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucket(
             input: S3Model.DeleteBucketRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7085,7 +7085,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketAnalyticsConfiguration(
             input: S3Model.DeleteBucketAnalyticsConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7119,7 +7119,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketCors(
             input: S3Model.DeleteBucketCorsRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7153,7 +7153,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketEncryption(
             input: S3Model.DeleteBucketEncryptionRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7187,7 +7187,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketIntelligentTieringConfiguration(
             input: S3Model.DeleteBucketIntelligentTieringConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7221,7 +7221,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketInventoryConfiguration(
             input: S3Model.DeleteBucketInventoryConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7255,7 +7255,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketLifecycle(
             input: S3Model.DeleteBucketLifecycleRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7289,7 +7289,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketMetricsConfiguration(
             input: S3Model.DeleteBucketMetricsConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7323,7 +7323,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketOwnershipControls(
             input: S3Model.DeleteBucketOwnershipControlsRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7357,7 +7357,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketPolicy(
             input: S3Model.DeleteBucketPolicyRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7391,7 +7391,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketReplication(
             input: S3Model.DeleteBucketReplicationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7425,7 +7425,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketTagging(
             input: S3Model.DeleteBucketTaggingRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7459,7 +7459,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteBucketWebsite(
             input: S3Model.DeleteBucketWebsiteRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7495,7 +7495,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteObject(
             input: S3Model.DeleteObjectRequest) async throws -> S3Model.DeleteObjectOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7531,7 +7531,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteObjectTagging(
             input: S3Model.DeleteObjectTaggingRequest) async throws -> S3Model.DeleteObjectTaggingOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7567,7 +7567,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deleteObjects(
             input: S3Model.DeleteObjectsRequest) async throws -> S3Model.DeleteObjectsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7601,7 +7601,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func deletePublicAccessBlock(
             input: S3Model.DeletePublicAccessBlockRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7637,7 +7637,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketAccelerateConfiguration(
             input: S3Model.GetBucketAccelerateConfigurationRequest) async throws -> S3Model.GetBucketAccelerateConfigurationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7673,7 +7673,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketAcl(
             input: S3Model.GetBucketAclRequest) async throws -> S3Model.GetBucketAclOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7709,7 +7709,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketAnalyticsConfiguration(
             input: S3Model.GetBucketAnalyticsConfigurationRequest) async throws -> S3Model.GetBucketAnalyticsConfigurationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7745,7 +7745,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketCors(
             input: S3Model.GetBucketCorsRequest) async throws -> S3Model.GetBucketCorsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7781,7 +7781,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketEncryption(
             input: S3Model.GetBucketEncryptionRequest) async throws -> S3Model.GetBucketEncryptionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7817,7 +7817,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketIntelligentTieringConfiguration(
             input: S3Model.GetBucketIntelligentTieringConfigurationRequest) async throws -> S3Model.GetBucketIntelligentTieringConfigurationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7853,7 +7853,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketInventoryConfiguration(
             input: S3Model.GetBucketInventoryConfigurationRequest) async throws -> S3Model.GetBucketInventoryConfigurationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7889,7 +7889,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketLifecycle(
             input: S3Model.GetBucketLifecycleRequest) async throws -> S3Model.GetBucketLifecycleOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7925,7 +7925,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketLifecycleConfiguration(
             input: S3Model.GetBucketLifecycleConfigurationRequest) async throws -> S3Model.GetBucketLifecycleConfigurationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7961,7 +7961,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketLocation(
             input: S3Model.GetBucketLocationRequest) async throws -> S3Model.GetBucketLocationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -7997,7 +7997,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketLogging(
             input: S3Model.GetBucketLoggingRequest) async throws -> S3Model.GetBucketLoggingOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8033,7 +8033,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketMetricsConfiguration(
             input: S3Model.GetBucketMetricsConfigurationRequest) async throws -> S3Model.GetBucketMetricsConfigurationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8069,7 +8069,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketNotification(
             input: S3Model.GetBucketNotificationConfigurationRequest) async throws -> S3Model.NotificationConfigurationDeprecated {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8105,7 +8105,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketNotificationConfiguration(
             input: S3Model.GetBucketNotificationConfigurationRequest) async throws -> S3Model.NotificationConfiguration {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8141,7 +8141,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketOwnershipControls(
             input: S3Model.GetBucketOwnershipControlsRequest) async throws -> S3Model.GetBucketOwnershipControlsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8177,7 +8177,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketPolicy(
             input: S3Model.GetBucketPolicyRequest) async throws -> S3Model.GetBucketPolicyOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8213,7 +8213,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketPolicyStatus(
             input: S3Model.GetBucketPolicyStatusRequest) async throws -> S3Model.GetBucketPolicyStatusOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8249,7 +8249,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketReplication(
             input: S3Model.GetBucketReplicationRequest) async throws -> S3Model.GetBucketReplicationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8285,7 +8285,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketRequestPayment(
             input: S3Model.GetBucketRequestPaymentRequest) async throws -> S3Model.GetBucketRequestPaymentOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8321,7 +8321,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketTagging(
             input: S3Model.GetBucketTaggingRequest) async throws -> S3Model.GetBucketTaggingOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8357,7 +8357,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketVersioning(
             input: S3Model.GetBucketVersioningRequest) async throws -> S3Model.GetBucketVersioningOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8393,7 +8393,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getBucketWebsite(
             input: S3Model.GetBucketWebsiteRequest) async throws -> S3Model.GetBucketWebsiteOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8430,7 +8430,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getObject(
             input: S3Model.GetObjectRequest) async throws -> S3Model.GetObjectOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8467,7 +8467,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getObjectAcl(
             input: S3Model.GetObjectAclRequest) async throws -> S3Model.GetObjectAclOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8504,7 +8504,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getObjectAttributes(
             input: S3Model.GetObjectAttributesRequest) async throws -> S3Model.GetObjectAttributesOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8540,7 +8540,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getObjectLegalHold(
             input: S3Model.GetObjectLegalHoldRequest) async throws -> S3Model.GetObjectLegalHoldOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8576,7 +8576,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getObjectLockConfiguration(
             input: S3Model.GetObjectLockConfigurationRequest) async throws -> S3Model.GetObjectLockConfigurationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8612,7 +8612,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getObjectRetention(
             input: S3Model.GetObjectRetentionRequest) async throws -> S3Model.GetObjectRetentionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8648,7 +8648,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getObjectTagging(
             input: S3Model.GetObjectTaggingRequest) async throws -> S3Model.GetObjectTaggingOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8684,7 +8684,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getObjectTorrent(
             input: S3Model.GetObjectTorrentRequest) async throws -> S3Model.GetObjectTorrentOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8720,7 +8720,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func getPublicAccessBlock(
             input: S3Model.GetPublicAccessBlockRequest) async throws -> S3Model.GetPublicAccessBlockOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8755,7 +8755,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func headBucket(
             input: S3Model.HeadBucketRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8792,7 +8792,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func headObject(
             input: S3Model.HeadObjectRequest) async throws -> S3Model.HeadObjectOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8828,7 +8828,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func listBucketAnalyticsConfigurations(
             input: S3Model.ListBucketAnalyticsConfigurationsRequest) async throws -> S3Model.ListBucketAnalyticsConfigurationsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8864,7 +8864,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func listBucketIntelligentTieringConfigurations(
             input: S3Model.ListBucketIntelligentTieringConfigurationsRequest) async throws -> S3Model.ListBucketIntelligentTieringConfigurationsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8900,7 +8900,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func listBucketInventoryConfigurations(
             input: S3Model.ListBucketInventoryConfigurationsRequest) async throws -> S3Model.ListBucketInventoryConfigurationsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8936,7 +8936,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func listBucketMetricsConfigurations(
             input: S3Model.ListBucketMetricsConfigurationsRequest) async throws -> S3Model.ListBucketMetricsConfigurationsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -8968,7 +8968,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
          Will be validated before being returned to caller.
      */
     public func listBuckets() async throws -> S3Model.ListBucketsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9004,7 +9004,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func listMultipartUploads(
             input: S3Model.ListMultipartUploadsRequest) async throws -> S3Model.ListMultipartUploadsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9040,7 +9040,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func listObjectVersions(
             input: S3Model.ListObjectVersionsRequest) async throws -> S3Model.ListObjectVersionsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9077,7 +9077,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func listObjects(
             input: S3Model.ListObjectsRequest) async throws -> S3Model.ListObjectsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9114,7 +9114,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func listObjectsV2(
             input: S3Model.ListObjectsV2Request) async throws -> S3Model.ListObjectsV2Output {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9150,7 +9150,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func listParts(
             input: S3Model.ListPartsRequest) async throws -> S3Model.ListPartsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9184,7 +9184,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketAccelerateConfiguration(
             input: S3Model.PutBucketAccelerateConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9218,7 +9218,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketAcl(
             input: S3Model.PutBucketAclRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9252,7 +9252,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketAnalyticsConfiguration(
             input: S3Model.PutBucketAnalyticsConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9286,7 +9286,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketCors(
             input: S3Model.PutBucketCorsRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9320,7 +9320,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketEncryption(
             input: S3Model.PutBucketEncryptionRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9354,7 +9354,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketIntelligentTieringConfiguration(
             input: S3Model.PutBucketIntelligentTieringConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9388,7 +9388,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketInventoryConfiguration(
             input: S3Model.PutBucketInventoryConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9422,7 +9422,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketLifecycle(
             input: S3Model.PutBucketLifecycleRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9456,7 +9456,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketLifecycleConfiguration(
             input: S3Model.PutBucketLifecycleConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9490,7 +9490,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketLogging(
             input: S3Model.PutBucketLoggingRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9524,7 +9524,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketMetricsConfiguration(
             input: S3Model.PutBucketMetricsConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9558,7 +9558,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketNotification(
             input: S3Model.PutBucketNotificationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9592,7 +9592,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketNotificationConfiguration(
             input: S3Model.PutBucketNotificationConfigurationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9626,7 +9626,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketOwnershipControls(
             input: S3Model.PutBucketOwnershipControlsRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9660,7 +9660,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketPolicy(
             input: S3Model.PutBucketPolicyRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9694,7 +9694,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketReplication(
             input: S3Model.PutBucketReplicationRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9728,7 +9728,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketRequestPayment(
             input: S3Model.PutBucketRequestPaymentRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9762,7 +9762,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketTagging(
             input: S3Model.PutBucketTaggingRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9796,7 +9796,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketVersioning(
             input: S3Model.PutBucketVersioningRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9830,7 +9830,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putBucketWebsite(
             input: S3Model.PutBucketWebsiteRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9866,7 +9866,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putObject(
             input: S3Model.PutObjectRequest) async throws -> S3Model.PutObjectOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9903,7 +9903,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putObjectAcl(
             input: S3Model.PutObjectAclRequest) async throws -> S3Model.PutObjectAclOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9939,7 +9939,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putObjectLegalHold(
             input: S3Model.PutObjectLegalHoldRequest) async throws -> S3Model.PutObjectLegalHoldOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -9975,7 +9975,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putObjectLockConfiguration(
             input: S3Model.PutObjectLockConfigurationRequest) async throws -> S3Model.PutObjectLockConfigurationOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -10011,7 +10011,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putObjectRetention(
             input: S3Model.PutObjectRetentionRequest) async throws -> S3Model.PutObjectRetentionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -10047,7 +10047,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putObjectTagging(
             input: S3Model.PutObjectTaggingRequest) async throws -> S3Model.PutObjectTaggingOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -10081,7 +10081,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func putPublicAccessBlock(
             input: S3Model.PutPublicAccessBlockRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -10118,7 +10118,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func restoreObject(
             input: S3Model.RestoreObjectRequest) async throws -> S3Model.RestoreObjectOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -10154,7 +10154,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func selectObjectContent(
             input: S3Model.SelectObjectContentRequest) async throws -> S3Model.SelectObjectContentOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -10190,7 +10190,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func uploadPart(
             input: S3Model.UploadPartRequest) async throws -> S3Model.UploadPartOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -10226,7 +10226,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func uploadPartCopy(
             input: S3Model.UploadPartCopyRequest) async throws -> S3Model.UploadPartCopyOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -10260,7 +10260,7 @@ public struct AWSS3Client<InvocationReportingType: HTTPClientCoreInvocationRepor
      */
     public func writeGetObjectResponse(
             input: S3Model.WriteGetObjectResponseRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/SchedulerClient/AWSSchedulerClient.swift
+++ b/Sources/SchedulerClient/AWSSchedulerClient.swift
@@ -1002,7 +1002,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func createSchedule(
             input: SchedulerModel.CreateScheduleInput) async throws -> SchedulerModel.CreateScheduleOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1038,7 +1038,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func createScheduleGroup(
             input: SchedulerModel.CreateScheduleGroupInput) async throws -> SchedulerModel.CreateScheduleGroupOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1074,7 +1074,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func deleteSchedule(
             input: SchedulerModel.DeleteScheduleInput) async throws -> SchedulerModel.DeleteScheduleOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1110,7 +1110,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func deleteScheduleGroup(
             input: SchedulerModel.DeleteScheduleGroupInput) async throws -> SchedulerModel.DeleteScheduleGroupOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1146,7 +1146,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getSchedule(
             input: SchedulerModel.GetScheduleInput) async throws -> SchedulerModel.GetScheduleOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1182,7 +1182,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func getScheduleGroup(
             input: SchedulerModel.GetScheduleGroupInput) async throws -> SchedulerModel.GetScheduleGroupOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1218,7 +1218,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listScheduleGroups(
             input: SchedulerModel.ListScheduleGroupsInput) async throws -> SchedulerModel.ListScheduleGroupsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1254,7 +1254,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listSchedules(
             input: SchedulerModel.ListSchedulesInput) async throws -> SchedulerModel.ListSchedulesOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1290,7 +1290,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func listTagsForResource(
             input: SchedulerModel.ListTagsForResourceInput) async throws -> SchedulerModel.ListTagsForResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1326,7 +1326,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func tagResource(
             input: SchedulerModel.TagResourceInput) async throws -> SchedulerModel.TagResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1362,7 +1362,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func untagResource(
             input: SchedulerModel.UntagResourceInput) async throws -> SchedulerModel.UntagResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1398,7 +1398,7 @@ public struct AWSSchedulerClient<InvocationReportingType: HTTPClientCoreInvocati
      */
     public func updateSchedule(
             input: SchedulerModel.UpdateScheduleInput) async throws -> SchedulerModel.UpdateScheduleOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
+++ b/Sources/SecurityTokenClient/AWSSecurityTokenClient.swift
@@ -784,7 +784,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func assumeRole(
             input: SecurityTokenModel.AssumeRoleRequest) async throws -> SecurityTokenModel.AssumeRoleResponseForAssumeRole {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -824,7 +824,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func assumeRoleWithSAML(
             input: SecurityTokenModel.AssumeRoleWithSAMLRequest) async throws -> SecurityTokenModel.AssumeRoleWithSAMLResponseForAssumeRoleWithSAML {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -864,7 +864,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func assumeRoleWithWebIdentity(
             input: SecurityTokenModel.AssumeRoleWithWebIdentityRequest) async throws -> SecurityTokenModel.AssumeRoleWithWebIdentityResponseForAssumeRoleWithWebIdentity {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -904,7 +904,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func decodeAuthorizationMessage(
             input: SecurityTokenModel.DecodeAuthorizationMessageRequest) async throws -> SecurityTokenModel.DecodeAuthorizationMessageResponseForDecodeAuthorizationMessage {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -943,7 +943,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func getAccessKeyInfo(
             input: SecurityTokenModel.GetAccessKeyInfoRequest) async throws -> SecurityTokenModel.GetAccessKeyInfoResponseForGetAccessKeyInfo {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -982,7 +982,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func getCallerIdentity(
             input: SecurityTokenModel.GetCallerIdentityRequest) async throws -> SecurityTokenModel.GetCallerIdentityResponseForGetCallerIdentity {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1022,7 +1022,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func getFederationToken(
             input: SecurityTokenModel.GetFederationTokenRequest) async throws -> SecurityTokenModel.GetFederationTokenResponseForGetFederationToken {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1062,7 +1062,7 @@ public struct AWSSecurityTokenClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func getSessionToken(
             input: SecurityTokenModel.GetSessionTokenRequest) async throws -> SecurityTokenModel.GetSessionTokenResponseForGetSessionToken {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
+++ b/Sources/SimpleNotificationClient/AWSSimpleNotificationClient.swift
@@ -3424,7 +3424,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func addPermission(
             input: SimpleNotificationModel.AddPermissionInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3464,7 +3464,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func checkIfPhoneNumberIsOptedOut(
             input: SimpleNotificationModel.CheckIfPhoneNumberIsOptedOutInput) async throws -> SimpleNotificationModel.CheckIfPhoneNumberIsOptedOutResponseForCheckIfPhoneNumberIsOptedOut {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3504,7 +3504,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func confirmSubscription(
             input: SimpleNotificationModel.ConfirmSubscriptionInput) async throws -> SimpleNotificationModel.ConfirmSubscriptionResponseForConfirmSubscription {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3544,7 +3544,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func createPlatformApplication(
             input: SimpleNotificationModel.CreatePlatformApplicationInput) async throws -> SimpleNotificationModel.CreatePlatformApplicationResponseForCreatePlatformApplication {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3584,7 +3584,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func createPlatformEndpoint(
             input: SimpleNotificationModel.CreatePlatformEndpointInput) async throws -> SimpleNotificationModel.CreateEndpointResponseForCreatePlatformEndpoint {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3624,7 +3624,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func createSMSSandboxPhoneNumber(
             input: SimpleNotificationModel.CreateSMSSandboxPhoneNumberInput) async throws -> SimpleNotificationModel.CreateSMSSandboxPhoneNumberResultForCreateSMSSandboxPhoneNumber {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3664,7 +3664,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func createTopic(
             input: SimpleNotificationModel.CreateTopicInput) async throws -> SimpleNotificationModel.CreateTopicResponseForCreateTopic {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3702,7 +3702,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func deleteEndpoint(
             input: SimpleNotificationModel.DeleteEndpointInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3740,7 +3740,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func deletePlatformApplication(
             input: SimpleNotificationModel.DeletePlatformApplicationInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3780,7 +3780,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func deleteSMSSandboxPhoneNumber(
             input: SimpleNotificationModel.DeleteSMSSandboxPhoneNumberInput) async throws -> SimpleNotificationModel.DeleteSMSSandboxPhoneNumberResultForDeleteSMSSandboxPhoneNumber {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3818,7 +3818,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func deleteTopic(
             input: SimpleNotificationModel.DeleteTopicInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3858,7 +3858,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func getDataProtectionPolicy(
             input: SimpleNotificationModel.GetDataProtectionPolicyInput) async throws -> SimpleNotificationModel.GetDataProtectionPolicyResponseForGetDataProtectionPolicy {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3898,7 +3898,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func getEndpointAttributes(
             input: SimpleNotificationModel.GetEndpointAttributesInput) async throws -> SimpleNotificationModel.GetEndpointAttributesResponseForGetEndpointAttributes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3938,7 +3938,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func getPlatformApplicationAttributes(
             input: SimpleNotificationModel.GetPlatformApplicationAttributesInput) async throws -> SimpleNotificationModel.GetPlatformApplicationAttributesResponseForGetPlatformApplicationAttributes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3978,7 +3978,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func getSMSAttributes(
             input: SimpleNotificationModel.GetSMSAttributesInput) async throws -> SimpleNotificationModel.GetSMSAttributesResponseForGetSMSAttributes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4018,7 +4018,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func getSMSSandboxAccountStatus(
             input: SimpleNotificationModel.GetSMSSandboxAccountStatusInput) async throws -> SimpleNotificationModel.GetSMSSandboxAccountStatusResultForGetSMSSandboxAccountStatus {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4058,7 +4058,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func getSubscriptionAttributes(
             input: SimpleNotificationModel.GetSubscriptionAttributesInput) async throws -> SimpleNotificationModel.GetSubscriptionAttributesResponseForGetSubscriptionAttributes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4098,7 +4098,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func getTopicAttributes(
             input: SimpleNotificationModel.GetTopicAttributesInput) async throws -> SimpleNotificationModel.GetTopicAttributesResponseForGetTopicAttributes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4138,7 +4138,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func listEndpointsByPlatformApplication(
             input: SimpleNotificationModel.ListEndpointsByPlatformApplicationInput) async throws -> SimpleNotificationModel.ListEndpointsByPlatformApplicationResponseForListEndpointsByPlatformApplication {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4178,7 +4178,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func listOriginationNumbers(
             input: SimpleNotificationModel.ListOriginationNumbersRequest) async throws -> SimpleNotificationModel.ListOriginationNumbersResultForListOriginationNumbers {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4218,7 +4218,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func listPhoneNumbersOptedOut(
             input: SimpleNotificationModel.ListPhoneNumbersOptedOutInput) async throws -> SimpleNotificationModel.ListPhoneNumbersOptedOutResponseForListPhoneNumbersOptedOut {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4258,7 +4258,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func listPlatformApplications(
             input: SimpleNotificationModel.ListPlatformApplicationsInput) async throws -> SimpleNotificationModel.ListPlatformApplicationsResponseForListPlatformApplications {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4298,7 +4298,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func listSMSSandboxPhoneNumbers(
             input: SimpleNotificationModel.ListSMSSandboxPhoneNumbersInput) async throws -> SimpleNotificationModel.ListSMSSandboxPhoneNumbersResultForListSMSSandboxPhoneNumbers {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4338,7 +4338,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func listSubscriptions(
             input: SimpleNotificationModel.ListSubscriptionsInput) async throws -> SimpleNotificationModel.ListSubscriptionsResponseForListSubscriptions {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4378,7 +4378,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func listSubscriptionsByTopic(
             input: SimpleNotificationModel.ListSubscriptionsByTopicInput) async throws -> SimpleNotificationModel.ListSubscriptionsByTopicResponseForListSubscriptionsByTopic {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4418,7 +4418,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func listTagsForResource(
             input: SimpleNotificationModel.ListTagsForResourceRequest) async throws -> SimpleNotificationModel.ListTagsForResourceResponseForListTagsForResource {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4458,7 +4458,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func listTopics(
             input: SimpleNotificationModel.ListTopicsInput) async throws -> SimpleNotificationModel.ListTopicsResponseForListTopics {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4498,7 +4498,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func optInPhoneNumber(
             input: SimpleNotificationModel.OptInPhoneNumberInput) async throws -> SimpleNotificationModel.OptInPhoneNumberResponseForOptInPhoneNumber {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4538,7 +4538,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func publish(
             input: SimpleNotificationModel.PublishInput) async throws -> SimpleNotificationModel.PublishResponseForPublish {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4578,7 +4578,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func publishBatch(
             input: SimpleNotificationModel.PublishBatchInput) async throws -> SimpleNotificationModel.PublishBatchResponseForPublishBatch {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4616,7 +4616,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func putDataProtectionPolicy(
             input: SimpleNotificationModel.PutDataProtectionPolicyInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4654,7 +4654,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func removePermission(
             input: SimpleNotificationModel.RemovePermissionInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4692,7 +4692,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func setEndpointAttributes(
             input: SimpleNotificationModel.SetEndpointAttributesInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4730,7 +4730,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func setPlatformApplicationAttributes(
             input: SimpleNotificationModel.SetPlatformApplicationAttributesInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4770,7 +4770,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func setSMSAttributes(
             input: SimpleNotificationModel.SetSMSAttributesInput) async throws -> SimpleNotificationModel.SetSMSAttributesResponseForSetSMSAttributes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4808,7 +4808,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func setSubscriptionAttributes(
             input: SimpleNotificationModel.SetSubscriptionAttributesInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4846,7 +4846,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func setTopicAttributes(
             input: SimpleNotificationModel.SetTopicAttributesInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4886,7 +4886,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func subscribe(
             input: SimpleNotificationModel.SubscribeInput) async throws -> SimpleNotificationModel.SubscribeResponseForSubscribe {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4926,7 +4926,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func tagResource(
             input: SimpleNotificationModel.TagResourceRequest) async throws -> SimpleNotificationModel.TagResourceResponseForTagResource {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -4964,7 +4964,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func unsubscribe(
             input: SimpleNotificationModel.UnsubscribeInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5004,7 +5004,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func untagResource(
             input: SimpleNotificationModel.UntagResourceRequest) async throws -> SimpleNotificationModel.UntagResourceResponseForUntagResource {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -5044,7 +5044,7 @@ public struct AWSSimpleNotificationClient<InvocationReportingType: HTTPClientCor
      */
     public func verifySMSSandboxPhoneNumber(
             input: SimpleNotificationModel.VerifySMSSandboxPhoneNumberInput) async throws -> SimpleNotificationModel.VerifySMSSandboxPhoneNumberResultForVerifySMSSandboxPhoneNumber {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
+++ b/Sources/SimpleQueueClient/AWSSimpleQueueClient.swift
@@ -1953,7 +1953,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func addPermission(
             input: SimpleQueueModel.AddPermissionRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -1993,7 +1993,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func cancelMessageMoveTask(
             input: SimpleQueueModel.CancelMessageMoveTaskRequest) async throws -> SimpleQueueModel.CancelMessageMoveTaskResultForCancelMessageMoveTask {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2031,7 +2031,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func changeMessageVisibility(
             input: SimpleQueueModel.ChangeMessageVisibilityRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2071,7 +2071,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func changeMessageVisibilityBatch(
             input: SimpleQueueModel.ChangeMessageVisibilityBatchRequest) async throws -> SimpleQueueModel.ChangeMessageVisibilityBatchResultForChangeMessageVisibilityBatch {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2111,7 +2111,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func createQueue(
             input: SimpleQueueModel.CreateQueueRequest) async throws -> SimpleQueueModel.CreateQueueResultForCreateQueue {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2149,7 +2149,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func deleteMessage(
             input: SimpleQueueModel.DeleteMessageRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2189,7 +2189,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func deleteMessageBatch(
             input: SimpleQueueModel.DeleteMessageBatchRequest) async throws -> SimpleQueueModel.DeleteMessageBatchResultForDeleteMessageBatch {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2226,7 +2226,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func deleteQueue(
             input: SimpleQueueModel.DeleteQueueRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2266,7 +2266,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func getQueueAttributes(
             input: SimpleQueueModel.GetQueueAttributesRequest) async throws -> SimpleQueueModel.GetQueueAttributesResultForGetQueueAttributes {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2306,7 +2306,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func getQueueUrl(
             input: SimpleQueueModel.GetQueueUrlRequest) async throws -> SimpleQueueModel.GetQueueUrlResultForGetQueueUrl {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2346,7 +2346,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func listDeadLetterSourceQueues(
             input: SimpleQueueModel.ListDeadLetterSourceQueuesRequest) async throws -> SimpleQueueModel.ListDeadLetterSourceQueuesResultForListDeadLetterSourceQueues {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2386,7 +2386,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func listMessageMoveTasks(
             input: SimpleQueueModel.ListMessageMoveTasksRequest) async throws -> SimpleQueueModel.ListMessageMoveTasksResultForListMessageMoveTasks {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2425,7 +2425,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func listQueueTags(
             input: SimpleQueueModel.ListQueueTagsRequest) async throws -> SimpleQueueModel.ListQueueTagsResultForListQueueTags {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2464,7 +2464,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func listQueues(
             input: SimpleQueueModel.ListQueuesRequest) async throws -> SimpleQueueModel.ListQueuesResultForListQueues {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2502,7 +2502,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func purgeQueue(
             input: SimpleQueueModel.PurgeQueueRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2542,7 +2542,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func receiveMessage(
             input: SimpleQueueModel.ReceiveMessageRequest) async throws -> SimpleQueueModel.ReceiveMessageResultForReceiveMessage {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2579,7 +2579,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func removePermission(
             input: SimpleQueueModel.RemovePermissionRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2619,7 +2619,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func sendMessage(
             input: SimpleQueueModel.SendMessageRequest) async throws -> SimpleQueueModel.SendMessageResultForSendMessage {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2659,7 +2659,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func sendMessageBatch(
             input: SimpleQueueModel.SendMessageBatchRequest) async throws -> SimpleQueueModel.SendMessageBatchResultForSendMessageBatch {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2697,7 +2697,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func setQueueAttributes(
             input: SimpleQueueModel.SetQueueAttributesRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2737,7 +2737,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func startMessageMoveTask(
             input: SimpleQueueModel.StartMessageMoveTaskRequest) async throws -> SimpleQueueModel.StartMessageMoveTaskResultForStartMessageMoveTask {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2774,7 +2774,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func tagQueue(
             input: SimpleQueueModel.TagQueueRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2811,7 +2811,7 @@ public struct AWSSimpleQueueClient<InvocationReportingType: HTTPClientCoreInvoca
      */
     public func untagQueue(
             input: SimpleQueueModel.UntagQueueRequest) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
+++ b/Sources/SimpleWorkflowClient/AWSSimpleWorkflowClient.swift
@@ -2716,7 +2716,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func countClosedWorkflowExecutions(
             input: SimpleWorkflowModel.CountClosedWorkflowExecutionsInput) async throws -> SimpleWorkflowModel.WorkflowExecutionCount {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2752,7 +2752,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func countOpenWorkflowExecutions(
             input: SimpleWorkflowModel.CountOpenWorkflowExecutionsInput) async throws -> SimpleWorkflowModel.WorkflowExecutionCount {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2788,7 +2788,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func countPendingActivityTasks(
             input: SimpleWorkflowModel.CountPendingActivityTasksInput) async throws -> SimpleWorkflowModel.PendingTaskCount {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2824,7 +2824,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func countPendingDecisionTasks(
             input: SimpleWorkflowModel.CountPendingDecisionTasksInput) async throws -> SimpleWorkflowModel.PendingTaskCount {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2858,7 +2858,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func deprecateActivityType(
             input: SimpleWorkflowModel.DeprecateActivityTypeInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2892,7 +2892,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func deprecateDomain(
             input: SimpleWorkflowModel.DeprecateDomainInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2926,7 +2926,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func deprecateWorkflowType(
             input: SimpleWorkflowModel.DeprecateWorkflowTypeInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2962,7 +2962,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeActivityType(
             input: SimpleWorkflowModel.DescribeActivityTypeInput) async throws -> SimpleWorkflowModel.ActivityTypeDetail {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2998,7 +2998,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeDomain(
             input: SimpleWorkflowModel.DescribeDomainInput) async throws -> SimpleWorkflowModel.DomainDetail {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3034,7 +3034,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeWorkflowExecution(
             input: SimpleWorkflowModel.DescribeWorkflowExecutionInput) async throws -> SimpleWorkflowModel.WorkflowExecutionDetail {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3070,7 +3070,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func describeWorkflowType(
             input: SimpleWorkflowModel.DescribeWorkflowTypeInput) async throws -> SimpleWorkflowModel.WorkflowTypeDetail {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3106,7 +3106,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func getWorkflowExecutionHistory(
             input: SimpleWorkflowModel.GetWorkflowExecutionHistoryInput) async throws -> SimpleWorkflowModel.History {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3142,7 +3142,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listActivityTypes(
             input: SimpleWorkflowModel.ListActivityTypesInput) async throws -> SimpleWorkflowModel.ActivityTypeInfos {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3178,7 +3178,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listClosedWorkflowExecutions(
             input: SimpleWorkflowModel.ListClosedWorkflowExecutionsInput) async throws -> SimpleWorkflowModel.WorkflowExecutionInfos {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3214,7 +3214,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listDomains(
             input: SimpleWorkflowModel.ListDomainsInput) async throws -> SimpleWorkflowModel.DomainInfos {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3250,7 +3250,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listOpenWorkflowExecutions(
             input: SimpleWorkflowModel.ListOpenWorkflowExecutionsInput) async throws -> SimpleWorkflowModel.WorkflowExecutionInfos {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3286,7 +3286,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listTagsForResource(
             input: SimpleWorkflowModel.ListTagsForResourceInput) async throws -> SimpleWorkflowModel.ListTagsForResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3322,7 +3322,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func listWorkflowTypes(
             input: SimpleWorkflowModel.ListWorkflowTypesInput) async throws -> SimpleWorkflowModel.WorkflowTypeInfos {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3358,7 +3358,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func pollForActivityTask(
             input: SimpleWorkflowModel.PollForActivityTaskInput) async throws -> SimpleWorkflowModel.ActivityTask {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3394,7 +3394,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func pollForDecisionTask(
             input: SimpleWorkflowModel.PollForDecisionTaskInput) async throws -> SimpleWorkflowModel.DecisionTask {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3430,7 +3430,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func recordActivityTaskHeartbeat(
             input: SimpleWorkflowModel.RecordActivityTaskHeartbeatInput) async throws -> SimpleWorkflowModel.ActivityTaskStatus {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3464,7 +3464,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func registerActivityType(
             input: SimpleWorkflowModel.RegisterActivityTypeInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3498,7 +3498,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func registerDomain(
             input: SimpleWorkflowModel.RegisterDomainInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3532,7 +3532,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func registerWorkflowType(
             input: SimpleWorkflowModel.RegisterWorkflowTypeInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3566,7 +3566,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func requestCancelWorkflowExecution(
             input: SimpleWorkflowModel.RequestCancelWorkflowExecutionInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3600,7 +3600,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func respondActivityTaskCanceled(
             input: SimpleWorkflowModel.RespondActivityTaskCanceledInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3634,7 +3634,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func respondActivityTaskCompleted(
             input: SimpleWorkflowModel.RespondActivityTaskCompletedInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3668,7 +3668,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func respondActivityTaskFailed(
             input: SimpleWorkflowModel.RespondActivityTaskFailedInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3702,7 +3702,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func respondDecisionTaskCompleted(
             input: SimpleWorkflowModel.RespondDecisionTaskCompletedInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3736,7 +3736,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func signalWorkflowExecution(
             input: SimpleWorkflowModel.SignalWorkflowExecutionInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3772,7 +3772,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func startWorkflowExecution(
             input: SimpleWorkflowModel.StartWorkflowExecutionInput) async throws -> SimpleWorkflowModel.Run {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3806,7 +3806,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func tagResource(
             input: SimpleWorkflowModel.TagResourceInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3840,7 +3840,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func terminateWorkflowExecution(
             input: SimpleWorkflowModel.TerminateWorkflowExecutionInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3874,7 +3874,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func undeprecateActivityType(
             input: SimpleWorkflowModel.UndeprecateActivityTypeInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3908,7 +3908,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func undeprecateDomain(
             input: SimpleWorkflowModel.UndeprecateDomainInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3942,7 +3942,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func undeprecateWorkflowType(
             input: SimpleWorkflowModel.UndeprecateWorkflowTypeInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3976,7 +3976,7 @@ public struct AWSSimpleWorkflowClient<InvocationReportingType: HTTPClientCoreInv
      */
     public func untagResource(
             input: SimpleWorkflowModel.UntagResourceInput) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
+++ b/Sources/StepFunctionsClient/AWSStepFunctionsClient.swift
@@ -2560,7 +2560,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func createActivity(
             input: StepFunctionsModel.CreateActivityInput) async throws -> StepFunctionsModel.CreateActivityOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2596,7 +2596,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func createStateMachine(
             input: StepFunctionsModel.CreateStateMachineInput) async throws -> StepFunctionsModel.CreateStateMachineOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2632,7 +2632,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func createStateMachineAlias(
             input: StepFunctionsModel.CreateStateMachineAliasInput) async throws -> StepFunctionsModel.CreateStateMachineAliasOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2668,7 +2668,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func deleteActivity(
             input: StepFunctionsModel.DeleteActivityInput) async throws -> StepFunctionsModel.DeleteActivityOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2704,7 +2704,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func deleteStateMachine(
             input: StepFunctionsModel.DeleteStateMachineInput) async throws -> StepFunctionsModel.DeleteStateMachineOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2740,7 +2740,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func deleteStateMachineAlias(
             input: StepFunctionsModel.DeleteStateMachineAliasInput) async throws -> StepFunctionsModel.DeleteStateMachineAliasOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2776,7 +2776,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func deleteStateMachineVersion(
             input: StepFunctionsModel.DeleteStateMachineVersionInput) async throws -> StepFunctionsModel.DeleteStateMachineVersionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2812,7 +2812,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func describeActivity(
             input: StepFunctionsModel.DescribeActivityInput) async throws -> StepFunctionsModel.DescribeActivityOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2848,7 +2848,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func describeExecution(
             input: StepFunctionsModel.DescribeExecutionInput) async throws -> StepFunctionsModel.DescribeExecutionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2884,7 +2884,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func describeMapRun(
             input: StepFunctionsModel.DescribeMapRunInput) async throws -> StepFunctionsModel.DescribeMapRunOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2920,7 +2920,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func describeStateMachine(
             input: StepFunctionsModel.DescribeStateMachineInput) async throws -> StepFunctionsModel.DescribeStateMachineOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2956,7 +2956,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func describeStateMachineAlias(
             input: StepFunctionsModel.DescribeStateMachineAliasInput) async throws -> StepFunctionsModel.DescribeStateMachineAliasOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -2992,7 +2992,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func describeStateMachineForExecution(
             input: StepFunctionsModel.DescribeStateMachineForExecutionInput) async throws -> StepFunctionsModel.DescribeStateMachineForExecutionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3028,7 +3028,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func getActivityTask(
             input: StepFunctionsModel.GetActivityTaskInput) async throws -> StepFunctionsModel.GetActivityTaskOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3064,7 +3064,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func getExecutionHistory(
             input: StepFunctionsModel.GetExecutionHistoryInput) async throws -> StepFunctionsModel.GetExecutionHistoryOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3100,7 +3100,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func listActivities(
             input: StepFunctionsModel.ListActivitiesInput) async throws -> StepFunctionsModel.ListActivitiesOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3136,7 +3136,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func listExecutions(
             input: StepFunctionsModel.ListExecutionsInput) async throws -> StepFunctionsModel.ListExecutionsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3172,7 +3172,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func listMapRuns(
             input: StepFunctionsModel.ListMapRunsInput) async throws -> StepFunctionsModel.ListMapRunsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3208,7 +3208,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func listStateMachineAliases(
             input: StepFunctionsModel.ListStateMachineAliasesInput) async throws -> StepFunctionsModel.ListStateMachineAliasesOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3244,7 +3244,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func listStateMachineVersions(
             input: StepFunctionsModel.ListStateMachineVersionsInput) async throws -> StepFunctionsModel.ListStateMachineVersionsOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3280,7 +3280,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func listStateMachines(
             input: StepFunctionsModel.ListStateMachinesInput) async throws -> StepFunctionsModel.ListStateMachinesOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3316,7 +3316,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func listTagsForResource(
             input: StepFunctionsModel.ListTagsForResourceInput) async throws -> StepFunctionsModel.ListTagsForResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3352,7 +3352,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func publishStateMachineVersion(
             input: StepFunctionsModel.PublishStateMachineVersionInput) async throws -> StepFunctionsModel.PublishStateMachineVersionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3388,7 +3388,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func sendTaskFailure(
             input: StepFunctionsModel.SendTaskFailureInput) async throws -> StepFunctionsModel.SendTaskFailureOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3424,7 +3424,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func sendTaskHeartbeat(
             input: StepFunctionsModel.SendTaskHeartbeatInput) async throws -> StepFunctionsModel.SendTaskHeartbeatOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3460,7 +3460,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func sendTaskSuccess(
             input: StepFunctionsModel.SendTaskSuccessInput) async throws -> StepFunctionsModel.SendTaskSuccessOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3496,7 +3496,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func startExecution(
             input: StepFunctionsModel.StartExecutionInput) async throws -> StepFunctionsModel.StartExecutionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3532,7 +3532,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func startSyncExecution(
             input: StepFunctionsModel.StartSyncExecutionInput) async throws -> StepFunctionsModel.StartSyncExecutionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3568,7 +3568,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func stopExecution(
             input: StepFunctionsModel.StopExecutionInput) async throws -> StepFunctionsModel.StopExecutionOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3604,7 +3604,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func tagResource(
             input: StepFunctionsModel.TagResourceInput) async throws -> StepFunctionsModel.TagResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3640,7 +3640,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func untagResource(
             input: StepFunctionsModel.UntagResourceInput) async throws -> StepFunctionsModel.UntagResourceOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3676,7 +3676,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func updateMapRun(
             input: StepFunctionsModel.UpdateMapRunInput) async throws -> StepFunctionsModel.UpdateMapRunOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3712,7 +3712,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func updateStateMachine(
             input: StepFunctionsModel.UpdateStateMachineInput) async throws -> StepFunctionsModel.UpdateStateMachineOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,
@@ -3748,7 +3748,7 @@ public struct AWSStepFunctionsClient<InvocationReportingType: HTTPClientCoreInvo
      */
     public func updateStateMachineAlias(
             input: StepFunctionsModel.UpdateStateMachineAliasInput) async throws -> StepFunctionsModel.UpdateStateMachineAliasOutput {
-        let handlerDelegate = AWSClientInvocationDelegate(
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
                     credentialsProvider: credentialsProvider,
                     awsRegion: awsRegion,
                     service: service,

--- a/docs/Support_Policy.md
+++ b/docs/Support_Policy.md
@@ -1,5 +1,5 @@
 ---
-date: 2023-04-17 10:00
+date: 2023-12-17 10:00
 description: Support Policy for SmokeAWS.
 tags: support policy
 ---
@@ -24,10 +24,10 @@ SmokeAWS has two mechanism for removing support for Swift Toolchain versions-
 Once support has been removed, testing via continuous integration may be removed and no guarantees will be given for compiling the package using this version of the toolchain.
 
 Following these rules, the support level for different Swift Toolchain versions are-
-1. **Swift 5.5 and earlier**: No support.
-2. **Swift 5.6**: Supported for SmokeAWS 2.x. Support to be removed after 30th of September, 2023. See https://github.com/amzn/smoke-aws/issues/130 for open compiler crash issue.
-3. **Swift 5.7**: Supported for SmokeAWS 2.x.
-4. **Swift 5.8**: Supported for SmokeAWS 2.x.
+1. **Swift 5.6 and earlier**: No support.
+2. **Swift 5.7**: Supported for SmokeAWS 2.x. Support to be removed after 18th of March, 2024.
+3. **Swift 5.8**: Supported for SmokeAWS 2.x.
+4. **Swift 5.9**: Supported for SmokeAWS 2.x.
 
 # Runtime Support
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use the AWSClientInvocationDelegate factory function for structured concurrency implementations. This will construct the AWSClientInvocationDelegate instance appropriately for the credentials provider instance passed, using credentials from the `CredentialsProviderV2` if available.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
