### PR TITLE
Add ChecksumAlgorithm CRC64NVME

### DIFF
--- a/Sources/S3Model/S3ModelTypes.swift
+++ b/Sources/S3Model/S3ModelTypes.swift
@@ -276,6 +276,7 @@ public enum ChecksumAlgorithm: String, Codable, CustomStringConvertible {
     case crc32c = "CRC32C"
     case sha1 = "SHA1"
     case sha256 = "SHA256"
+    case crc64nvme = "CRC64NVME"
 
     public var description: String {
         return rawValue


### PR DESCRIPTION
*Issue #, if available:*
Add missing ChecksumAlgorithm CRC64NVME

*Description of changes:*
ChecksumAlgorithm is missing case CRC64NVME. This could cause failure when get the s3 object that has this checksum algorithm. This is not support by go v1 sdk now. Therefore, manually add it to unblock the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
