### PR TITLE
Update smoke http and smoke-aws-support major versions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "smoke-aws-support",
         "repositoryURL": "https://github.com/amzn/smoke-aws-support.git",
         "state": {
-          "branch": null,
-          "revision": "c46cd7e8b8f32d6629d57a8b2b58d6622bd898be",
-          "version": "1.7.0"
+          "branch": "update-smoke-http",
+          "revision": "74c9ec7b99d558d92c93a06245af6392a55b637d",
+          "version": null
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "d37f4c40e3f00a880fc09b7927f8a2fbf4c5d018",
-          "version": "2.22.5"
+          "revision": "a6f386fc42d4758719b01a4e45f20c68bed88d50",
+          "version": "3.0.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "smoke-aws-support",
         "repositoryURL": "https://github.com/amzn/smoke-aws-support.git",
         "state": {
-          "branch": "update-smoke-http",
-          "revision": "74c9ec7b99d558d92c93a06245af6392a55b637d",
-          "version": null
+          "branch": null,
+          "revision": "b858670eac000b3a957d85672b915c03275c0d9b",
+          "version": "2.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -144,7 +144,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
         .package(url: "https://github.com/amzn/smoke-http.git", from: "3.0.0"),
-        .package(url: "https://github.com/amzn/smoke-aws-support.git", branch: "update-smoke-http"),
+        .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -143,8 +143,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.19.1"),
-        .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.7.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "3.0.0"),
+        .package(url: "https://github.com/amzn/smoke-aws-support.git", branch: "update-smoke-http"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update to use latest versions for dependencies. Follow up to https://github.com/amzn/smoke-http/pull/138 and https://github.com/amzn/smoke-aws-support/pull/20

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
