### PR TITLE
Update CloudWatch client to send payload in POST body instead of URL

### DIFF
--- a/Sources/CloudWatchClient/AWSCloudWatchClient.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClient.swift
@@ -43,7 +43,7 @@ public enum CloudWatchClientError: Swift.Error {
 
     public func isRetriable() -> Bool? {
         switch self {
-        case .limitExceededException, .limitExceededFault:
+        case .limitExceededException, .limitExceededFault, .throttling:
             return true
         default:
             return nil
@@ -86,7 +86,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
                 endpointPort: Int = 443,
                 requiresTLS: Bool? = nil,
                 service: String = "monitoring",
-                contentType: String = "application/octet-stream",
+                contentType: String = "application/x-www-form-urlencoded; charset=utf-8",
                 apiVersion: String = "2010-08-01",
                 connectionTimeoutSeconds: Int64 = 10,
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
@@ -95,7 +95,7 @@ public struct AWSCloudWatchClient<InvocationReportingType: HTTPClientCoreInvocat
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>
                     = SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>() ) {
         let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
-        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: useTLS,
+        let clientDelegate = FormEncodedXMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: useTLS,
             outputListDecodingStrategy: .collapseListUsingItemTag("member"), 
             inputQueryListEncodingStrategy: .expandListWithIndexAndItemTag(itemTag: "member"))
 

--- a/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
+++ b/Sources/CloudWatchClient/AWSCloudWatchClientGenerator.swift
@@ -60,7 +60,7 @@ public struct AWSCloudWatchClientGenerator {
                 endpointPort: Int = 443,
                 requiresTLS: Bool? = nil,
                 service: String = "monitoring",
-                contentType: String = "application/octet-stream",
+                contentType: String = "application/x-www-form-urlencoded; charset=utf-8",
                 apiVersion: String = "2010-08-01",
                 connectionTimeoutSeconds: Int64 = 10,
                 retryConfiguration: HTTPClientRetryConfiguration = .default,
@@ -69,7 +69,7 @@ public struct AWSCloudWatchClientGenerator {
                 reportingConfiguration: SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>
                     = SmokeAWSClientReportingConfiguration<CloudWatchModelOperations>() ) {
         let useTLS = requiresTLS ?? AWSHTTPClientDelegate.requiresTLS(forEndpointPort: endpointPort)
-        let clientDelegate = XMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: useTLS,
+        let clientDelegate = FormEncodedXMLAWSHttpClientDelegate<CloudWatchError>(requiresTLS: useTLS,
             outputListDecodingStrategy: .collapseListUsingItemTag("member"), 
             inputQueryListEncodingStrategy: .expandListWithIndexAndItemTag(itemTag: "member"))
 

--- a/Sources/CloudWatchModel/CloudWatchModelErrors.swift
+++ b/Sources/CloudWatchModel/CloudWatchModelErrors.swift
@@ -46,7 +46,18 @@ private let limitExceededFaultIdentity = "LimitExceeded"
 private let missingRequiredParameterIdentity = "MissingParameter"
 private let resourceNotFoundIdentity = "ResourceNotFound"
 private let resourceNotFoundExceptionIdentity = "ResourceNotFoundException"
+private let throttlingIdentity = "ThrottlingException"
 private let __accessDeniedIdentity = "AccessDenied"
+
+public struct CloudWatchErrorPayload: Codable {
+    public let type: String
+    public let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case type = "Code"
+        case message = "Message"
+    }
+}
 
 public enum CloudWatchError: Swift.Error, Decodable {
     case concurrentModification(ConcurrentModificationException)
@@ -62,6 +73,7 @@ public enum CloudWatchError: Swift.Error, Decodable {
     case missingRequiredParameter(MissingRequiredParameterException)
     case resourceNotFound(ResourceNotFound)
     case resourceNotFoundException(ResourceNotFoundException)
+    case throttling(CloudWatchErrorPayload)
     case accessDenied(message: String?)
     case validationError(reason: String)
     case unrecognizedError(String, String?)
@@ -120,6 +132,9 @@ public enum CloudWatchError: Swift.Error, Decodable {
         case resourceNotFoundExceptionIdentity:
             let errorPayload = try ResourceNotFoundException(from: decoder)
             self = CloudWatchError.resourceNotFoundException(errorPayload)
+        case throttlingIdentity:
+            let errorPayload = try CloudWatchErrorPayload(from: decoder)
+            self = CloudWatchError.throttling(errorPayload)
         case __accessDeniedIdentity:
             self = .accessDenied(message: errorMessage)
         default:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is a follow up to https://github.com/amzn/smoke-aws-generate/pull/98

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
